### PR TITLE
Add white glow to mascot sprite

### DIFF
--- a/src/styles/mascot.css
+++ b/src/styles/mascot.css
@@ -6,6 +6,7 @@
   background-repeat: no-repeat;
   background-size: var(--sprite-width) 128px;
   animation: sprite-play var(--sprite-duration) steps(var(--sprite-steps), end) infinite;
+  filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.8)) drop-shadow(0 0 8px rgba(255, 255, 255, 0.5));
 }
 
 .sprite.frozen {


### PR DESCRIPTION
## Summary
- Add `drop-shadow` filter to mascot sprite for better visibility on any desktop background
- Uses white glow that follows the dog's pixel outline

## Test plan
- [x] Verify dog sprite has visible glow on dark backgrounds
- [x] Verify glow follows the dog shape, not a bounding box
- [x] Verify animation still works correctly with the filter