### PR TITLE
Fix unused variable in UpdateBanner causing CI failure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,6 @@ function App() {
       {showUpdate && (
         <UpdateBanner
           latest={update.latest}
-          current={update.current}
           onDismiss={dismissUpdate}
         />
       )}

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -3,11 +3,10 @@ import "../styles/update-banner.css";
 
 interface UpdateBannerProps {
   latest: string;
-  current: string;
   onDismiss: () => void;
 }
 
-export function UpdateBanner({ latest, current, onDismiss }: UpdateBannerProps) {
+export function UpdateBanner({ latest, onDismiss }: UpdateBannerProps) {
   const handleUpdate = async () => {
     await invoke("update_now");
     onDismiss();


### PR DESCRIPTION
## Summary
- Remove unused `current` prop from `UpdateBanner` component and call site in `App.tsx`
- Fixes `TS6133: 'current' is declared but its value is never read` that broke the v0.14.15 release build

## Post-merge
- Re-tag v0.14.15 and push to trigger release CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)