### PR TITLE
Release v0.13.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.13.19] - 2026-04-04
+
+### Added
+- Native macOS menu bar with About, Settings (Cmd+,), and Quit
+- Settings window with sidebar navigation (General, About)
+- Dark/light theme toggle for status pill via CSS custom properties
+- Pet selection: choose between Rottweiler and Dalmatian
+- Dalmatian pixel art sprites (idle, bark, sniff, sit, sleep)
+- Preferences persistence via tauri-plugin-store (theme + pet survive restarts)
+- Cross-window real-time sync for theme and pet changes
+- About page with app info, author, and Twitter link
+
+### Changed
+- Mascot window fitted to content size (140x175)
+- Status pill colors now driven by CSS variables for theming
+- Vite configured for multi-page build (main + settings)
+
+### Fixed
+- Opt out of macOS Sequoia window tiling/snapping via NSWindowCollectionBehavior
+
 ## [0.2.17] - 2026-04-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.2.17",
+  "version": "0.13.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.2.17"
+version = "0.13.19"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.2.17",
+  "version": "0.13.19",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -87,7 +87,7 @@ export function Settings() {
             <div className="settings-card">
               <div className="about-info">
                 <div className="about-name">Ani-Mime</div>
-                <div className="about-version">Version 0.2.17</div>
+                <div className="about-version">Version 0.13.19</div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.13.19 across all config files
- Update CHANGELOG.md with v0.13.19 release notes

## Release Notes
### Added
- Native macOS menu bar with About, Settings (Cmd+,), and Quit
- Settings window with sidebar navigation (General, About)
- Dark/light theme toggle for status pill
- Pet selection: Rottweiler and Dalmatian
- Preferences persistence via tauri-plugin-store
- Cross-window real-time sync for theme and pet changes

### Changed
- Mascot window fitted to content size
- Status pill colors driven by CSS variables

### Fixed
- macOS Sequoia window tiling/snapping opt-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)