### PR TITLE
chore: release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.15.1] - 2026-04-12
+## [0.15.2] - 2026-04-12
 
 ### Fixed
 - **Peer discovery broken in release builds** — added macOS entitlements (`Entitlements.plist`) for network access; Tauri's ad-hoc signing doesn't embed entitlements, so a post-build re-sign step is now required

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.15.1"
+version = "0.15.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -660,7 +660,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.15.0{devMode && " (Dev Mode)"}
+                  Version 0.15.2{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.15.2 in package.json, Cargo.toml, tauri.conf.json, Settings.tsx, CHANGELOG
- Fix hardcoded version string in Settings About page (was still showing 0.15.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)