### PR TITLE
feat: .animime export/import for custom mime sharing

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "autostart:allow-is-enabled",
     "dialog:default",
     "dialog:allow-open",
+    "dialog:allow-save",
     "fs:default",
     "fs:allow-appdata-read-recursive",
     "fs:allow-appdata-write-recursive",
@@ -29,6 +30,7 @@
     "fs:allow-copy-file",
     "fs:allow-remove",
     "fs:read-all",
+    "fs:write-all",
     "fs:scope-appdata-recursive",
     "log:default",
     "core:path:default"

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -73,7 +73,7 @@ export function Settings() {
   const { enabled: autoStartEnabled, setEnabled: setAutoStartEnabled } = useAutoStart();
   const { enabled: autoUpdateEnabled, setEnabled: setAutoUpdateEnabled } = useAutoUpdate();
   const { scale, setScale, SCALE_PRESETS } = useScale();
-  const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, deleteMime } = useCustomMimes();
+  const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, deleteMime, exportMime, importMime } = useCustomMimes();
   const [tab, setTab] = useState<Tab>("general");
   const [creating, setCreating] = useState<false | "manual" | "smart">(false);
   const [editingMime, setEditingMime] = useState<string | null>(null);
@@ -586,6 +586,15 @@ export function Settings() {
                             &#9998;
                           </button>
                           <button
+                            className="export-mime-btn"
+                            onClick={(e) => { e.stopPropagation(); exportMime(m.id); }}
+                            title="Export"
+                            data-testid={`export-mime-${m.id}`}
+                            aria-label="Export mime"
+                          >
+                            &#8599;
+                          </button>
+                          <button
                             className="delete-mime-btn"
                             onClick={(e) => { e.stopPropagation(); handleDeleteCustom(m.id); }}
                             title="Delete"
@@ -603,7 +612,22 @@ export function Settings() {
                     </button>
                     <button className="pet-card add-card" onClick={() => setCreating("smart")}>
                       <div className="add-icon">*</div>
-                      <span className="pet-name">Import</span>
+                      <span className="pet-name">Import Sheet</span>
+                    </button>
+                    <button
+                      className="pet-card add-card"
+                      data-testid="import-animime-btn"
+                      onClick={async () => {
+                        try {
+                          const id = await importMime();
+                          if (id) setPet(id);
+                        } catch (err) {
+                          logError(`[settings] import failed: ${err instanceof Error ? err.message : err}`);
+                        }
+                      }}
+                    >
+                      <div className="add-icon">&#8598;</div>
+                      <span className="pet-name">Animime</span>
                     </button>
                   </div>
                 </>

--- a/src/hooks/useCustomMimes.ts
+++ b/src/hooks/useCustomMimes.ts
@@ -1,8 +1,8 @@
 import { useState, useLayoutEffect, useCallback } from "react";
 import { load } from "@tauri-apps/plugin-store";
 import { emit, listen } from "@tauri-apps/api/event";
-import { open } from "@tauri-apps/plugin-dialog";
-import { copyFile, mkdir, exists, remove, writeFile } from "@tauri-apps/plugin-fs";
+import { open, save } from "@tauri-apps/plugin-dialog";
+import { copyFile, mkdir, exists, remove, writeFile, readFile } from "@tauri-apps/plugin-fs";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { info } from "@tauri-apps/plugin-log";
@@ -196,6 +196,82 @@ export function useCustomMimes() {
     [mimes, saveMimes, ensureSpritesDir]
   );
 
+  const exportMime = useCallback(async (id: string) => {
+    const mime = mimes.find((m) => m.id === id);
+    if (!mime) return;
+
+    const dir = await ensureSpritesDir();
+    const sprites: Record<string, { frames: number; data: string }> = {};
+
+    for (const status of ALL_STATUSES) {
+      const { fileName, frames } = mime.sprites[status];
+      const bytes = await readFile(`${dir}/${fileName}`);
+      const binary = Array.from(bytes).map((b) => String.fromCharCode(b)).join("");
+      sprites[status] = { frames, data: btoa(binary) };
+    }
+
+    const payload = JSON.stringify({ version: 1, name: mime.name, sprites }, null, 2);
+    const date = new Date().toISOString().slice(0, 10);
+    const safeName = mime.name.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const defaultName = `animime-${safeName}-${date}`;
+
+    const dest = await save({
+      defaultPath: defaultName,
+      filters: [{ name: "Ani-Mime Export", extensions: ["animime"] }],
+    });
+    if (!dest) return;
+
+    const path = dest.endsWith(".animime") ? dest : `${dest}.animime`;
+    const encoder = new TextEncoder();
+    await writeFile(path, encoder.encode(payload));
+    info(`[custom-mimes] exported "${mime.name}" to ${path}`);
+  }, [mimes, ensureSpritesDir]);
+
+  const importMime = useCallback(async (): Promise<string | null> => {
+    const result = await open({
+      multiple: false,
+      filters: [{ name: "Ani-Mime Export", extensions: ["animime"] }],
+    });
+    if (!result) return null;
+
+    const bytes = await readFile(result);
+    const decoder = new TextDecoder();
+    const payload = JSON.parse(decoder.decode(bytes));
+
+    if (payload.version !== 1 || !payload.name || !payload.sprites) {
+      throw new Error("Invalid .animime file");
+    }
+
+    const id = `custom-${Date.now()}`;
+    info(`[custom-mimes] importMime: name="${payload.name}", id=${id}`);
+    const dir = await ensureSpritesDir();
+
+    const sprites: Record<string, { fileName: string; frames: number }> = {};
+    for (const status of ALL_STATUSES) {
+      const entry = payload.sprites[status];
+      if (!entry || !entry.data) {
+        throw new Error(`Missing sprite data for "${status}"`);
+      }
+      const binary = atob(entry.data);
+      const blob = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) blob[i] = binary.charCodeAt(i);
+
+      const fileName = `${id}-${status}.png`;
+      await writeFile(`${dir}/${fileName}`, blob);
+      sprites[status] = { fileName, frames: entry.frames };
+    }
+
+    const newMime: CustomMimeData = {
+      id,
+      name: payload.name,
+      sprites: sprites as Record<Status, { fileName: string; frames: number }>,
+    };
+
+    await saveMimes([...mimes, newMime]);
+    info(`[custom-mimes] imported "${payload.name}" as ${id}`);
+    return id;
+  }, [mimes, saveMimes, ensureSpritesDir]);
+
   const getSpriteUrl = useCallback(
     async (fileName: string): Promise<string> => {
       const base = await appDataDir();
@@ -205,5 +281,5 @@ export function useCustomMimes() {
     []
   );
 
-  return { mimes, loaded, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, deleteMime, getSpriteUrl };
+  return { mimes, loaded, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, deleteMime, exportMime, importMime, getSpriteUrl };
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -590,8 +590,29 @@
   font-family: inherit;
 }
 
+.export-mime-btn {
+  position: absolute;
+  bottom: -4px;
+  left: -4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: #34c759;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font-family: inherit;
+}
+
 .pet-card-wrapper:hover .edit-mime-btn,
-.pet-card-wrapper:hover .delete-mime-btn {
+.pet-card-wrapper:hover .delete-mime-btn,
+.pet-card-wrapper:hover .export-mime-btn {
   display: flex;
 }
 


### PR DESCRIPTION
## Summary

- **Export** — hover any custom mime card → green export button → save dialog → writes `.animime` file with all 7 sprite PNGs embedded as base64
- **Import** — new "Animime" button in Create Your Own → open dialog → picks `.animime` file → decodes sprites → saves to disk → adds to registry
- **File format** — `animime-{name}-{date}.animime` — self-contained JSON, single file, easy to share

## Test plan

- [ ] Create a custom mime → hover card → click export (green ↗) → save to Desktop
- [ ] Verify file is named `animime-{name}-{date}.animime`
- [ ] Delete the custom mime → click "Animime" import button → pick the exported file
- [ ] Verify mime is restored with correct name and all sprite animations
- [ ] Try importing an invalid file → verify it fails gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)