### PR TITLE
feat: bubble test scenario, dev tag toggle, and UI polish

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -74,7 +74,7 @@ name = "ani-mime"
 version = "0.14.19"
 dependencies = [
  "cocoa",
- "dirs",
+ "dirs 6.0.0",
  "hostname",
  "log",
  "mdns-sd",
@@ -83,6 +83,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
@@ -269,6 +270,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
 
 [[package]]
 name = "autocfg"
@@ -926,11 +938,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -941,7 +973,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1062,7 +1094,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3275,6 +3307,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4159,7 +4202,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4209,7 +4252,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4279,6 +4322,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4854,7 +4911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5819,6 +5876,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5931,7 +5997,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,12 @@ fn clear_logs() {
 }
 
 #[tauri::command]
+fn set_dev_mode(enabled: bool, app: tauri::AppHandle) {
+    crate::app_log!("[dev] dev-mode-changed -> {}", enabled);
+    let _ = app.emit("dev-mode-changed", enabled);
+}
+
+#[tauri::command]
 fn scenario_override(status: Option<String>, app: tauri::AppHandle) {
     match &status {
         Some(s) => {
@@ -134,6 +140,12 @@ fn preview_dialog(dialog_id: String, app: tauri::AppHandle) {
             }
             "bubble_discovery_hint" => {
                 let _ = app.emit("discovery-hint", "no_peers");
+            }
+
+            // --- Persistent bubbles for scenario testing (no auto-hide) ---
+            id if id.starts_with("bubble_persist:") => {
+                let message = id.strip_prefix("bubble_persist:").unwrap_or("Hello!");
+                let _ = app.emit("bubble-preview", message);
             }
 
             _ => {
@@ -289,7 +301,7 @@ pub fn run() {
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_superpower, scenario_override, preview_dialog])
+        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_superpower, set_dev_mode, scenario_override, preview_dialog])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
       {status !== "visiting" && <Mascot status={status} />}
       {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
       <StatusPill status={status} glow={visible} />
-      {devMode && !scenario && <DevTag />}
+      {devMode && <DevTag />}
       {visitors.map((v, i) => (
         <VisitorDog key={v.nickname} pet={v.pet} nickname={v.nickname} index={i} />
       ))}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -138,14 +138,14 @@ export function Settings() {
   }, []);
 
   const handleVersionClick = async () => {
-    if (devMode) return;
-
     clickCountRef.current += 1;
     clearTimeout(clickTimerRef.current);
 
     if (clickCountRef.current >= 10) {
       clickCountRef.current = 0;
-      setDevMode(true);
+      if (!devMode) {
+        setDevMode(true);
+      }
       await emit("dev-mode-changed", true);
     } else {
       clickTimerRef.current = setTimeout(() => {
@@ -654,6 +654,7 @@ export function Settings() {
                     { login: "thnh-dng", avatar: "https://avatars.githubusercontent.com/u/213000297?v=4" },
                     { login: "yanmad27", avatar: "https://avatars.githubusercontent.com/u/38394675?v=4" },
                     { login: "thanh-dong", avatar: "https://avatars.githubusercontent.com/u/15724923?v=4" },
+                    { login: "setnsail", avatar: "https://avatars.githubusercontent.com/u/213003653?v=4" },
                   ].map((c) => (
                     <a
                       key={c.login}

--- a/src/components/SuperpowerTool.tsx
+++ b/src/components/SuperpowerTool.tsx
@@ -162,7 +162,14 @@ function LogViewer() {
 
 export function SuperpowerTool() {
   const [activeMenu, setActiveMenu] = useState<MenuItem>("logs");
+  const [devTagVisible, setDevTagVisible] = useState(true);
   useTheme();
+
+  const handleDevTagToggle = () => {
+    const next = !devTagVisible;
+    setDevTagVisible(next);
+    invoke("set_dev_mode", { enabled: next });
+  };
 
   return (
     <div className="superpower">
@@ -184,6 +191,19 @@ export function SuperpowerTool() {
         </button>
       </nav>
       <main className="superpower-content">
+        <div className="superpower-toolbar">
+          <div className="superpower-toolbar-item">
+            <span className="superpower-toolbar-label">DEV Tag</span>
+            <button
+              className={`toggle-switch ${devTagVisible ? "active" : ""}`}
+              onClick={handleDevTagToggle}
+              data-testid="dev-tag-toggle"
+              aria-label="Toggle DEV tag visibility"
+            >
+              <span className="toggle-knob" />
+            </button>
+          </div>
+        </div>
         {activeMenu === "logs" && <LogViewer />}
         {activeMenu === "scenarios" && <ScenarioViewer />}
       </main>

--- a/src/components/scenarios/PetStatusScenario.tsx
+++ b/src/components/scenarios/PetStatusScenario.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { Status } from "../../types/status";
 
-const statuses: { status: Status; label: string; desc: string; color: string }[] = [
+const statuses: { status: Status; label: string; desc: string; color: string; bubble?: string }[] = [
   { status: "idle", label: "Free", desc: "No active tasks", color: "#34c759" },
   { status: "busy", label: "Working", desc: "Running a command", color: "#ff3b30" },
   { status: "service", label: "Service", desc: "Brief service event", color: "#5e5ce6" },
@@ -10,14 +10,19 @@ const statuses: { status: Status; label: string; desc: string; color: string }[]
   { status: "initializing", label: "Initializing", desc: "App starting up", color: "#ff9f0a" },
   { status: "searching", label: "Searching", desc: "Looking for shell sessions", color: "#ffcc00" },
   { status: "visiting", label: "Visiting", desc: "Dog visiting a peer", color: "#af52de" },
+  { status: "idle", label: "Free + Bubble", desc: "Idle with short bubble", color: "#30d158", bubble: "Task complete!" },
+  { status: "idle", label: "Long Bubble", desc: "Test long text overflow", color: "#30d158", bubble: "Hey! Your build finished successfully after 42 seconds. Everything looks good!" },
 ];
 
 export function PetStatusScenario() {
-  const [active, setActive] = useState<Status | null>(null);
+  const [active, setActive] = useState<string | null>(null);
 
-  const handleClick = (status: Status) => {
-    setActive(status);
+  const handleClick = (label: string, status: Status, bubble?: string) => {
+    setActive(label);
     invoke("scenario_override", { status });
+    if (bubble) {
+      invoke("preview_dialog", { dialogId: `bubble_persist:${bubble}` });
+    }
   };
 
   return (
@@ -26,11 +31,11 @@ export function PetStatusScenario() {
         Click a status to preview it on the mascot in real-time.
       </div>
       <div className="scenario-status-grid">
-        {statuses.map(({ status, label, desc, color }) => (
+        {statuses.map(({ status, label, desc, color, bubble }) => (
           <button
-            key={status}
-            className={`scenario-status-btn ${active === status ? "active" : ""}`}
-            onClick={() => handleClick(status)}
+            key={label}
+            className={`scenario-status-btn ${active === label ? "active" : ""}`}
+            onClick={() => handleClick(label, status, bubble)}
           >
             <div className="scenario-status-title">
               <span className="scenario-status-dot" style={{ background: color }} />

--- a/src/hooks/useBubble.ts
+++ b/src/hooks/useBubble.ts
@@ -126,6 +126,18 @@ export function useBubble() {
     };
   }, []);
 
+  // Listen for bubble-preview: persistent bubble from scenario (no auto-hide, dismiss manually)
+  useEffect(() => {
+    const unlisten = listen<string>("bubble-preview", (e) => {
+      clearTimeout(timerRef.current);
+      setMessage(e.payload);
+      setVisible(true);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   const dismiss = useCallback(() => {
     clearTimeout(timerRef.current);
     setVisible(false);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -30,6 +30,7 @@ body {
   -webkit-user-select: none;
   position: relative;
   padding-left: 20px;
+  padding-bottom: 6px;
 }
 
 .container.dragging {

--- a/src/styles/superpower.css
+++ b/src/styles/superpower.css
@@ -72,6 +72,60 @@
   overflow: hidden;
 }
 
+/* Toolbar */
+.superpower-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 16px;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.15);
+  flex-shrink: 0;
+}
+
+.superpower-toolbar-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.superpower-toolbar-label {
+  font-size: 11px;
+  font-weight: 500;
+  opacity: 0.6;
+}
+
+.superpower-toolbar .toggle-switch {
+  position: relative;
+  width: 32px;
+  height: 18px;
+  border-radius: 9px;
+  border: none;
+  background: rgba(128, 128, 128, 0.3);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s;
+}
+
+.superpower-toolbar .toggle-switch.active {
+  background: #34c759;
+}
+
+.superpower-toolbar .toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s;
+}
+
+.superpower-toolbar .toggle-switch.active .toggle-knob {
+  transform: translateX(14px);
+}
+
 /* Log viewer */
 .log-viewer {
   display: flex;
@@ -507,4 +561,102 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 8px;
+}
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.bubble-test-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bubble-test-label {
+  font-size: 12px;
+  opacity: 0.6;
+}
+
+.bubble-test-interval {
+  display: flex;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+}
+
+.bubble-test-interval-btn {
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  opacity: 0.5;
+  font-family: inherit;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.bubble-test-interval-btn.active {
+  opacity: 1;
+  background: rgba(128, 128, 128, 0.2);
+}
+
+.bubble-test-interval-btn:disabled {
+  cursor: not-allowed;
+}
+
+.bubble-test-toggle {
+  padding: 6px 18px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  background: #34c759;
+  color: #fff;
+  transition: background 0.15s;
+}
+
+.bubble-test-toggle:hover {
+  background: #2da44e;
+}
+
+.bubble-test-toggle.running {
+  background: #ff3b30;
+}
+
+.bubble-test-toggle.running:hover {
+  background: #d32f2f;
+}
+
+.bubble-test-current {
+  padding: 10px 12px;
+  background: rgba(128, 128, 128, 0.08);
+  border: 1px solid rgba(128, 128, 128, 0.12);
+  border-radius: 8px;
+}
+
+.bubble-test-current-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.4;
+  margin-bottom: 4px;
+}
+
+.bubble-test-current-status {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: capitalize;
+  margin-bottom: 2px;
+}
+
+.bubble-test-current-msg {
+  font-size: 11px;
+  opacity: 0.6;
 }


### PR DESCRIPTION
## Summary

- **Bubble test in scenarios** — "Free + Bubble" and "Long Bubble" entries in Pet Status scenario with persistent bubbles (no auto-hide, click to dismiss)
- **DEV Tag toggle** — toggle in Superpower toolbar to show/hide the DEV tag on the mascot without leaving dev mode
- **Dev tag re-show** — 10-click version in Settings re-shows the DEV tag if it was hidden via the toggle
- **DevTag in scenario mode** — DEV tag no longer hides when a scenario is active
- **Shadow fix** — bottom padding on container prevents status pill glow from being clipped by window auto-resize
- **New contributor** — added setnsail to the Settings about page

## Test plan

- [ ] Enable dev mode (10-click version in Settings) → DEV tag appears
- [ ] Open Superpower → toggle DEV Tag off → tag hides on mascot
- [ ] Toggle DEV Tag back on → tag reappears
- [ ] 10-click version again while tag is hidden → tag reappears
- [ ] Scenarios → Pet Status → click "Free + Bubble" → bubble stays visible until clicked
- [ ] Click "Long Bubble" → long text bubble stays visible
- [ ] Check status pill glow is not clipped at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)