### PR TITLE
Release v0.14.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.14.15] - 2026-04-08
+
+### Added
+- **In-app update checker**: Background check for new GitHub releases with dismissible update banner
+- **Auto-dismiss speech bubble**: Bubble hides automatically when status transitions to busy or service
+
+### Changed
+- Claude Code setup dialog only appears when CLI is installed — no more prompt when Claude is not found
+- Friendlier Claude Code setup dialog copy describing real-time mascot reactions
+
+### Fixed
+- Claude Code hooks no longer error when Ani-Mime is not running (silent fail with `--max-time 1`)
+
 ## [0.14.12] - 2026-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.14.12",
+  "version": "0.14.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.14.12"
+version = "0.14.15"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.14.12",
+  "version": "0.14.15",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Bump version to 0.14.15
- Add in-app update checker with dismissible banner
- Auto-dismiss speech bubble on busy/service status
- Simplify Claude Code setup dialog (skip when CLI not installed, friendlier copy)
- Fix Claude Code hooks error when Ani-Mime is not running

## Post-merge checklist
- [ ] Merge this PR
- [ ] Push tag: `git tag v0.14.15 && git push origin v0.14.15`
- [ ] CI builds release artifacts (arm64 + x64 DMGs)
- [ ] Update Homebrew cask with new version + SHA256 hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)