### PR TITLE
Release v0.14.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.14.12] - 2026-04-08
+
+### Added
+- **Mime tab**: Dedicated settings tab for character selection with categorized grid (Pet, Character) and nickname input with save button
+- **Samurai & Hancock**: Two new character sprites with full animation sets
+- **Glow modes**: Glow effect upgraded from toggle to 3-mode selector (Off / Light / Dark)
+- **Contributors section**: About page now shows contributors with GitHub avatars and a thank-you message
+- `MimeCategory` type system for organizing mimes into extensible categories
+
+### Changed
+- Pet selection moved from General to its own Mime sidebar tab
+- Pet grid now displays 4 items per row with compact card sizing
+- Author and Twitter combined into a single row in About
+- Nickname input now requires explicit Save button instead of saving on every keystroke
+
+### Fixed
+- Hancock sleep sprite: use single-frame image instead of multi-frame reference
+- Peer discovery on macOS with enhanced diagnostic logging
+
 ## [0.14.3] - 2026-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.14.3",
+  "version": "0.14.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.14.3"
+version = "0.14.12"
 dependencies = [
  "cocoa",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.14.3"
+version = "0.14.12"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.14.3",
+  "version": "0.14.12",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -202,7 +202,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.14.3{devMode && " (Dev Mode)"}
+                  Version 0.14.12{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.14.12
- Add Mime tab with categorized character selection (Pet / Character) and nickname save
- Add Samurai & Hancock character sprites
- Upgrade glow effect to 3-mode selector (Off / Light / Dark)
- Add contributors section in About with GitHub avatars
- Compact pet grid (4 per row), combined Author/Twitter row in About

## Test plan
- [ ] Verify version shows 0.14.12 in About
- [ ] Test Mime tab: categories, pet selection, nickname save
- [ ] Test glow modes: Off, Light, Dark
- [ ] Verify About: author/twitter row, contributors with avatars
- [ ] Confirm all 4 mimes animate correctly across all statuses
- [ ] Settings persist across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)