### PR TITLE
Fix peer discovery: advertise local IP and accept external connections

### DIFF
--- a/src-tauri/src/discovery.rs
+++ b/src-tauri/src/discovery.rs
@@ -43,7 +43,8 @@ pub fn start_discovery(
             "",
             port,
             &properties[..],
-        ).expect("Failed to create ServiceInfo");
+        ).expect("Failed to create ServiceInfo")
+         .enable_addr_auto();
 
         mdns.register(service_info.clone())
             .expect("Failed to register mDNS service");

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -7,7 +7,7 @@ use crate::state::{emit_if_changed, AppState, Session, TaskCompleted};
 pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppState>>) {
     std::thread::spawn(move || {
         let port = get_port();
-        let addr = format!("127.0.0.1:{}", port);
+        let addr = format!("0.0.0.0:{}", port);
         let server = match tiny_http::Server::http(&addr) {
             Ok(s) => s,
             Err(e) => {


### PR DESCRIPTION
mDNS ServiceInfo was registered with no IP addresses (empty string yields empty set), so peers could never resolve our address. Enable addr_auto so mdns-sd advertises the host's real LAN IPs. Also bind HTTP server to 0.0.0.0 instead of 127.0.0.1 so peers on other devices can reach the /visit endpoint.