### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - **Peer discovery broken in release builds** — added macOS entitlements (`Entitlements.plist`) for network access; Tauri's ad-hoc signing doesn't embed entitlements, so a post-build re-sign step is now required
 - **Visitor collision when peers share a nickname** — visitors are now keyed by `instance_name` (unique per process) instead of `nickname`
 - **Silent discovery failure** — mDNS daemon, registration, and browse errors now emit a `discovery-error` event to the frontend instead of failing silently
+- **Log viewer overflow** — last rows in Superpower log viewer were clipped by container overflow
 
 ### Added
+- **Menu Bar Tray Icon** — always-visible system tray icon; left-click toggles mascot window, right-click shows menu (Show, Settings, Quit)
+- **Hide from Dock** — toggle in Settings to remove app from Dock and Cmd+Tab switcher via `ActivationPolicy`, persisted across restarts
 - `src-tauri/Entitlements.plist` — macOS Hardened Runtime entitlements for network client/server, JIT, and library validation
 - `bundle.macOS` config in `tauri.conf.json` — explicit entitlements and Info.plist references
 - `src-tauri/script/post-build-sign.sh` — re-signs the .app with entitlements and re-creates the DMG after `tauri build`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.15.0"
+version = "0.15.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Bump version to 0.15.1 in package.json, Cargo.toml, tauri.conf.json
- Update CHANGELOG with menu bar tray icon, hide-from-dock, and log viewer fix entries (from PR #55)

## Changelog additions
- **Menu Bar Tray Icon** — always-visible system tray icon
- **Hide from Dock** — toggle in Settings
- **Log viewer overflow** fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)