### PR TITLE
fix: post-build-sign script for cross-target CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,20 @@ jobs:
 
       - name: Re-sign with entitlements (ad-hoc builds)
         if: ${{ !env.APPLE_SIGNING_IDENTITY }}
-        run: bash src-tauri/script/post-build-sign.sh
+        run: bash src-tauri/script/post-build-sign.sh ${{ matrix.target }}
+
+      - name: Upload re-signed DMG
+        if: ${{ !env.APPLE_SIGNING_IDENTITY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "${{ matrix.target }}" == *"aarch64"* ]]; then
+            ARCH="aarch64"
+          else
+            ARCH="x64"
+          fi
+          DMG="src-tauri/target/${{ matrix.target }}/release/bundle/dmg/ani-mime_${VERSION}_${ARCH}.dmg"
+          if [ -f "$DMG" ]; then
+            gh release upload "$GITHUB_REF_NAME" "$DMG" --clobber
+          fi

--- a/src-tauri/script/post-build-sign.sh
+++ b/src-tauri/script/post-build-sign.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 # Post-build: re-sign the .app with entitlements and re-package the DMG.
 # Tauri doesn't embed entitlements for ad-hoc signing, so we do it manually.
+#
+# Usage: post-build-sign.sh [TARGET_TRIPLE]
+#   e.g. post-build-sign.sh aarch64-apple-darwin
+#   Without argument, uses target/release/ (local builds).
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TAURI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENTITLEMENTS="$TAURI_DIR/Entitlements.plist"
-APP_PATH="$TAURI_DIR/target/release/bundle/macos/ani-mime.app"
-DMG_DIR="$TAURI_DIR/target/release/bundle/dmg"
+
+TARGET="${1:-}"
+if [ -n "$TARGET" ]; then
+  RELEASE_DIR="$TAURI_DIR/target/$TARGET/release"
+else
+  RELEASE_DIR="$TAURI_DIR/target/release"
+fi
+
+APP_PATH="$RELEASE_DIR/bundle/macos/ani-mime.app"
+DMG_DIR="$RELEASE_DIR/bundle/dmg"
 
 if [ ! -d "$APP_PATH" ]; then
   echo "Error: $APP_PATH not found. Run 'bun run tauri build' first."
@@ -30,7 +42,15 @@ codesign -d --entitlements - "$APP_PATH" 2>&1 | grep -q "network.server" \
 
 # Re-create DMG
 VERSION=$(grep '"version"' "$TAURI_DIR/tauri.conf.json" | head -1 | sed 's/.*: "//;s/".*//')
-ARCH=$(uname -m)
+if [ -n "$TARGET" ]; then
+  case "$TARGET" in
+    aarch64*) ARCH="aarch64" ;;
+    x86_64*)  ARCH="x64" ;;
+    *)        ARCH=$(uname -m) ;;
+  esac
+else
+  ARCH=$(uname -m)
+fi
 DMG_NAME="ani-mime_${VERSION}_${ARCH}.dmg"
 DMG_PATH="$DMG_DIR/$DMG_NAME"
 


### PR DESCRIPTION
## Summary
- Fix `post-build-sign.sh` to accept optional target triple arg (handles `target/<triple>/release/` path in CI)
- Add re-upload step in release workflow to replace unsigned DMG with signed one
- Derive arch name from target triple instead of `uname -m` for consistent naming

This fixes the v0.15.1 release build failure where the re-sign step couldn't find the .app at the hardcoded `target/release/` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)