### PR TITLE
Release v0.14.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.14.19] - 2026-04-10
+
+### Added
+- **Dialog Preview scenario**: New scenario in Superpower Tool to preview all native macOS dialogs and speech bubbles without side effects (update alerts, setup dialogs, bubbles)
+
+### Changed
+- **Native update dialog**: Replaced in-app update banner with native macOS alert dialog (Later / Changelog / Update Now)
+- **Check for Updates menu**: Added "Check for Updates..." item to the macOS menu bar for manual update checks
+
 ## [0.14.16] - 2026-04-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.14.16",
+  "version": "0.14.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.14.16"
+version = "0.14.19"
 dependencies = [
  "cocoa",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.14.16"
+version = "0.14.19"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.14.16",
+  "version": "0.14.19",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Replace in-app update banner with native macOS alert dialog (Later / Changelog / Update Now)
- Add "Check for Updates..." menu item to macOS menu bar
- Add Dialog Preview scenario to Superpower Tool for previewing all native dialogs and speech bubbles

## Changelog
See [CHANGELOG.md](./CHANGELOG.md) for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)