### PR TITLE
Fix hardcoded version in Settings screen

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -202,7 +202,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.14.16{devMode && " (Dev Mode)"}
+                  Version 0.14.19{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Fix version string in Settings > About showing 0.14.16 instead of 0.14.19

## Test plan
- Open Settings > About and verify version shows 0.14.19