### PR TITLE
Release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.14.2] - 2026-04-08
+
+### Fixed
+- Peer discovery now advertises local IP and accepts external connections
+
 ## [0.14.1] - 2026-04-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.14.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "cocoa",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.14.1"
+version = "0.14.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -121,7 +121,7 @@ export function Settings() {
             <div className="settings-card">
               <div className="about-info">
                 <div className="about-name">Ani-Mime</div>
-                <div className="about-version">Version 0.14.1</div>
+                <div className="about-version">Version 0.14.2</div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.14.2
- Fix peer discovery: advertise local IP and accept external connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)