### PR TITLE
Show setup complete dialog and restart app

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,11 +496,17 @@ fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
 
         macos_dialog(
             "Ani-Mime",
-            "Setup complete!\n\nPlease open a new terminal tab or window for the tracking to take effect.",
+            "Setup complete!\n\nPlease open a new terminal tab or window for the tracking to take effect.\n\nThe app will now restart.",
             &["OK"],
         );
 
-        let _ = app_handle.emit("status-changed", "searching");
+        // Restart the app
+        let current_exe = std::env::current_exe().unwrap();
+        let _ = std::process::Command::new("open")
+            .arg("-a")
+            .arg(&current_exe)
+            .spawn();
+        std::process::exit(0);
     });
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -494,6 +494,12 @@ fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
         let _ = std::fs::write(&setup_marker, "done");
         eprintln!("[setup] setup complete, marker written");
 
+        macos_dialog(
+            "Ani-Mime",
+            "Setup complete!\n\nPlease open a new terminal tab or window for the tracking to take effect.",
+            &["OK"],
+        );
+
         let _ = app_handle.emit("status-changed", "searching");
     });
 }


### PR DESCRIPTION
## Summary
- Show "Setup complete" dialog telling user to open a new terminal
- Auto-restart the app after user clicks OK

## Test plan
- [ ] First launch: complete setup → see dialog → app restarts
- [ ] Second launch: skips setup silently

Generated with [Claude Code](https://claude.com/claude-code)