### PR TITLE
fix: peer discovery broken in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,7 @@ jobs:
           releaseDraft: false
           prerelease: false
           args: --target ${{ matrix.target }}
+
+      - name: Re-sign with entitlements (ad-hoc builds)
+        if: ${{ !env.APPLE_SIGNING_IDENTITY }}
+        run: bash src-tauri/script/post-build-sign.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.15.1] - 2026-04-12
+
+### Fixed
+- **Peer discovery broken in release builds** — added macOS entitlements (`Entitlements.plist`) for network access; Tauri's ad-hoc signing doesn't embed entitlements, so a post-build re-sign step is now required
+- **Visitor collision when peers share a nickname** — visitors are now keyed by `instance_name` (unique per process) instead of `nickname`
+- **Silent discovery failure** — mDNS daemon, registration, and browse errors now emit a `discovery-error` event to the frontend instead of failing silently
+
+### Added
+- `src-tauri/Entitlements.plist` — macOS Hardened Runtime entitlements for network client/server, JIT, and library validation
+- `bundle.macOS` config in `tauri.conf.json` — explicit entitlements and Info.plist references
+- `src-tauri/script/post-build-sign.sh` — re-signs the .app with entitlements and re-creates the DMG after `tauri build`
+- `src-tauri/script/install-mac.sh` — installer script for users receiving the app without notarization (removes quarantine)
+- Peer visit troubleshooting section in README
+
+### Changed
+- Visit protocol now includes `instance_name` field in `/visit` and `/visit-end` request bodies (backward-compatible: falls back to `nickname` for older peers)
+- `VisitingDog` struct has new `instance_name` field
+- `visitor-arrived` and `visitor-left` events include `instance_name`
+- Release workflow updated with post-build entitlement signing step
+
 ## [0.15.0] - 2026-04-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,11 @@ A floating macOS desktop mascot (pixel dog) that reacts to terminal and Claude C
 ## Quick Reference
 
 - **Dev**: `bun run tauri dev`
-- **Build**: `bun run tauri build`
+- **Build**: `bun run tauri build && bash src-tauri/script/post-build-sign.sh`
 - **Type check frontend**: `npx tsc --noEmit`
 - **Type check backend**: `cd src-tauri && cargo check`
 - **Package manager**: Bun (not npm/yarn)
+- **Entitlements**: `src-tauri/Entitlements.plist` (network + Hardened Runtime); post-build re-sign is required for ad-hoc builds
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ It also integrates with **Claude Code** — the dog knows when Claude is thinkin
 - **Custom Sprites** — upload your own PNG sprite sheets via manual import or smart extraction with chroma-key background removal
 - **Frame Range Expressions** — specify frames as ranges like `1-5` or `41-55,57,58` when importing custom sprites
 - **Display Scale** — resize your mascot with Tiny / Normal / Large / XL presets
+- **Peer Visits** — discover other Ani-Mime users on your local network via Bonjour/mDNS; right-click to send your pet to visit theirs
 - **Manual Tagging** — zsh hooks classify commands as `task` or `service`
 - **Heartbeat Architecture** — no process tree scanning, no time-based guessing
 - **Claude Code Hooks** — tracks when Claude is actively working vs waiting
@@ -116,6 +117,55 @@ npx playwright test --config=e2e/playwright.config.ts
 ```
 
 The e2e suite covers app startup, status transitions, speech bubbles, scenario mode, settings, custom sprite upload (including frame range expressions), sprite display sizing, and custom sprite editing.
+
+---
+
+## Peer Visits
+
+Ani-Mime instances on the same local network automatically discover each other via mDNS (Bonjour). Right-click your mascot to see nearby peers and send your pet to visit them.
+
+### Requirements
+
+- Both machines on the **same WiFi / LAN subnet**
+- **macOS Local Network permission** — allow when prompted on first launch (or enable in System Settings > Privacy & Security > Local Network)
+
+### Troubleshooting
+
+If peers can't find each other:
+
+1. Check that both machines are on the same network (`192.168.x.x` subnet)
+2. Verify Local Network permission is enabled for ani-mime on both machines
+3. Run `dns-sd -B _ani-mime._tcp local.` in Terminal — you should see both instances
+4. Run `curl http://127.0.0.1:1234/debug` to check the registered IP and peer list
+5. If sharing the app via DMG without a Developer ID, the recipient must run:
+   ```bash
+   xattr -cr /Applications/ani-mime.app
+   ```
+
+See [docs/peer-discovery.md](docs/peer-discovery.md) for the full protocol reference.
+
+---
+
+## Building for Release
+
+```bash
+# Build the Tauri app
+bun run tauri build
+
+# Re-sign with entitlements and re-create the DMG
+# (required because Tauri doesn't embed entitlements for ad-hoc signing)
+bash src-tauri/script/post-build-sign.sh
+```
+
+The signed DMG is output to `src-tauri/target/release/bundle/dmg/`.
+
+**Without the post-build sign step**, the app will run on the build machine but peer discovery (mDNS) and the HTTP server will silently fail on other machines due to missing network entitlements.
+
+If the recipient sees "app is damaged", they need to remove the quarantine attribute:
+
+```bash
+xattr -cr /Applications/ani-mime.app
+```
 
 ---
 

--- a/docs/events-reference.md
+++ b/docs/events-reference.md
@@ -25,14 +25,15 @@ User interaction → invoke() command → Rust handler → app.emit() → React 
 |-------|---------|--------|----------|
 | `peers-changed` | `Vec<PeerInfo>` | `discovery.rs` (resolve/remove) | `usePeers` |
 | `discovery-hint` | `string` ("no_peers") | `discovery.rs` (30s heartbeat) | `useBubble` |
+| `discovery-error` | `string` (error message) | `discovery.rs` (daemon/register/browse failure) | — |
 
 ### Visiting
 
 | Event | Payload | Source | Listener |
 |-------|---------|--------|----------|
 | `dog-away` | `bool` | `start_visit` command / visit thread | `useStatus` |
-| `visitor-arrived` | `{ pet, nickname, duration_secs }` | `/visit` route | `useVisitors` |
-| `visitor-left` | `{ nickname }` | `/visit-end` route / watchdog | `useVisitors` |
+| `visitor-arrived` | `{ instance_name, pet, nickname, duration_secs }` | `/visit` route | `useVisitors` |
+| `visitor-left` | `{ instance_name, nickname }` | `/visit-end` route / watchdog | `useVisitors` |
 
 ### Dev/Testing
 

--- a/docs/peer-discovery.md
+++ b/docs/peer-discovery.md
@@ -68,7 +68,7 @@ A background thread checks every 30 seconds. If no peers are found after the fir
    - Sets `AppState.visiting = Some(peer_id)`
    - Sends `POST /visit` to peer's HTTP server with JSON body:
      ```json
-     { "pet": "rottweiler", "nickname": "Alice", "duration_secs": 15 }
+     { "instance_name": "Alice-12345", "pet": "rottweiler", "nickname": "Alice", "duration_secs": 15 }
      ```
    - Emits `dog-away: true` (hides local mascot)
    - Spawns thread: sleeps for `VISIT_DURATION_SECS` (15s)
@@ -76,7 +76,7 @@ A background thread checks every 30 seconds. If no peers are found after the fir
 ### Receiving a Visit
 
 1. `/visit` route receives POST with visitor info
-2. Creates `VisitingDog { pet, nickname, arrived_at, duration_secs }`
+2. Creates `VisitingDog { instance_name, pet, nickname, arrived_at, duration_secs }`
 3. Adds to `AppState.visitors`
 4. Emits `visitor-arrived` event → frontend shows visitor sprite
 
@@ -84,12 +84,12 @@ A background thread checks every 30 seconds. If no peers are found after the fir
 
 After the visit duration:
 1. Spawned thread wakes up
-2. Sends `POST /visit-end` to peer with `{ "nickname": "Alice" }`
+2. Sends `POST /visit-end` to peer with `{ "instance_name": "Alice-12345", "nickname": "Alice" }`
 3. Clears `AppState.visiting`
 4. Emits `dog-away: false` (shows local mascot again)
 
 Peer side:
-1. `/visit-end` removes visitor by nickname
+1. `/visit-end` removes visitor by `instance_name` (falls back to `nickname` for older peers)
 2. Emits `visitor-left` event → frontend removes visitor sprite
 
 ### Visit Expiration
@@ -126,23 +126,50 @@ When the local dog is visiting someone:
 
 ## macOS Permissions
 
-Peer discovery requires Bonjour entitlements for release builds:
+Peer discovery requires entitlements for release builds. These are defined in `src-tauri/Entitlements.plist`:
 
-```xml
-<!-- In entitlements -->
-<key>com.apple.security.network.client</key>
-<true/>
-<key>com.apple.security.network.server</key>
-<true/>
+| Entitlement | Purpose |
+|-------------|---------|
+| `com.apple.security.cs.allow-jit` | WebView JIT under Hardened Runtime |
+| `com.apple.security.cs.disable-library-validation` | Required by `macOSPrivateApi` (window transparency) |
+| `com.apple.security.network.server` | mDNS multicast sockets + HTTP server on :1234 |
+| `com.apple.security.network.client` | Outgoing HTTP (visit requests) + UDP (IP detection) |
+
+Additionally, `src-tauri/Info.plist` declares:
+- `NSBonjourServices`: `_ani-mime._tcp` — triggers the macOS Local Network permission dialog
+- `NSLocalNetworkUsageDescription` — explains why the app needs network access
+
+**Important**: Tauri does not embed entitlements for ad-hoc (no Developer ID) builds. The post-build script `src-tauri/script/post-build-sign.sh` re-signs the app with entitlements and re-creates the DMG. See the release build section in the README.
+
+## Troubleshooting
+
+### Peers not finding each other
+
+1. **Both machines must be on the same WiFi/LAN subnet** — mDNS doesn't cross subnets
+2. **macOS Local Network permission** — on first launch, macOS asks to allow local network access. If denied, go to **System Settings > Privacy & Security > Local Network** and enable ani-mime
+3. **Verify registration** — run in Terminal: `dns-sd -B _ani-mime._tcp local.` — you should see your instance name within seconds
+4. **Check debug endpoint** — run `curl http://127.0.0.1:1234/debug` to see registered IP and discovered peers
+5. **Entitlements missing** — if shared via DMG without the post-build sign step, mDNS silently fails. Re-build with `bun run tauri build && bash src-tauri/script/post-build-sign.sh`
+6. **Quarantine attribute** — apps transferred between Macs get quarantined. Run `xattr -cr /Applications/ani-mime.app` on the receiving machine
+
+### Verify mDNS is working
+
+```bash
+# See all ani-mime instances on the network
+dns-sd -B _ani-mime._tcp local.
+
+# See details of a specific instance
+dns-sd -L "InstanceName" "_ani-mime._tcp" "local."
+
+# Test with a fake peer (appears in context menu)
+dns-sd -R "TestBuddy-9999" "_ani-mime._tcp" "local." 1235 nickname=Buddy pet=dalmatian
 ```
-
-Without these, mDNS registration silently fails in sandboxed builds.
 
 ## Limitations
 
-- **LAN only** - mDNS doesn't cross subnet boundaries (no WAN discovery)
-- **No authentication** - any Ani-Mime instance on the network can visit
-- **No rejection** - visits are automatically accepted
-- **No encryption** - HTTP traffic is plaintext
-- **Single visit** - can only visit one peer at a time
-- **Fixed duration** - visits last exactly 15 seconds, not configurable by user
+- **LAN only** — mDNS doesn't cross subnet boundaries (no WAN discovery)
+- **No authentication** — any Ani-Mime instance on the network can visit
+- **No rejection** — visits are automatically accepted
+- **No encryption** — HTTP traffic is plaintext
+- **Single visit** — can only visit one peer at a time
+- **Fixed duration** — visits last exactly 15 seconds, not configurable by user

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.14.19"
+version = "0.15.0"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Hardened Runtime: allow JIT for WebView -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <!-- Hardened Runtime: required by macOSPrivateApi (Cocoa private frameworks) -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <!-- Network: mDNS multicast + HTTP server on :1234 -->
+  <key>com.apple.security.network.server</key>
+  <true/>
+  <!-- Network: outgoing HTTP (ureq visit requests) + UDP (IP detection) -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/script/install-mac.sh
+++ b/src-tauri/script/install-mac.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Ani-Mime installer — removes quarantine and copies to /Applications
+set -e
+
+APP_NAME="ani-mime.app"
+DEST="/Applications/$APP_NAME"
+
+# Find the .app relative to this script (inside the DMG)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE="$SCRIPT_DIR/$APP_NAME"
+
+if [ ! -d "$SOURCE" ]; then
+  # Fallback: look in the DMG mount root
+  SOURCE="/Volumes/ani-mime/$APP_NAME"
+fi
+
+if [ ! -d "$SOURCE" ]; then
+  echo "Error: Cannot find $APP_NAME"
+  exit 1
+fi
+
+echo "Installing Ani-Mime..."
+
+# Remove quarantine attribute (prevents 'damaged' error)
+xattr -cr "$SOURCE" 2>/dev/null || true
+
+# Copy to /Applications (overwrite if exists)
+if [ -d "$DEST" ]; then
+  echo "Removing previous version..."
+  rm -rf "$DEST"
+fi
+
+cp -R "$SOURCE" "$DEST"
+xattr -cr "$DEST" 2>/dev/null || true
+
+echo "Installed to $DEST"
+echo "You can now open Ani-Mime from your Applications folder."
+open "$DEST"

--- a/src-tauri/script/post-build-sign.sh
+++ b/src-tauri/script/post-build-sign.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Post-build: re-sign the .app with entitlements and re-package the DMG.
+# Tauri doesn't embed entitlements for ad-hoc signing, so we do it manually.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TAURI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENTITLEMENTS="$TAURI_DIR/Entitlements.plist"
+APP_PATH="$TAURI_DIR/target/release/bundle/macos/ani-mime.app"
+DMG_DIR="$TAURI_DIR/target/release/bundle/dmg"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "Error: $APP_PATH not found. Run 'bun run tauri build' first."
+  exit 1
+fi
+
+if [ ! -f "$ENTITLEMENTS" ]; then
+  echo "Error: $ENTITLEMENTS not found."
+  exit 1
+fi
+
+echo "==> Re-signing ani-mime.app with entitlements..."
+codesign --force --sign - --entitlements "$ENTITLEMENTS" "$APP_PATH"
+
+# Verify
+echo "==> Verifying entitlements..."
+codesign -d --entitlements - "$APP_PATH" 2>&1 | grep -q "network.server" \
+  && echo "    OK: network entitlements embedded" \
+  || { echo "    FAIL: entitlements not found"; exit 1; }
+
+# Re-create DMG
+VERSION=$(grep '"version"' "$TAURI_DIR/tauri.conf.json" | head -1 | sed 's/.*: "//;s/".*//')
+ARCH=$(uname -m)
+DMG_NAME="ani-mime_${VERSION}_${ARCH}.dmg"
+DMG_PATH="$DMG_DIR/$DMG_NAME"
+
+echo "==> Creating DMG: $DMG_NAME"
+rm -f "$DMG_PATH"
+mkdir -p "$DMG_DIR"
+
+hdiutil create -volname "ani-mime" \
+  -srcfolder "$APP_PATH" \
+  -ov -format UDZO \
+  "$DMG_PATH"
+
+echo ""
+echo "Done! Distribution-ready files:"
+echo "  .app: $APP_PATH"
+echo "  .dmg: $DMG_PATH"

--- a/src-tauri/src/discovery.rs
+++ b/src-tauri/src/discovery.rs
@@ -59,6 +59,7 @@ pub fn start_discovery(
             }
             Err(e) => {
                 crate::app_error!("[discovery] failed to create mDNS daemon: {}", e);
+                let _ = app_handle.emit("discovery-error", format!("mDNS daemon failed: {}", e));
                 return;
             }
         };
@@ -104,6 +105,7 @@ pub fn start_discovery(
             Ok(info) => info.enable_addr_auto(),
             Err(e) => {
                 crate::app_error!("[discovery] failed to create ServiceInfo: {}", e);
+                let _ = app_handle.emit("discovery-error", format!("ServiceInfo failed: {}", e));
                 return;
             }
         };
@@ -122,6 +124,7 @@ pub fn start_discovery(
             Ok(_) => crate::app_log!("[discovery] registered as {} on {} (port={})", instance_name, host_name, port),
             Err(e) => {
                 crate::app_error!("[discovery] failed to register mDNS service: {}", e);
+                let _ = app_handle.emit("discovery-error", format!("mDNS register failed: {}", e));
                 return;
             }
         }
@@ -142,6 +145,7 @@ pub fn start_discovery(
             }
             Err(e) => {
                 crate::app_error!("[discovery] failed to start mDNS browse: {}", e);
+                let _ = app_handle.emit("discovery-error", format!("mDNS browse failed: {}", e));
                 return;
             }
         };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,7 +179,7 @@ fn start_visit(
 ) -> Result<(), String> {
     crate::app_log!("[visit] starting visit to peer={} as {} ({})", peer_id, nickname, pet);
 
-    let (ip, port) = {
+    let (ip, port, my_instance) = {
         let st = state.lock().unwrap();
 
         if st.visiting.is_some() {
@@ -187,10 +187,12 @@ fn start_visit(
             return Err("Already visiting someone".to_string());
         }
 
+        let instance = st.discovery_instance.clone();
+
         match st.peers.get(&peer_id) {
             Some(peer) => {
                 crate::app_log!("[visit] target peer: {} at {}:{}", peer.nickname, peer.ip, peer.port);
-                (peer.ip.clone(), peer.port)
+                (peer.ip.clone(), peer.port, instance)
             }
             None => {
                 crate::app_error!("[visit] peer not found: {}", peer_id);
@@ -200,6 +202,7 @@ fn start_visit(
     };
 
     let body = serde_json::json!({
+        "instance_name": my_instance,
         "pet": pet,
         "nickname": nickname,
         "duration_secs": VISIT_DURATION_SECS,
@@ -246,8 +249,12 @@ fn start_visit(
         crate::app_log!("[visit] dog away, returning in {}s", VISIT_DURATION_SECS);
         std::thread::sleep(std::time::Duration::from_secs(VISIT_DURATION_SECS));
 
-        // Send visit-end to peer
-        let end_body = serde_json::json!({ "nickname": nickname_clone });
+        // Send visit-end to peer — use instance_name as stable identifier
+        let my_instance_clone = {
+            let st = state_clone.lock().unwrap();
+            st.discovery_instance.clone()
+        };
+        let end_body = serde_json::json!({ "instance_name": my_instance_clone, "nickname": nickname_clone });
         match {
             let st = state_clone.lock().unwrap();
             st.peers.get(&peer_id).cloned().ok_or(())

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -153,14 +153,16 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
 
                 match serde_json::from_str::<serde_json::Value>(&body) {
                     Ok(payload) => {
+                        let instance_name = payload["instance_name"].as_str().unwrap_or("unknown").to_string();
                         let pet = payload["pet"].as_str().unwrap_or("rottweiler").to_string();
                         let nickname = payload["nickname"].as_str().unwrap_or("Unknown").to_string();
                         let duration_secs = payload["duration_secs"].as_u64().unwrap_or(15);
 
-                        crate::app_log!("[visit] {} ({}) arrived for {}s", nickname, pet, duration_secs);
+                        crate::app_log!("[visit] {} ({}) [{}] arrived for {}s", nickname, pet, instance_name, duration_secs);
 
                         let mut st = app_state.lock().unwrap();
                         st.visitors.push(crate::state::VisitingDog {
+                            instance_name: instance_name.clone(),
                             pet: pet.clone(),
                             nickname: nickname.clone(),
                             arrived_at: now,
@@ -172,6 +174,7 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
                         crate::app_log!("[visit] total visitors: {}", visitor_count);
 
                         if let Err(e) = app_handle.emit("visitor-arrived", serde_json::json!({
+                            "instance_name": instance_name,
                             "pet": pet,
                             "nickname": nickname,
                             "duration_secs": duration_secs,
@@ -211,17 +214,24 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
 
                 match serde_json::from_str::<serde_json::Value>(&body) {
                     Ok(payload) => {
+                        let instance_name = payload["instance_name"].as_str().unwrap_or("").to_string();
                         let nickname = payload["nickname"].as_str().unwrap_or("").to_string();
 
                         let mut st = app_state.lock().unwrap();
                         let before = st.visitors.len();
-                        st.visitors.retain(|v| v.nickname != nickname);
+                        if !instance_name.is_empty() {
+                            st.visitors.retain(|v| v.instance_name != instance_name);
+                        } else {
+                            // Fallback for older peers that don't send instance_name
+                            st.visitors.retain(|v| v.nickname != nickname);
+                        }
                         let after = st.visitors.len();
                         drop(st);
 
-                        crate::app_log!("[visit] {} left (visitors: {} -> {})", nickname, before, after);
+                        crate::app_log!("[visit] {} [{}] left (visitors: {} -> {})", nickname, instance_name, before, after);
 
                         if let Err(e) = app_handle.emit("visitor-left", serde_json::json!({
+                            "instance_name": instance_name,
                             "nickname": nickname,
                         })) {
                             crate::app_error!("[visit] failed to emit visitor-left: {}", e);
@@ -272,8 +282,8 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
                 lines.push(format!("=== Visitors ({}) ===", st.visitors.len()));
                 for v in &st.visitors {
                     lines.push(format!(
-                        "  {} ({}) arrived={}s_ago duration={}s",
-                        v.nickname, v.pet, now.saturating_sub(v.arrived_at), v.duration_secs
+                        "  {} ({}) [{}] arrived={}s_ago duration={}s",
+                        v.nickname, v.pet, v.instance_name, now.saturating_sub(v.arrived_at), v.duration_secs
                     ));
                 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -21,6 +21,7 @@ pub struct PeerInfo {
 /// A dog currently visiting this screen.
 #[derive(Clone, Serialize)]
 pub struct VisitingDog {
+    pub instance_name: String,
     pub pet: String,
     pub nickname: String,
     pub arrived_at: u64,

--- a/src-tauri/src/watchdog.rs
+++ b/src-tauri/src/watchdog.rs
@@ -59,15 +59,16 @@ pub fn start_watchdog(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppStat
         }
 
         // Remove expired visitors
-        let expired_visitors: Vec<String> = st.visitors
+        let expired_visitors: Vec<(String, String)> = st.visitors
             .iter()
             .filter(|v| now - v.arrived_at >= v.duration_secs)
-            .map(|v| v.nickname.clone())
+            .map(|v| (v.instance_name.clone(), v.nickname.clone()))
             .collect();
 
-        for nickname in &expired_visitors {
-            crate::app_log!("[watchdog] visitor {} expired", nickname);
+        for (instance_name, nickname) in &expired_visitors {
+            crate::app_log!("[watchdog] visitor {} [{}] expired", nickname, instance_name);
             if let Err(e) = app_handle.emit("visitor-left", serde_json::json!({
+                "instance_name": instance_name,
                 "nickname": nickname,
             })) {
                 crate::app_error!("[watchdog] failed to emit visitor-left: {}", e);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,6 +62,10 @@
     ],
     "active": true,
     "targets": "all",
+    "macOS": {
+      "entitlements": "./Entitlements.plist",
+      "infoPlist": "./Info.plist"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,7 @@ function App() {
       <StatusPill status={status} glow={visible} />
       {devMode && <DevTag />}
       {visitors.map((v, i) => (
-        <VisitorDog key={v.nickname} pet={v.pet} nickname={v.nickname} index={i} />
+        <VisitorDog key={v.instance_name || v.nickname} pet={v.pet} nickname={v.nickname} index={i} />
       ))}
     </div>
   );

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -27,7 +27,7 @@ vi.mock("../hooks/useTheme", () => ({
   useTheme: () => ({ theme: "dark", setTheme: vi.fn(), loaded: true }),
 }));
 
-const mockUseVisitors = vi.fn(() => [] as Array<{ pet: string; nickname: string; duration_secs: number }>);
+const mockUseVisitors = vi.fn(() => [] as Array<{ instance_name: string; pet: string; nickname: string; duration_secs: number }>);
 vi.mock("../hooks/useVisitors", () => ({
   useVisitors: () => mockUseVisitors(),
 }));
@@ -133,8 +133,8 @@ describe("App", () => {
 
   it("renders VisitorDog components for each visitor", () => {
     mockUseVisitors.mockReturnValue([
-      { pet: "dalmatian", nickname: "Buddy", duration_secs: 30 },
-      { pet: "rottweiler", nickname: "Rex", duration_secs: 60 },
+      { instance_name: "Buddy-1234", pet: "dalmatian", nickname: "Buddy", duration_secs: 30 },
+      { instance_name: "Rex-5678", pet: "rottweiler", nickname: "Rex", duration_secs: 60 },
     ]);
 
     render(<App />);

--- a/src/__tests__/hooks/useVisitors.test.ts
+++ b/src/__tests__/hooks/useVisitors.test.ts
@@ -14,6 +14,7 @@ describe("useVisitors", () => {
 
     await act(async () => {
       emitMockEvent("visitor-arrived", {
+        instance_name: "Buddy-1234",
         pet: "dalmatian",
         nickname: "Buddy",
         duration_secs: 30,
@@ -22,6 +23,7 @@ describe("useVisitors", () => {
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0]).toEqual({
+      instance_name: "Buddy-1234",
       pet: "dalmatian",
       nickname: "Buddy",
       duration_secs: 30,
@@ -33,11 +35,13 @@ describe("useVisitors", () => {
 
     await act(async () => {
       emitMockEvent("visitor-arrived", {
+        instance_name: "Buddy-1234",
         pet: "dalmatian",
         nickname: "Buddy",
         duration_secs: 30,
       });
       emitMockEvent("visitor-arrived", {
+        instance_name: "Rex-5678",
         pet: "rottweiler",
         nickname: "Rex",
         duration_secs: 60,
@@ -47,16 +51,18 @@ describe("useVisitors", () => {
     expect(result.current).toHaveLength(2);
   });
 
-  it("removes visitor on 'visitor-left' event", async () => {
+  it("removes visitor by instance_name on 'visitor-left' event", async () => {
     const { result } = renderHook(() => useVisitors());
 
     await act(async () => {
       emitMockEvent("visitor-arrived", {
+        instance_name: "Buddy-1234",
         pet: "dalmatian",
         nickname: "Buddy",
         duration_secs: 30,
       });
       emitMockEvent("visitor-arrived", {
+        instance_name: "Rex-5678",
         pet: "rottweiler",
         nickname: "Rex",
         duration_secs: 60,
@@ -66,11 +72,32 @@ describe("useVisitors", () => {
     expect(result.current).toHaveLength(2);
 
     await act(async () => {
-      emitMockEvent("visitor-left", { nickname: "Buddy" });
+      emitMockEvent("visitor-left", { instance_name: "Buddy-1234", nickname: "Buddy" });
     });
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0].nickname).toBe("Rex");
+  });
+
+  it("falls back to nickname removal when instance_name is empty", async () => {
+    const { result } = renderHook(() => useVisitors());
+
+    await act(async () => {
+      emitMockEvent("visitor-arrived", {
+        instance_name: "",
+        pet: "dalmatian",
+        nickname: "Buddy",
+        duration_secs: 30,
+      });
+    });
+
+    expect(result.current).toHaveLength(1);
+
+    await act(async () => {
+      emitMockEvent("visitor-left", { instance_name: "", nickname: "Buddy" });
+    });
+
+    expect(result.current).toHaveLength(0);
   });
 
   it("cleans up listeners on unmount", async () => {
@@ -83,7 +110,7 @@ describe("useVisitors", () => {
 
     // Emit event after unmount — state should not change
     await act(async () => {
-      emitMockEvent("visitor-arrived", { nickname: "Ghost", pet: "dalmatian", duration_secs: 30 });
+      emitMockEvent("visitor-arrived", { instance_name: "Ghost-9999", nickname: "Ghost", pet: "dalmatian", duration_secs: 30 });
     });
 
     expect(result.current).toEqual([]);

--- a/src/hooks/useVisitors.ts
+++ b/src/hooks/useVisitors.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 
 export interface Visitor {
+  instance_name: string;
   pet: string;
   nickname: string;
   duration_secs: number;
@@ -15,8 +16,14 @@ export function useVisitors() {
       setVisitors((prev) => [...prev, e.payload]);
     });
 
-    const unlistenLeft = listen<{ nickname: string }>("visitor-left", (e) => {
-      setVisitors((prev) => prev.filter((v) => v.nickname !== e.payload.nickname));
+    const unlistenLeft = listen<{ instance_name: string; nickname: string }>("visitor-left", (e) => {
+      setVisitors((prev) => {
+        if (e.payload.instance_name) {
+          return prev.filter((v) => v.instance_name !== e.payload.instance_name);
+        }
+        // Fallback for older peers
+        return prev.filter((v) => v.nickname !== e.payload.nickname);
+      });
     });
 
     return () => {


### PR DESCRIPTION
## Summary

- **Root cause**: Tauri's ad-hoc signing doesn't embed entitlements from `Entitlements.plist`. Without network entitlements (`network.client`, `network.server`), macOS Hardened Runtime silently blocks mDNS multicast and the HTTP server in release builds.
- **Added `Entitlements.plist`** with 4 entitlements: `allow-jit`, `disable-library-validation`, `network.server`, `network.client`
- **Added `post-build-sign.sh`** — re-signs the .app with entitlements and re-creates the DMG after `tauri build`
- **Added `install-mac.sh`** — removes quarantine for recipients without a Developer ID
- **Emit `discovery-error` events** on mDNS failure (was silent before)
- **Visitor dedup by `instance_name`** instead of `nickname` — prevents collision when two peers share a nickname
- **Updated release workflow** with post-build entitlement signing step
- **Updated docs**: README (peer visits section, build instructions), peer-discovery.md (troubleshooting), events-reference.md, CHANGELOG.md, CLAUDE.md

## Test plan

- [ ] `bun run tauri build && bash src-tauri/script/post-build-sign.sh` produces DMG with entitlements
- [ ] Verify entitlements: `codesign -d --entitlements - path/to/ani-mime.app` shows all 4 keys
- [ ] Install on a second Mac via DMG + `xattr -cr`, allow Local Network permission
- [ ] Both instances discover each other: `dns-sd -B _ani-mime._tcp local.` shows both
- [ ] Right-click context menu shows peer, visit works
- [ ] `bunx vitest run src/__tests__/hooks/useVisitors.test.ts` passes (12 tests)
- [ ] Frontend builds: `bunx vite build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)