### PR TITLE
Add update checker and auto-dismiss speech bubble

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod platform;
 mod server;
 mod setup;
 mod state;
+mod updater;
 mod watchdog;
 
 use std::collections::HashMap;
@@ -170,7 +171,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::new().build())
-        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_superpower, scenario_override])
+        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_superpower, scenario_override, updater::update_now, updater::skip_version])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
 
@@ -222,6 +223,9 @@ pub fn run() {
             let resource_dir = app.path().resource_dir().unwrap();
             crate::app_log!("[app] resource dir: {}", resource_dir.display());
             setup::auto_setup(resource_dir, setup_handle);
+
+            // Check for updates in background
+            updater::check_for_updates(app.handle().clone());
 
             let app_state = Arc::new(Mutex::new(AppState {
                 sessions: HashMap::new(),

--- a/src-tauri/src/setup/mod.rs
+++ b/src-tauri/src/setup/mod.rs
@@ -1,5 +1,5 @@
 mod claude;
-mod shell;
+pub(crate) mod shell;
 
 use std::path::PathBuf;
 use tauri::Emitter;

--- a/src-tauri/src/setup/mod.rs
+++ b/src-tauri/src/setup/mod.rs
@@ -102,25 +102,21 @@ pub fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
             let has_claude = shell::cmd_exists("claude");
             crate::app_log!("[setup] claude CLI installed: {}", has_claude);
 
-            let answer = if has_claude {
-                macos_dialog(
+            if has_claude {
+                let answer = macos_dialog(
                     "Ani-Mime Setup",
-                    "Claude Code detected! Ani-Mime can track when Claude is working.\n\nThis adds hooks to ~/.claude/settings.json.\n\nAllow setup?",
+                    "Ani-Mime also supports Claude Code! Your mascot can react in real-time when Claude is thinking or using tools.\n\nThis will add lightweight hooks to ~/.claude/settings.json.\n\nWould you like to enable it?",
                     &["Yes", "Skip"],
-                )
-            } else {
-                macos_dialog(
-                    "Ani-Mime",
-                    "Claude Code is not installed.\n\nThis is optional — Ani-Mime works without it.\nIf you install Claude Code later, restart Ani-Mime to set up tracking.\n\nWould you like to pre-configure the hooks now?",
-                    &["Yes", "Skip"],
-                )
-            };
+                );
 
-            crate::app_log!("[setup] user chose '{}' for Claude hooks", answer);
-            if answer == "Yes" {
-                setup_claude_hooks(&home);
+                crate::app_log!("[setup] user chose '{}' for Claude hooks", answer);
+                if answer == "Yes" {
+                    setup_claude_hooks(&home);
+                } else {
+                    crate::app_log!("[setup] user skipped Claude Code hooks setup");
+                }
             } else {
-                crate::app_log!("[setup] user skipped Claude Code hooks setup");
+                crate::app_log!("[setup] claude CLI not installed, skipping hooks setup");
             }
         }
 

--- a/src-tauri/src/setup/shell.rs
+++ b/src-tauri/src/setup/shell.rs
@@ -56,7 +56,7 @@ pub fn detect_shells(home: &Path) -> Vec<ShellInfo> {
 }
 
 /// Show a native macOS dialog. Returns the button text the user clicked.
-pub fn macos_dialog(title: &str, message: &str, buttons: &[&str]) -> String {
+pub(crate) fn macos_dialog(title: &str, message: &str, buttons: &[&str]) -> String {
     let buttons_str = buttons
         .iter()
         .map(|b| format!("\"{}\"", b))

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,0 +1,118 @@
+use tauri::{Emitter, Manager};
+
+const GITHUB_RELEASES_URL: &str =
+    "https://api.github.com/repos/vietnguyenhoangw/ani-mime/releases/latest";
+
+/// Check GitHub for a newer release and show a native dialog if one exists.
+/// Runs in a background thread, non-blocking.
+pub fn check_for_updates(app_handle: tauri::AppHandle) {
+    std::thread::spawn(move || {
+        // Small delay so the app window appears first
+        std::thread::sleep(std::time::Duration::from_secs(3));
+
+        let current = env!("CARGO_PKG_VERSION");
+        crate::app_log!("[updater] checking for updates (current: v{})", current);
+
+        let latest = match fetch_latest_version() {
+            Some(v) => v,
+            None => {
+                crate::app_log!("[updater] could not fetch latest version, skipping");
+                return;
+            }
+        };
+
+        crate::app_log!("[updater] latest release: v{}", latest);
+
+        if !is_newer(&latest, current) {
+            crate::app_log!("[updater] already up to date");
+            return;
+        }
+
+        // Check if user previously skipped this version
+        let app_data_dir = match app_handle.path().app_data_dir() {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+        let store_path = app_data_dir.join("settings.json");
+        if let Ok(content) = std::fs::read_to_string(&store_path) {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(skipped) = json.get("skippedVersion").and_then(|v| v.as_str()) {
+                    if skipped == latest {
+                        crate::app_log!("[updater] v{} was skipped by user", latest);
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Emit update-available event to frontend
+        let _ = app_handle.emit("update-available", serde_json::json!({
+            "latest": latest,
+            "current": current,
+        }));
+        crate::app_log!("[updater] emitted update-available event");
+    });
+}
+
+fn fetch_latest_version() -> Option<String> {
+    let mut response = ureq::get(GITHUB_RELEASES_URL)
+        .header("User-Agent", "ani-mime-updater")
+        .call()
+        .ok()?;
+
+    let json: serde_json::Value = response.body_mut().read_json().ok()?;
+    let tag = json.get("tag_name")?.as_str()?;
+
+    // Strip leading 'v' if present
+    Some(tag.trim_start_matches('v').to_string())
+}
+
+fn is_newer(latest: &str, current: &str) -> bool {
+    let parse = |v: &str| -> Vec<u32> {
+        v.split('.')
+            .filter_map(|s| s.parse().ok())
+            .collect()
+    };
+    let l = parse(latest);
+    let c = parse(current);
+    l > c
+}
+
+#[tauri::command]
+pub fn update_now() {
+    crate::app_log!("[updater] user chose: Update");
+    let script = r#"tell application "Terminal"
+    activate
+    do script "brew upgrade --cask ani-mime"
+end tell"#;
+    let _ = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .spawn();
+}
+
+#[tauri::command]
+pub fn skip_version(version: String, app_handle: tauri::AppHandle) {
+    crate::app_log!("[updater] user chose: Skip v{}", version);
+    if let Ok(app_data_dir) = app_handle.path().app_data_dir() {
+        save_skipped_version(&app_data_dir.join("settings.json"), &version);
+    }
+}
+
+fn save_skipped_version(store_path: &std::path::Path, version: &str) {
+    let mut json: serde_json::Value = if store_path.exists() {
+        std::fs::read_to_string(store_path)
+            .ok()
+            .and_then(|c| serde_json::from_str(&c).ok())
+            .unwrap_or(serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    json["skippedVersion"] = serde_json::Value::String(version.to_string());
+
+    if let Ok(s) = serde_json::to_string_pretty(&json) {
+        let _ = std::fs::write(store_path, s);
+        crate::app_log!("[updater] saved skipped version: v{}", version);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { Mascot } from "./components/Mascot";
 import { StatusPill } from "./components/StatusPill";
 import { SpeechBubble } from "./components/SpeechBubble";
+import { UpdateBanner } from "./components/UpdateBanner";
 import { VisitorDog } from "./components/VisitorDog";
 import { DevTag } from "./components/DevTag";
 import { useStatus } from "./hooks/useStatus";
 import { useDrag } from "./hooks/useDrag";
 import { useTheme } from "./hooks/useTheme";
 import { useBubble } from "./hooks/useBubble";
+import { useUpdate } from "./hooks/useUpdate";
 import { useVisitors } from "./hooks/useVisitors";
 import { usePeers } from "./hooks/usePeers";
 import { useNickname } from "./hooks/useNickname";
@@ -25,8 +27,11 @@ function App() {
   const peers = usePeers();
   const { nickname } = useNickname();
   const { pet } = usePet();
+  const { update, dismiss: dismissUpdate } = useUpdate();
   const devMode = useDevMode();
   useTheme();
+
+  const showUpdate = update && status !== "busy" && status !== "service";
 
   const onContextMenu = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -75,7 +80,14 @@ function App() {
       onContextMenu={onContextMenu}
     >
       {scenario && <div className="scenario-badge">SCENARIO</div>}
-      <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
+      {showUpdate && (
+        <UpdateBanner
+          latest={update.latest}
+          current={update.current}
+          onDismiss={dismissUpdate}
+        />
+      )}
+      <SpeechBubble visible={visible && !showUpdate} message={message} onDismiss={dismiss} />
       {status !== "visiting" && <Mascot status={status} />}
       {status === "visiting" && <div style={{ width: 128, height: 128 }} />}
       <StatusPill status={status} glow={visible} />

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import "../styles/update-banner.css";
+
+interface UpdateBannerProps {
+  latest: string;
+  current: string;
+  onDismiss: () => void;
+}
+
+export function UpdateBanner({ latest, current, onDismiss }: UpdateBannerProps) {
+  const handleUpdate = async () => {
+    await invoke("update_now");
+    onDismiss();
+  };
+
+  const handleSkip = async () => {
+    await invoke("skip_version", { version: latest });
+    onDismiss();
+  };
+
+  return (
+    <div className="update-banner">
+      <div className="update-text">
+        v{latest} available
+      </div>
+      <div className="update-actions">
+        <button className="update-btn primary" onClick={handleUpdate}>Update</button>
+        <button className="update-btn" onClick={onDismiss}>Later</button>
+        <button className="update-btn" onClick={handleSkip}>Skip</button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useBubble.ts
+++ b/src/hooks/useBubble.ts
@@ -74,6 +74,19 @@ export function useBubble() {
     };
   }, [enabled]);
 
+  // Hide bubble when status changes to busy/service
+  useEffect(() => {
+    const unlisten = listen<string>("status-changed", (e) => {
+      if (e.payload === "busy" || e.payload === "service") {
+        clearTimeout(timerRef.current);
+        setVisible(false);
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   // Listen for task-completed events
   useEffect(() => {
     const unlisten = listen<TaskCompleted>("task-completed", () => {

--- a/src/hooks/useUpdate.ts
+++ b/src/hooks/useUpdate.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+interface UpdateInfo {
+  latest: string;
+  current: string;
+}
+
+export function useUpdate() {
+  const [update, setUpdate] = useState<UpdateInfo | null>(null);
+
+  useEffect(() => {
+    const unlisten = listen<UpdateInfo>("update-available", (event) => {
+      setUpdate(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const dismiss = () => setUpdate(null);
+
+  return { update, dismiss };
+}

--- a/src/styles/update-banner.css
+++ b/src/styles/update-banner.css
@@ -1,0 +1,48 @@
+.update-banner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(8px);
+  border-radius: 8px;
+  margin-bottom: 4px;
+}
+
+.update-text {
+  font-size: 10px;
+  font-weight: 600;
+  color: #fff;
+  opacity: 0.9;
+}
+
+.update-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.update-btn {
+  padding: 2px 8px;
+  font-size: 9px;
+  font-weight: 500;
+  font-family: inherit;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  transition: background 0.15s;
+}
+
+.update-btn:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.update-btn.primary {
+  background: #007aff;
+}
+
+.update-btn.primary:hover {
+  background: #0063d1;
+}


### PR DESCRIPTION
## Summary
- Add in-app update checker that fetches latest GitHub release on startup
- Show inline update banner (not blocking macOS dialog) with Update/Later/Skip buttons
- "Skip This Version" persists so it won't nag again until a newer release
- Auto-hide speech bubble when status changes to busy or service

## Test plan
- [ ] Set `Cargo.toml` version to `0.0.1`, run app — verify update banner appears above mascot
- [ ] Click "Update" — opens Terminal with `brew upgrade` command
- [ ] Click "Skip" — restart app, verify banner doesn't reappear
- [ ] Click "Later" — restart app, verify banner reappears
- [ ] Trigger "All finished!" bubble, then start a new task — verify bubble hides immediately
- [ ] Verify banner auto-hides when status goes to busy/service

🤖 Generated with [Claude Code](https://claude.com/claude-code)