### PR TITLE
Release v0.13.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.13.25] - 2026-04-07
+
+### Added
+- Speech bubble notifications on task completion with random fun messages
+- Welcome bubble greeting on first "Free" status after app launch
+- Neon glow effects on status pill: green pulse on task done, red pulse when busy
+- Idle-to-sleep countdown: pet sleeps after 2 minutes of inactivity, wakes on real work
+- Speech bubble toggle in Settings > General > Behavior with macOS-style switch
+- Theme-aware bubble styling (grey bubble in dark mode, white in light mode)
+- `busy_since` tracking for task duration measurement
+- `task-completed` Tauri event emitted on busy→idle transition
+
+### Fixed
+- Claude Code (pid=0) sessions no longer expire prematurely during long tasks
+- Heartbeats now keep busy sessions alive (long-running commands stay as "Working...")
+- Fixed "Initializing..." flashing to "Sleep" on first app launch
+- Widened mascot window (140→200px) to prevent speech bubble text clipping
+
+### Changed
+- Mascot window size increased to 200x190 for bubble space
+- Status pill vertical padding reduced (8→6px) for tighter layout
+- Added spacing between mascot and status pill
+
 ## [0.13.19] - 2026-04-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.13.19",
+  "version": "0.13.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.13.19"
+version = "0.13.25"
 dependencies = [
  "cocoa",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.13.19"
+version = "0.13.25"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.13.19",
+  "version": "0.13.25",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -103,7 +103,7 @@ export function Settings() {
             <div className="settings-card">
               <div className="about-info">
                 <div className="about-name">Ani-Mime</div>
-                <div className="about-version">Version 0.13.19</div>
+                <div className="about-version">Version 0.13.25</div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.13.25 across all config files
- Update CHANGELOG with speech bubble, neon glow, idle-to-sleep, and bug fix entries
- Homebrew cask already updated in `vietnguyenhoangw/homebrew-ani-mime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)