### PR TITLE
Release v0.14.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.14.16] - 2026-04-09
+
+### Added
+- **New contributor**: thanh-dong added to the About page
+
+### Fixed
+- Peer detection not working in release mode on macOS (added Info.plist with Bonjour networking entitlements)
+- Unused variable in UpdateBanner causing CI build failure
+- Version display in Settings now shows correct version
+
 ## [0.14.15] - 2026-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.14.15",
+  "version": "0.14.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.14.12"
+version = "0.14.15"
 dependencies = [
  "cocoa",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.14.15"
+version = "0.14.16"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.14.15",
+  "version": "0.14.16",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -202,7 +202,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.14.12{devMode && " (Dev Mode)"}
+                  Version 0.14.16{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>
@@ -234,6 +234,7 @@ export function Settings() {
                   {[
                     { login: "thnh-dng", avatar: "https://avatars.githubusercontent.com/u/213000297?v=4" },
                     { login: "yanmad27", avatar: "https://avatars.githubusercontent.com/u/38394675?v=4" },
+                    { login: "thanh-dong", avatar: "https://avatars.githubusercontent.com/u/15724923?v=4" },
                   ].map((c) => (
                     <a
                       key={c.login}


### PR DESCRIPTION
## Summary
- Add thanh-dong as contributor in Settings About page
- Bump version to 0.14.16 across all config files
- Fix version display in Settings (was stuck at 0.14.12)
- CHANGELOG: peer detection fix, UpdateBanner fix, new contributor

## Test plan
- [ ] Verify Settings > About shows thanh-dong in contributors
- [ ] Verify version shows 0.14.16 in Settings
- [ ] Build and run `bun run tauri dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)