### PR TITLE
Add multi-shell support (zsh, bash, fish)

### DIFF
--- a/src-tauri/script/terminal-mirror.bash
+++ b/src-tauri/script/terminal-mirror.bash
@@ -1,0 +1,67 @@
+# --- Ani-Mime Terminal Mirror (Bash) ---
+# Source this in .bashrc:  source /path/to/terminal-mirror.bash
+
+export TAURI_MIRROR_PORT=1234
+_TM_URL="http://127.0.0.1:${TAURI_MIRROR_PORT}"
+_TM_CMD_RUNNING=0
+
+# --- Detect if a command is Claude Code ---
+_tm_is_claude() {
+  local first_word="${1%% *}"
+  [[ "$first_word" == "claude" ]] && return 0
+  local resolved=$(type -p "$first_word" 2>/dev/null)
+  [[ "$resolved" == *claude* ]] && return 0
+  return 1
+}
+
+# --- Command categorization ---
+_tm_classify() {
+  local cmd="$1"
+  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|docker-compose|docker\ compose|up) ]]; then
+    echo "service"
+  else
+    echo "task"
+  fi
+}
+
+# --- Heartbeat (background, every 20s) ---
+_tm_heartbeat() {
+  while true; do
+    curl -s --max-time 2 "${_TM_URL}/heartbeat?pid=$$" > /dev/null 2>&1
+    sleep 20
+  done
+}
+
+# Start heartbeat only once per shell session
+if [[ -z "$_TM_HEARTBEAT_PID" ]]; then
+  _tm_heartbeat &
+  _TM_HEARTBEAT_PID=$!
+  disown $_TM_HEARTBEAT_PID 2>/dev/null
+  trap "kill $_TM_HEARTBEAT_PID 2>/dev/null" EXIT
+fi
+
+# --- Preexec via DEBUG trap ---
+_tm_preexec() {
+  # Guard: only fire once per command, not per pipeline segment
+  [[ "$_TM_CMD_RUNNING" == "1" ]] && return
+  # Skip if this is the PROMPT_COMMAND itself
+  [[ "$BASH_COMMAND" == "_tm_precmd" ]] && return
+  [[ "$BASH_COMMAND" == *"_tm_precmd"* ]] && return
+
+  _TM_CMD_RUNNING=1
+  local cmd="$BASH_COMMAND"
+
+  # Claude Code has its own hooks — skip entirely
+  _tm_is_claude "$cmd" && return
+
+  local cmd_type=$(_tm_classify "$cmd")
+  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=busy&type=${cmd_type}" > /dev/null 2>&1 &) 2>/dev/null
+}
+trap '_tm_preexec' DEBUG
+
+# --- Precmd via PROMPT_COMMAND ---
+_tm_precmd() {
+  _TM_CMD_RUNNING=0
+  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=idle" > /dev/null 2>&1 &) 2>/dev/null
+}
+PROMPT_COMMAND="_tm_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"

--- a/src-tauri/script/terminal-mirror.fish
+++ b/src-tauri/script/terminal-mirror.fish
@@ -1,0 +1,55 @@
+# --- Ani-Mime Terminal Mirror (Fish) ---
+# Add to fish config:  source /path/to/terminal-mirror.fish
+
+set -g _TM_URL "http://127.0.0.1:1234"
+
+# --- Detect if a command is Claude Code ---
+function _tm_is_claude
+    set -l first_word (string split ' ' -- $argv[1])[1]
+    test "$first_word" = "claude"; and return 0
+    set -l resolved (type -p "$first_word" 2>/dev/null)
+    string match -q '*claude*' -- "$resolved"; and return 0
+    return 1
+end
+
+# --- Command categorization ---
+function _tm_classify
+    set -l cmd "$argv[1]"
+    if string match -rq '(^|\s|/)(start|dev|serve|watch|metro|docker-compose|docker compose|up)(\s|$)' -- "$cmd"
+        echo "service"
+    else
+        echo "task"
+    end
+end
+
+# --- Heartbeat (background, every 20s) ---
+function _tm_heartbeat
+    while true
+        curl -s --max-time 2 "$_TM_URL/heartbeat?pid=$fish_pid" >/dev/null 2>&1
+        sleep 20
+    end
+end
+
+# Start heartbeat only once per shell session
+if not set -q _TM_HEARTBEAT_STARTED
+    set -g _TM_HEARTBEAT_STARTED 1
+    _tm_heartbeat &
+    disown
+end
+
+# --- Hooks ---
+function _tm_preexec --on-event fish_preexec
+    set -l cmd "$argv[1]"
+
+    # Claude Code has its own hooks — skip entirely
+    _tm_is_claude "$cmd"; and return
+
+    set -l cmd_type (_tm_classify "$cmd")
+    curl -s --max-time 1 "$_TM_URL/status?pid=$fish_pid&state=busy&type=$cmd_type" >/dev/null 2>&1 &
+    disown
+end
+
+function _tm_postexec --on-event fish_postexec
+    curl -s --max-time 1 "$_TM_URL/status?pid=$fish_pid&state=idle" >/dev/null 2>&1 &
+    disown
+end

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -274,77 +274,193 @@ fn macos_dialog(title: &str, message: &str, buttons: &[&str]) -> String {
     }
 }
 
+/// Show a macOS "choose from list" dialog. Returns selected items.
+fn macos_choose_list(title: &str, message: &str, items: &[&str]) -> Vec<String> {
+    let items_str = items
+        .iter()
+        .map(|i| format!("\"{}\"", i))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let script = format!(
+        r#"choose from list {{{}}} with title "{}" with prompt "{}" with multiple selections allowed"#,
+        items_str,
+        title.replace('"', "\\\""),
+        message.replace('"', "\\\""),
+    );
+
+    let output = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output();
+
+    match output {
+        Ok(o) => {
+            let result = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if result == "false" || result.is_empty() {
+                return vec![];
+            }
+            result.split(", ").map(|s| s.to_string()).collect()
+        }
+        Err(_) => vec![],
+    }
+}
+
+struct ShellInfo {
+    name: &'static str,
+    script_file: &'static str,
+    rc_path: PathBuf,
+    marker: &'static str,
+}
+
 /// Auto-setup on first launch:
-/// 1. Detect zsh + Claude Code
-/// 2. Inject terminal-mirror.zsh into ~/.zshrc (requires zsh)
-/// 3. Add Claude Code hooks to ~/.claude/settings.json (requires claude)
+/// 1. Detect installed shells (zsh, bash, fish)
+/// 2. Ask user which shells to set up
+/// 3. Optionally configure Claude Code hooks
 fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
     std::thread::spawn(move || {
         let home = dirs::home_dir().unwrap();
-        let zsh_script = resource_dir.join("script/terminal-mirror.zsh");
-        let zshrc = home.join(".zshrc");
         let settings_path = home.join(".claude/settings.json");
 
-        let has_zsh = cmd_exists("zsh");
-        let has_claude = cmd_exists("claude");
+        // --- Detect installed shells and which need setup ---
+        let shells: Vec<ShellInfo> = vec![
+            ShellInfo {
+                name: "zsh",
+                script_file: "terminal-mirror.zsh",
+                rc_path: home.join(".zshrc"),
+                marker: "terminal-mirror.zsh",
+            },
+            ShellInfo {
+                name: "bash",
+                script_file: "terminal-mirror.bash",
+                rc_path: home.join(".bashrc"),
+                marker: "terminal-mirror.bash",
+            },
+            ShellInfo {
+                name: "fish",
+                script_file: "terminal-mirror.fish",
+                rc_path: home.join(".config/fish/config.fish"),
+                marker: "terminal-mirror.fish",
+            },
+        ];
 
-        // Check if already initialized for each component
-        let zshrc_done = {
-            let content = std::fs::read_to_string(&zshrc).unwrap_or_default();
-            content.contains("terminal-mirror.zsh")
-        };
+        // Filter: installed + not yet configured
+        let available: Vec<&ShellInfo> = shells
+            .iter()
+            .filter(|s| cmd_exists(s.name))
+            .collect();
+
+        let needs_setup: Vec<&ShellInfo> = available
+            .iter()
+            .filter(|s| {
+                let content = std::fs::read_to_string(&s.rc_path).unwrap_or_default();
+                !content.contains(s.marker)
+            })
+            .copied()
+            .collect();
+
         let claude_done = {
             let content = std::fs::read_to_string(&settings_path).unwrap_or_default();
             content.contains("127.0.0.1:1234")
         };
 
-        // Already fully initialized — skip silently
-        if zshrc_done && claude_done {
+        // Nothing to do — skip silently
+        if needs_setup.is_empty() && claude_done {
             eprintln!("[setup] already initialized, skipping");
-            return;
-        }
-        // zsh done but claude not installed — nothing more to do
-        if zshrc_done && !has_claude {
             return;
         }
 
         let _ = app_handle.emit("status-changed", "initializing");
 
-        // --- 1. Setup ~/.zshrc ---
-        if !zshrc_done {
-            if !has_zsh {
-                // zsh not installed — warn user
-                macos_dialog(
-                    "Ani-Mime",
-                    "zsh is not installed on this machine.\n\nAni-Mime requires zsh for terminal tracking.\nPlease install zsh and restart the app.",
-                    &["OK"],
-                );
-            } else if zsh_script.exists() {
-                // zsh found, ask to install hook
+        // --- 1. Shell setup ---
+        if !needs_setup.is_empty() {
+            let chosen: Vec<String> = if needs_setup.len() == 1 {
+                // Only one shell needs setup — simple Yes/No
+                let shell = needs_setup[0];
                 let answer = macos_dialog(
                     "Ani-Mime Setup",
-                    "Ani-Mime needs to add a hook to your ~/.zshrc to track terminal activity.\n\nAllow setup?",
-                    &["Yes", "No"],
+                    &format!(
+                        "{} detected. Ani-Mime needs to add a hook to {} to track terminal activity.\n\nAllow setup?",
+                        shell.name, shell.rc_path.display()
+                    ),
+                    &["Yes", "Skip"],
                 );
                 if answer == "Yes" {
-                    let line = format!(
-                        "\n# --- Ani-Mime Terminal Hook ---\nsource \"{}\"\n",
-                        zsh_script.display()
-                    );
-                    let _ = std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(&zshrc)
-                        .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()));
-                    eprintln!("[setup] injected terminal-mirror.zsh into ~/.zshrc");
+                    vec![shell.name.to_string()]
                 } else {
-                    eprintln!("[setup] user skipped zsh hook setup");
+                    vec![]
+                }
+            } else {
+                // Multiple shells — let user choose
+                let mut items: Vec<&str> = needs_setup.iter().map(|s| s.name).collect();
+                items.push("All");
+                let selected = macos_choose_list(
+                    "Ani-Mime Setup",
+                    "Multiple shells detected. Select which ones to set up for terminal tracking:",
+                    &items,
+                );
+                if selected.iter().any(|s| s == "All") {
+                    needs_setup.iter().map(|s| s.name.to_string()).collect()
+                } else {
+                    selected
+                }
+            };
+
+            // User skipped all shells and none were previously configured — quit
+            if chosen.is_empty() {
+                let any_shell_configured = shells.iter().any(|s| {
+                    let content = std::fs::read_to_string(&s.rc_path).unwrap_or_default();
+                    content.contains(s.marker)
+                });
+                if !any_shell_configured {
+                    macos_dialog(
+                        "Ani-Mime",
+                        "Ani-Mime requires at least one shell (zsh, bash, or fish) to be configured for terminal tracking.\n\nThe app will now close.\nRestart Ani-Mime when you're ready to set up.",
+                        &["OK"],
+                    );
+                    std::process::exit(0);
                 }
             }
+
+            // Install hooks for chosen shells
+            for shell in &needs_setup {
+                if !chosen.iter().any(|c| c == shell.name) {
+                    continue;
+                }
+                let script_path = resource_dir.join(format!("script/{}", shell.script_file));
+                if !script_path.exists() {
+                    eprintln!("[setup] script not found: {}", script_path.display());
+                    continue;
+                }
+
+                // Ensure parent directory exists (for fish)
+                if let Some(parent) = shell.rc_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+
+                let line = format!(
+                    "\n# --- Ani-Mime Terminal Hook ---\nsource \"{}\"\n",
+                    script_path.display()
+                );
+                let _ = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&shell.rc_path)
+                    .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()));
+                eprintln!("[setup] injected {} into {}", shell.script_file, shell.rc_path.display());
+            }
+        } else if available.is_empty() {
+            macos_dialog(
+                "Ani-Mime",
+                "No supported shell found (zsh, bash, or fish).\n\nPlease install one and restart the app.",
+                &["OK"],
+            );
+            std::process::exit(0);
         }
 
-        // --- 2. Setup Claude Code hooks ---
+        // --- 2. Claude Code hooks ---
         if !claude_done {
+            let has_claude = cmd_exists("claude");
             let answer = if has_claude {
                 macos_dialog(
                     "Ani-Mime Setup",
@@ -358,92 +474,92 @@ fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
                     &["Yes", "Skip"],
                 )
             };
-            if answer != "Yes" {
-                eprintln!("[setup] user skipped Claude Code hooks setup");
-                let _ = app_handle.emit("status-changed", "searching");
-                return;
-            }
-
-            let claude_dir = home.join(".claude");
-            let settings_path = claude_dir.join("settings.json");
-
-            let mut settings: serde_json::Value = if settings_path.exists() {
-                let content = std::fs::read_to_string(&settings_path).unwrap_or_default();
-                serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+            if answer == "Yes" {
+                setup_claude_hooks(&home);
             } else {
-                let _ = std::fs::create_dir_all(&claude_dir);
-                serde_json::json!({})
-            };
-
-            let hooks = settings
-                .as_object_mut()
-                .unwrap()
-                .entry("hooks")
-                .or_insert(serde_json::json!({}));
-
-            let busy_cmd = "curl -s --max-time 1 'http://127.0.0.1:1234/status?pid=0&state=busy&type=task' > /dev/null 2>&1";
-            let idle_cmd = "curl -s --max-time 1 'http://127.0.0.1:1234/status?pid=0&state=idle' > /dev/null 2>&1";
-            let ani_marker = "127.0.0.1:1234";
-
-            let has_ani_hook = |arr: &serde_json::Value| -> bool {
-                arr.as_array().map_or(false, |entries| {
-                    entries.iter().any(|entry| {
-                        entry["hooks"].as_array().map_or(false, |hks| {
-                            hks.iter().any(|h| {
-                                h["command"]
-                                    .as_str()
-                                    .map_or(false, |c| c.contains(ani_marker))
-                            })
-                        })
-                    })
-                })
-            };
-
-            let add_hook = |hooks_obj: &mut serde_json::Value, event: &str, cmd: &str| {
-                let arr = hooks_obj
-                    .as_object_mut()
-                    .unwrap()
-                    .entry(event)
-                    .or_insert(serde_json::json!([]));
-
-                if !has_ani_hook(arr) {
-                    if let Some(entries) = arr.as_array_mut() {
-                        if entries.is_empty() {
-                            entries.push(serde_json::json!({
-                                "matcher": "",
-                                "hooks": [{ "type": "command", "command": cmd }]
-                            }));
-                        } else {
-                            if let Some(first) = entries.first_mut() {
-                                if let Some(hks) = first["hooks"].as_array_mut() {
-                                    hks.push(serde_json::json!({
-                                        "type": "command",
-                                        "command": cmd
-                                    }));
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            add_hook(hooks, "PreToolUse", busy_cmd);
-            add_hook(hooks, "UserPromptSubmit", busy_cmd);
-            add_hook(hooks, "Stop", idle_cmd);
-            add_hook(hooks, "SessionStart", idle_cmd);
-            add_hook(hooks, "SessionEnd", idle_cmd);
-
-            let _ = std::fs::write(
-                &settings_path,
-                serde_json::to_string_pretty(&settings).unwrap(),
-            );
-            eprintln!("[setup] configured Claude Code hooks in ~/.claude/settings.json");
-        } else if !has_claude {
-            eprintln!("[ani-mime] Claude Code not found (optional). Install it for Claude activity tracking.");
+                eprintln!("[setup] user skipped Claude Code hooks setup");
+            }
         }
 
         let _ = app_handle.emit("status-changed", "searching");
     });
+}
+
+fn setup_claude_hooks(home: &std::path::Path) {
+    let claude_dir = home.join(".claude");
+    let settings_path = claude_dir.join("settings.json");
+
+    let mut settings: serde_json::Value = if settings_path.exists() {
+        let content = std::fs::read_to_string(&settings_path).unwrap_or_default();
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+    } else {
+        let _ = std::fs::create_dir_all(&claude_dir);
+        serde_json::json!({})
+    };
+
+    let hooks = settings
+        .as_object_mut()
+        .unwrap()
+        .entry("hooks")
+        .or_insert(serde_json::json!({}));
+
+    let busy_cmd = "curl -s --max-time 1 'http://127.0.0.1:1234/status?pid=0&state=busy&type=task' > /dev/null 2>&1";
+    let idle_cmd = "curl -s --max-time 1 'http://127.0.0.1:1234/status?pid=0&state=idle' > /dev/null 2>&1";
+    let ani_marker = "127.0.0.1:1234";
+
+    let has_ani_hook = |arr: &serde_json::Value| -> bool {
+        arr.as_array().map_or(false, |entries| {
+            entries.iter().any(|entry| {
+                entry["hooks"].as_array().map_or(false, |hks| {
+                    hks.iter().any(|h| {
+                        h["command"]
+                            .as_str()
+                            .map_or(false, |c| c.contains(ani_marker))
+                    })
+                })
+            })
+        })
+    };
+
+    let add_hook = |hooks_obj: &mut serde_json::Value, event: &str, cmd: &str| {
+        let arr = hooks_obj
+            .as_object_mut()
+            .unwrap()
+            .entry(event)
+            .or_insert(serde_json::json!([]));
+
+        if !has_ani_hook(arr) {
+            if let Some(entries) = arr.as_array_mut() {
+                if entries.is_empty() {
+                    entries.push(serde_json::json!({
+                        "matcher": "",
+                        "hooks": [{ "type": "command", "command": cmd }]
+                    }));
+                } else {
+                    if let Some(first) = entries.first_mut() {
+                        if let Some(hks) = first["hooks"].as_array_mut() {
+                            hks.push(serde_json::json!({
+                                "type": "command",
+                                "command": cmd
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    add_hook(hooks, "PreToolUse", busy_cmd);
+    add_hook(hooks, "UserPromptSubmit", busy_cmd);
+    add_hook(hooks, "Stop", idle_cmd);
+    add_hook(hooks, "SessionStart", idle_cmd);
+    add_hook(hooks, "SessionEnd", idle_cmd);
+
+    let _ = std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&settings).unwrap(),
+    );
+    eprintln!("[setup] configured Claude Code hooks in ~/.claude/settings.json");
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,8 @@
   "bundle": {
     "resources": [
       "script/terminal-mirror.zsh",
+      "script/terminal-mirror.bash",
+      "script/terminal-mirror.fish",
       "script/tauri-hook.sh"
     ],
     "active": true,


### PR DESCRIPTION
## Summary
- Add `terminal-mirror.bash` — DEBUG trap + PROMPT_COMMAND for bash tracking
- Add `terminal-mirror.fish` — fish_preexec/postexec events for fish tracking
- Rewrite auto-setup flow to detect all installed shells
- 1 shell → simple Yes/Skip dialog
- 2+ shells → multi-select list with "All" option
- App quits if user skips setup with no shell configured
- No shells installed → warning dialog then quit

## Test plan
- [ ] Test with only zsh installed — single dialog
- [ ] Test with zsh + bash — multi-select list
- [ ] Test skipping all shells — app should close
- [ ] Test subsequent launch after setup — should skip silently
- [ ] Test bash tracking: `sleep 5` shows Working, then Free
- [ ] Test fish tracking: same behavior

Generated with [Claude Code](https://claude.com/claude-code)