### PR TITLE
Add speech bubble notifications and neon glow effects

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.2.17"
+version = "0.13.19"
 dependencies = [
  "cocoa",
  "dirs",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,8 @@ pub fn run() {
             let app_state = Arc::new(Mutex::new(AppState {
                 sessions: HashMap::new(),
                 current_ui: "searching".to_string(),
+                idle_since: 0,
+                sleeping: false,
             }));
 
             server::start_http_server(app.handle().clone(), app_state.clone());

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1,7 +1,8 @@
 use std::sync::{Arc, Mutex};
+use tauri::Emitter;
 
 use crate::helpers::{get_query_param, now_secs};
-use crate::state::{emit_if_changed, AppState, Session};
+use crate::state::{emit_if_changed, AppState, Session, TaskCompleted};
 
 pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppState>>) {
     std::thread::spawn(move || {
@@ -38,16 +39,26 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
                             if cmd_type == "service" {
                                 session.ui_state = "service".to_string();
                                 session.service_since = now;
+                                session.busy_since = 0;
                             } else {
                                 session.ui_state = "busy".to_string();
                                 session.service_since = 0;
+                                session.busy_since = now;
                             }
 
                             emit_if_changed(&app_handle, &mut st);
                         } else if url.contains("state=idle") {
+                            // Emit task-completed if this session was busy
+                            let busy_since = session.busy_since;
+                            if busy_since > 0 {
+                                let duration = now.saturating_sub(busy_since);
+                                let _ = app_handle.emit("task-completed", TaskCompleted { duration_secs: duration });
+                            }
+
                             session.busy_type.clear();
                             session.ui_state = "idle".to_string();
                             session.service_since = 0;
+                            session.busy_since = 0;
                             emit_if_changed(&app_handle, &mut st);
                         }
                     }
@@ -60,12 +71,7 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
                             .sessions
                             .entry(pid)
                             .or_insert_with(|| Session::new_idle(now));
-                        // Only refresh last_seen for idle sessions.
-                        // Busy sessions should NOT be kept alive by heartbeat —
-                        // let the watchdog clean them up if no status signal comes.
-                        if session.ui_state != "busy" {
-                            session.last_seen = now;
-                        }
+                        session.last_seen = now;
 
                         emit_if_changed(&app_handle, &mut st);
                     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,5 +1,12 @@
 use std::collections::HashMap;
+use serde::Serialize;
 use tauri::Emitter;
+
+/// Payload emitted when a task finishes (busy → idle).
+#[derive(Clone, Serialize)]
+pub struct TaskCompleted {
+    pub duration_secs: u64,
+}
 
 /// Per-shell session state.
 #[derive(Clone)]
@@ -12,6 +19,8 @@ pub struct Session {
     pub last_seen: u64,
     /// When this session entered "service" state (0 = not in service).
     pub service_since: u64,
+    /// When this session entered "busy" state (0 = not busy).
+    pub busy_since: u64,
 }
 
 impl Session {
@@ -21,6 +30,7 @@ impl Session {
             ui_state: "idle".to_string(),
             last_seen: now,
             service_since: 0,
+            busy_since: 0,
         }
     }
 }
@@ -29,6 +39,10 @@ pub struct AppState {
     pub sessions: HashMap<u32, Session>,
     /// What the frontend is currently showing.
     pub current_ui: String,
+    /// When the UI entered "idle" state (0 = not idle).
+    pub idle_since: u64,
+    /// True when idle countdown triggered sleep. Only busy/service wakes up.
+    pub sleeping: bool,
 }
 
 /// Picks the "winning" UI state across all sessions.
@@ -57,7 +71,23 @@ pub fn resolve_ui_state(sessions: &HashMap<u32, Session>) -> &'static str {
 
 pub fn emit_if_changed(app: &tauri::AppHandle, state: &mut AppState) {
     let new_ui = resolve_ui_state(&state.sessions);
+
+    // If sleeping, only wake up for busy or service
+    if state.sleeping {
+        if new_ui == "busy" || new_ui == "service" {
+            state.sleeping = false;
+        } else {
+            return;
+        }
+    }
+
     if new_ui != state.current_ui {
+        // Track when UI enters idle for sleep countdown
+        if new_ui == "idle" {
+            state.idle_since = crate::helpers::now_secs();
+        } else {
+            state.idle_since = 0;
+        }
         let _ = app.emit("status-changed", new_ui);
         state.current_ui = new_ui.to_string();
     }

--- a/src-tauri/src/watchdog.rs
+++ b/src-tauri/src/watchdog.rs
@@ -6,6 +6,7 @@ use crate::state::{emit_if_changed, AppState};
 
 const HEARTBEAT_TIMEOUT_SECS: u64 = 40;
 const SERVICE_DISPLAY_SECS: u64 = 2;
+const IDLE_TO_SLEEP_SECS: u64 = 120;
 
 /// Watchdog: runs every 2s.
 /// - Transitions service → idle after 2s of showing service.
@@ -29,29 +30,34 @@ pub fn start_watchdog(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppStat
         }
 
         // Remove stale sessions (no heartbeat for 40s)
-        // pid=0 is the Claude Code hooks session — keep it alive as long as
-        // any shell session exists (shell heartbeat keeps everything alive)
-        let has_shell_sessions = st
-            .sessions
-            .iter()
-            .any(|(pid, s)| *pid != 0 && now - s.last_seen < HEARTBEAT_TIMEOUT_SECS);
-
+        // pid=0 (Claude Code): no heartbeat, never expire by timeout
         st.sessions.retain(|pid, session| {
             if *pid == 0 {
-                has_shell_sessions
+                true
             } else {
                 now - session.last_seen < HEARTBEAT_TIMEOUT_SECS
             }
         });
 
         // Update UI
-        if st.sessions.is_empty() && st.current_ui != "searching" {
+        if st.sessions.is_empty() && st.current_ui != "searching" && st.current_ui != "initializing" {
             if st.current_ui != "disconnected" {
                 let _ = app_handle.emit("status-changed", "disconnected");
                 st.current_ui = "disconnected".to_string();
             }
         } else {
             emit_if_changed(&app_handle, &mut st);
+        }
+
+        // Idle → Sleep countdown: if UI has been "idle" long enough, transition to sleep
+        if st.current_ui == "idle"
+            && st.idle_since > 0
+            && now - st.idle_since >= IDLE_TO_SLEEP_SECS
+        {
+            let _ = app_handle.emit("status-changed", "disconnected");
+            st.current_ui = "disconnected".to_string();
+            st.idle_since = 0;
+            st.sleeping = true;
         }
     });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,8 +14,8 @@
     "windows": [
       {
         "title": "Ani-Mime",
-        "width": 140,
-        "height": 175,
+        "width": 200,
+        "height": 190,
         "resizable": false,
         "fullscreen": false,
         "alwaysOnTop": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,17 @@
 import { Mascot } from "./components/Mascot";
 import { StatusPill } from "./components/StatusPill";
+import { SpeechBubble } from "./components/SpeechBubble";
 import { useStatus } from "./hooks/useStatus";
 import { useDrag } from "./hooks/useDrag";
 import { useTheme } from "./hooks/useTheme";
+import { useBubble } from "./hooks/useBubble";
 import "./styles/theme.css";
 import "./styles/app.css";
 
 function App() {
   const status = useStatus();
   const { dragging, onMouseDown } = useDrag();
+  const { visible, message, dismiss } = useBubble();
   useTheme();
 
   return (
@@ -16,8 +19,9 @@ function App() {
       className={`container ${dragging ? "dragging" : ""}`}
       onMouseDown={onMouseDown}
     >
+      <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
       <Mascot status={status} />
-      <StatusPill status={status} />
+      <StatusPill status={status} glow={visible} />
     </div>
   );
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTheme, type Theme } from "../hooks/useTheme";
 import { usePet } from "../hooks/usePet";
+import { useBubble } from "../hooks/useBubble";
 import { pets } from "../constants/sprites";
 import "../styles/settings.css";
 
@@ -9,6 +10,7 @@ type Tab = "general" | "about";
 export function Settings() {
   const { theme, setTheme } = useTheme();
   const { pet, setPet } = usePet();
+  const { enabled: bubbleEnabled, setEnabled: setBubbleEnabled } = useBubble();
   const [tab, setTab] = useState<Tab>("general");
 
   return (
@@ -78,6 +80,20 @@ export function Settings() {
                   </button>
                 );
               })}
+            </div>
+          </div>
+          <div className="settings-section">
+            <div className="settings-section-title">Behavior</div>
+            <div className="settings-card">
+              <div className="settings-row">
+                <span className="settings-row-label">Speech Bubbles</span>
+                <button
+                  className={`toggle-switch ${bubbleEnabled ? "active" : ""}`}
+                  onClick={() => setBubbleEnabled(!bubbleEnabled)}
+                >
+                  <span className="toggle-knob" />
+                </button>
+              </div>
             </div>
           </div>
           </>

--- a/src/components/SpeechBubble.tsx
+++ b/src/components/SpeechBubble.tsx
@@ -1,0 +1,18 @@
+import "../styles/speech-bubble.css";
+
+interface SpeechBubbleProps {
+  visible: boolean;
+  message: string;
+  onDismiss: () => void;
+}
+
+export function SpeechBubble({ visible, message, onDismiss }: SpeechBubbleProps) {
+  if (!visible) return null;
+
+  return (
+    <div className="speech-bubble" onClick={onDismiss}>
+      <span className="speech-bubble-text">{message}</span>
+      <div className="speech-bubble-tail" />
+    </div>
+  );
+}

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -3,6 +3,7 @@ import "../styles/status-pill.css";
 
 interface StatusPillProps {
   status: Status;
+  glow?: boolean;
 }
 
 const dotClassMap: Record<Status, string> = {
@@ -23,9 +24,9 @@ const labelMap: Record<Status, string> = {
   searching: "Searching...",
 };
 
-export function StatusPill({ status }: StatusPillProps) {
+export function StatusPill({ status, glow }: StatusPillProps) {
   return (
-    <div className="pill">
+    <div className={`pill ${glow ? "neon-glow" : ""} ${status === "busy" ? "neon-busy" : ""}`}>
       <span className={dotClassMap[status] ?? "dot searching"} />
       <span className="label">{labelMap[status] ?? "Searching..."}</span>
     </div>

--- a/src/hooks/useBubble.ts
+++ b/src/hooks/useBubble.ts
@@ -15,10 +15,10 @@ const messages = [
 ];
 
 const welcomeMessages = [
-  "Hey there! Ready to work",
-  "Hi! Let's get started",
-  "Hello! I'm here for you",
-  "Woof! Nice to see you",
+  "Hey! Ready to work",
+  "Let's get started!",
+  "Hello there!",
+  "Woof! Hi!",
 ];
 
 function randomMessage(): string {

--- a/src/hooks/useBubble.ts
+++ b/src/hooks/useBubble.ts
@@ -1,0 +1,111 @@
+import { useState, useEffect, useRef, useCallback, useLayoutEffect } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { emit, listen } from "@tauri-apps/api/event";
+
+const STORE_FILE = "settings.json";
+const STORE_KEY = "bubbleEnabled";
+const BUBBLE_DURATION_MS = 7000;
+
+const messages = [
+  "Done! Check it out",
+  "All finished!",
+  "Hey, take a look!",
+  "Task complete!",
+  "Ready for you!",
+];
+
+const welcomeMessages = [
+  "Hey there! Ready to work",
+  "Hi! Let's get started",
+  "Hello! I'm here for you",
+  "Woof! Nice to see you",
+];
+
+function randomMessage(): string {
+  return messages[Math.floor(Math.random() * messages.length)];
+}
+
+interface TaskCompleted {
+  duration_secs: number;
+}
+
+export function useBubble() {
+  const [enabled, setEnabledState] = useState(true);
+  const [visible, setVisible] = useState(false);
+  const [message, setMessage] = useState("");
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const hasGreeted = useRef(false);
+
+  // Load saved preference
+  useLayoutEffect(() => {
+    load(STORE_FILE).then((store) => {
+      store.get<boolean>(STORE_KEY).then((saved) => {
+        setEnabledState(saved ?? true);
+      });
+    });
+  }, []);
+
+  // Listen for setting changes from Settings window
+  useEffect(() => {
+    const unlisten = listen<boolean>("bubble-changed", (event) => {
+      setEnabledState(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  // Welcome bubble on first "idle" after app launch
+  useEffect(() => {
+    const unlisten = listen<string>("status-changed", (e) => {
+      if (hasGreeted.current || !enabled) return;
+      if (e.payload === "idle") {
+        hasGreeted.current = true;
+        clearTimeout(timerRef.current);
+        setMessage(welcomeMessages[Math.floor(Math.random() * welcomeMessages.length)]);
+        setVisible(true);
+        timerRef.current = setTimeout(() => {
+          setVisible(false);
+        }, BUBBLE_DURATION_MS);
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [enabled]);
+
+  // Listen for task-completed events
+  useEffect(() => {
+    const unlisten = listen<TaskCompleted>("task-completed", () => {
+      if (!enabled) return;
+
+      clearTimeout(timerRef.current);
+      setMessage(randomMessage());
+      setVisible(true);
+
+      timerRef.current = setTimeout(() => {
+        setVisible(false);
+      }, BUBBLE_DURATION_MS);
+    });
+
+    return () => {
+      clearTimeout(timerRef.current);
+      unlisten.then((fn) => fn());
+    };
+  }, [enabled]);
+
+  const dismiss = useCallback(() => {
+    clearTimeout(timerRef.current);
+    setVisible(false);
+  }, []);
+
+  const setEnabled = async (next: boolean) => {
+    setEnabledState(next);
+    const store = await load(STORE_FILE);
+    await store.set(STORE_KEY, next);
+    await store.save();
+    await emit("bubble-changed", next);
+  };
+
+  return { visible, message, dismiss, enabled, setEnabled };
+}

--- a/src/styles/mascot.css
+++ b/src/styles/mascot.css
@@ -1,5 +1,6 @@
 /* --- Sprite animation --- */
 .sprite {
+  margin-bottom: 4px;
   image-rendering: pixelated;
   background-repeat: no-repeat;
   background-size: var(--sprite-width) 128px;

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -161,6 +161,39 @@
   color: #007aff;
 }
 
+/* Toggle switch */
+.toggle-switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  border: none;
+  background: rgba(128, 128, 128, 0.3);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s;
+}
+
+.toggle-switch.active {
+  background: #34c759;
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s;
+}
+
+.toggle-switch.active .toggle-knob {
+  transform: translateX(16px);
+}
+
 /* About */
 .about-info {
   padding: 10px 12px;

--- a/src/styles/speech-bubble.css
+++ b/src/styles/speech-bubble.css
@@ -1,0 +1,48 @@
+.speech-bubble {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 14px;
+  margin-bottom: -46px;
+  z-index: 1;
+  border-radius: 12px;
+  background: var(--bg-bubble);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--border-pill);
+  cursor: pointer;
+  animation: bubble-pop-in 0.3s ease-out;
+  pointer-events: auto;
+}
+
+.speech-bubble-text {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-bubble);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.speech-bubble-tail {
+  position: absolute;
+  bottom: -6px;
+  right: 16px;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid var(--bg-bubble);
+  filter: drop-shadow(0 1px 0 var(--border-pill));
+}
+
+@keyframes bubble-pop-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.8) translateY(4px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -3,7 +3,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border-radius: 9999px;
   background: var(--bg-pill);
   backdrop-filter: blur(10px);
@@ -66,6 +66,62 @@
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
+}
+
+/* Neon glow on task completion */
+.pill.neon-glow {
+  border-color: #34c759;
+  box-shadow:
+    0 0 6px rgba(52, 199, 89, 0.4),
+    0 0 14px rgba(52, 199, 89, 0.25),
+    0 0 30px rgba(52, 199, 89, 0.15),
+    inset 0 0 6px rgba(52, 199, 89, 0.1);
+  animation: neon-pulse 1.5s ease-in-out infinite;
+}
+
+/* Red neon glow when busy/working */
+.pill.neon-busy {
+  border-color: #ff3b30;
+  box-shadow:
+    0 0 6px rgba(255, 59, 48, 0.4),
+    0 0 14px rgba(255, 59, 48, 0.25),
+    0 0 30px rgba(255, 59, 48, 0.15),
+    inset 0 0 6px rgba(255, 59, 48, 0.1);
+  animation: neon-pulse-red 1.5s ease-in-out infinite;
+}
+
+@keyframes neon-pulse-red {
+  0%, 100% {
+    box-shadow:
+      0 0 6px rgba(255, 59, 48, 0.4),
+      0 0 14px rgba(255, 59, 48, 0.25),
+      0 0 30px rgba(255, 59, 48, 0.15),
+      inset 0 0 6px rgba(255, 59, 48, 0.1);
+  }
+  50% {
+    box-shadow:
+      0 0 10px rgba(255, 59, 48, 0.6),
+      0 0 22px rgba(255, 59, 48, 0.4),
+      0 0 44px rgba(255, 59, 48, 0.2),
+      inset 0 0 10px rgba(255, 59, 48, 0.15);
+  }
+}
+
+@keyframes neon-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 6px rgba(52, 199, 89, 0.4),
+      0 0 14px rgba(52, 199, 89, 0.25),
+      0 0 30px rgba(52, 199, 89, 0.15),
+      inset 0 0 6px rgba(52, 199, 89, 0.1);
+  }
+  50% {
+    box-shadow:
+      0 0 10px rgba(52, 199, 89, 0.6),
+      0 0 22px rgba(52, 199, 89, 0.4),
+      0 0 44px rgba(52, 199, 89, 0.2),
+      inset 0 0 10px rgba(52, 199, 89, 0.15);
+  }
 }
 
 .label {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -7,6 +7,8 @@
   --border-pill-hover: rgba(255, 255, 255, 0.15);
   --shadow-pill-hover: 0 0 12px rgba(255, 255, 255, 0.05);
   --text-primary: rgba(255, 255, 255, 0.85);
+  --bg-bubble: rgba(128, 128, 128, 0.85);
+  --text-bubble: #fff;
 }
 
 /* Light theme */
@@ -17,4 +19,6 @@
   --border-pill-hover: rgba(0, 0, 0, 0.2);
   --shadow-pill-hover: 0 0 12px rgba(0, 0, 0, 0.08);
   --text-primary: rgba(0, 0, 0, 0.85);
+  --bg-bubble: rgba(255, 255, 255, 0.8);
+  --text-bubble: rgba(0, 0, 0, 0.85);
 }


### PR DESCRIPTION
## Summary
- **Speech bubble**: Pops up above the mascot on task completion with random fun messages ("Done! Check it out", "All finished!", etc.) and a welcome greeting on first launch
- **Neon glow effects**: Status pill glows green on task completion, red when busy/working — pulsing neon animation
- **Idle-to-sleep countdown**: After 2 minutes of idle, pet transitions to sleep mode. Only wakes up for real activity (busy/service), not heartbeats
- **Bug fixes**: Fixed Claude Code (pid=0) session handling — no longer expires prematurely. Fixed heartbeat blocking for long-running commands. Fixed initializing/sleep flash on app startup
- **Settings**: Toggle for speech bubbles in Settings > General > Behavior with macOS-style toggle switch
- **Theme support**: Bubble adapts to dark/light mode with dedicated CSS variables

## Test plan
- [ ] Run a terminal command → verify bubble appears on completion with neon green glow
- [ ] Run Claude Code task → verify bubble appears when Claude finishes
- [ ] Run a long command (>40s) → verify status stays "Working..." throughout
- [ ] Wait 2min idle → verify pet transitions to "Sleep"
- [ ] Start a new command after sleep → verify pet wakes up
- [ ] Toggle speech bubbles off in Settings → verify no bubble on task completion
- [ ] Test both dark and light themes for bubble styling
- [ ] Open app fresh → verify welcome bubble on first "Free" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)