### PR TITLE
Fix zsh job notifications from terminal-mirror hook

### DIFF
--- a/src-tauri/script/terminal-mirror.bash
+++ b/src-tauri/script/terminal-mirror.bash
@@ -34,11 +34,13 @@ _tm_heartbeat() {
 
 # Start heartbeat only once per shell session
 if [[ -z "$_TM_HEARTBEAT_PID" ]]; then
-  _tm_heartbeat &
+  { _tm_heartbeat & disown; } 2>/dev/null
   _TM_HEARTBEAT_PID=$!
-  disown $_TM_HEARTBEAT_PID 2>/dev/null
   trap "kill $_TM_HEARTBEAT_PID 2>/dev/null" EXIT
 fi
+
+# Helper: run a command in background without job notifications
+_tm_bg() { { "$@" & disown; } 2>/dev/null; }
 
 # --- Preexec via DEBUG trap ---
 _tm_preexec() {
@@ -55,13 +57,13 @@ _tm_preexec() {
   _tm_is_claude "$cmd" && return
 
   local cmd_type=$(_tm_classify "$cmd")
-  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=busy&type=${cmd_type}" > /dev/null 2>&1 &) 2>/dev/null
+  _tm_bg curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=busy&type=${cmd_type}" > /dev/null 2>&1
 }
 trap '_tm_preexec' DEBUG
 
 # --- Precmd via PROMPT_COMMAND ---
 _tm_precmd() {
   _TM_CMD_RUNNING=0
-  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=idle" > /dev/null 2>&1 &) 2>/dev/null
+  _tm_bg curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=idle" > /dev/null 2>&1
 }
 PROMPT_COMMAND="_tm_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"

--- a/src-tauri/script/terminal-mirror.zsh
+++ b/src-tauri/script/terminal-mirror.zsh
@@ -38,9 +38,8 @@ _tm_heartbeat() {
 
 # Start heartbeat only once per shell session
 if [[ -z "$_TM_HEARTBEAT_PID" ]]; then
-  _tm_heartbeat &
+  _tm_heartbeat &!
   _TM_HEARTBEAT_PID=$!
-  disown $_TM_HEARTBEAT_PID 2>/dev/null
   trap "kill $_TM_HEARTBEAT_PID 2>/dev/null" EXIT
 fi
 
@@ -49,11 +48,11 @@ _tm_preexec() {
   # Claude Code has its own hooks — skip entirely
   _tm_is_claude "$1" && return
   local cmd_type=$(_tm_classify "$1")
-  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=busy&type=${cmd_type}" > /dev/null 2>&1 &) 2>/dev/null
+  curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=busy&type=${cmd_type}" > /dev/null 2>&1 &!
 }
 
 _tm_precmd() {
-  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=idle" > /dev/null 2>&1 &) 2>/dev/null
+  curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=idle" > /dev/null 2>&1 &!
 }
 
 autoload -Uz add-zsh-hook

--- a/terminal-mirror.zsh
+++ b/terminal-mirror.zsh
@@ -38,9 +38,8 @@ _tm_heartbeat() {
 
 # Start heartbeat only once per shell session
 if [[ -z "$_TM_HEARTBEAT_PID" ]]; then
-  _tm_heartbeat &
+  _tm_heartbeat &!
   _TM_HEARTBEAT_PID=$!
-  disown $_TM_HEARTBEAT_PID 2>/dev/null
   trap "kill $_TM_HEARTBEAT_PID 2>/dev/null" EXIT
 fi
 
@@ -49,11 +48,11 @@ _tm_preexec() {
   # Claude Code has its own hooks — skip entirely
   _tm_is_claude "$1" && return
   local cmd_type=$(_tm_classify "$1")
-  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=busy&type=${cmd_type}" > /dev/null 2>&1 &) 2>/dev/null
+  curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=busy&type=${cmd_type}" > /dev/null 2>&1 &!
 }
 
 _tm_precmd() {
-  (curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=idle" > /dev/null 2>&1 &) 2>/dev/null
+  curl -s --max-time 1 "${_TM_URL}/status?pid=$$&state=idle" > /dev/null 2>&1 &!
 }
 
 autoload -Uz add-zsh-hook


### PR DESCRIPTION
## Summary
- Replace `(... &) 2>/dev/null` and `& ; disown` with zsh `&!` operator in terminal-mirror hook
- Fixes `[3] 19434` job control messages appearing on every new prompt
- Auto-patches for users on next app update (script is sourced from app bundle)

## Test plan
- [ ] Open a new terminal tab — no `[N] PID` messages should appear
- [ ] Run a few commands — no `[N]  + done` messages on prompt return
- [ ] Verify Ani-Mime still reacts to terminal activity (idle/busy transitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)