### PR TITLE
feat(superpower): add Reveal in Finder and dropdown log filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,10 @@ Every interactive or observable UI element must be locatable by automated tests 
 
 - **Unit tests** (Vitest + React Testing Library): `src/**/*.test.{ts,tsx}`
 - **E2E tests** (Playwright): `e2e/*.spec.ts`
-- **Run e2e**: `bunx playwright test`
+- **Run e2e**: `bunx playwright test -c e2e/playwright.config.ts --project=chromium`
 - **Playwright config**: `e2e/playwright.config.ts` — chromium + webkit, trace on failure
+- **When to run e2e**: Before pushing. No pre-commit or pre-push hook is configured — run manually. E2e takes ~7s on Chromium; too slow for a commit hook.
+- **Tauri mock**: `e2e/tauri-mock.ts` — injects fake `__TAURI_INTERNALS__` for store, dialog, FS, window, and event plugins. Supports `__MOCK_DIALOG_RESULT__`, `__MOCK_READ_FILE_BYTES__`, `__MOCK_READ_FILE_MAP__`, `__MOCK_SAVE_DIALOG_RESULT__`, `__MOCK_WRITTEN_FILES__`, `__MOCK_WINDOW_SIZES__` for test assertions.
 
 ## Adding Features
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Shell hooks (curl) → HTTP :1234 → Rust state → Tauri event → React UI
 | `setup/mod.rs` | First-launch auto-setup orchestrator |
 | `setup/shell.rs` | Shell detection, native dialogs, RC file injection |
 | `setup/claude.rs` | Claude Code hooks configuration |
+| `logger.rs` | Log file tail-reader, `app_log!`/`app_warn!`/`app_error!` macros |
 | `platform/macos.rs` | Cocoa/objc window transparency, workspace visibility, dock visibility |
 
 ### Frontend (`src/`)
@@ -69,6 +70,16 @@ When multiple terminals are open, the UI shows one winner: `busy > service > idl
 - macOS-only: uses `cocoa` + `objc` crates for window transparency (behind `#[cfg(target_os = "macos")]`)
 - Tray icon is always present; left-click toggles main window, right-click shows menu (Show, Settings, Quit)
 - "Hide from Dock" preference stored as `hideDock` in `settings.json`; applied at startup via `ActivationPolicy::Accessory`
+
+## Logging
+
+- **Writer**: `tauri-plugin-log` appends structured lines to `ani-mime.log` inside the Tauri log dir (`~/Library/Logs/<bundle-id>/`)
+- **Reader**: `logger.rs` reads the tail of that same file to display in the Superpower Tool UI
+- **Rotation**: Configured as `KeepSome(3)` with 1MB max per file — do not increase without reason
+- **Tail-read**: `read_log_file()` seeks to the end of the file and reads only the last ~N×256 bytes. Never load the entire log file into memory.
+- **Macros**: Use `app_log!()`, `app_warn!()`, `app_error!()` for app-level logging — these route through the `log` crate so the plugin writes them to file
+- **Levels**: `debug` for dev diagnostics, `info` for state changes, `warn`/`error` for problems. Third-party crate noise is filtered in `lib.rs` (e.g. `mdns_sd` set to `Warn`)
+- **Don't truncate the log file externally** — `tauri-plugin-log` holds its own file handle; truncating causes stale size tracking and premature rotation
 
 ## Testing
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -596,9 +596,9 @@ test('export Charlotte mime as .animime file', async ({ page }) => {
 });
 
 // ---------------------------------------------------------------------------
-// 15. Delete Charlotte then re-import from .animime file
+// 15. Delete Charlotte custom mime
 // ---------------------------------------------------------------------------
-test('delete Charlotte then re-import from .animime file', async ({ page }) => {
+test('delete Charlotte custom mime', async ({ page }) => {
   await loadWithMock(page, '/settings.html');
 
   const mimeId = 'custom-1776007930810';
@@ -626,7 +626,7 @@ test('delete Charlotte then re-import from .animime file', async ({ page }) => {
   }, charlotte);
   await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).toBeVisible();
 
-  // --- Delete Charlotte ---
+  // Hover to reveal delete button, then click it
   const charlotteWrapper = page.locator('.pet-card-wrapper', {
     has: page.locator('.pet-name', { hasText: 'Charlotte' }),
   });
@@ -635,17 +635,35 @@ test('delete Charlotte then re-import from .animime file', async ({ page }) => {
 
   // Charlotte should be gone
   await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).not.toBeVisible();
+});
 
-  // --- Build .animime payload from real sprite files ---
+// ---------------------------------------------------------------------------
+// 16. Import Charlotte from .animime file
+// ---------------------------------------------------------------------------
+test('import Charlotte from .animime file', async ({ page }) => {
+  await loadWithMock(page, '/settings.html');
+
+  const charlotte = {
+    idle:          { frames: 12 },
+    busy:          { frames: 38 },
+    service:       { frames: 11 },
+    disconnected:  { frames: 7 },
+    searching:     { frames: 8 },
+    initializing:  { frames: 5 },
+    visiting:      { frames: 24 },
+  };
+
+  // Build .animime payload from real Charlotte sprite files
   const spritesDir = path.resolve(
     os.homedir(),
     'Library/Application Support/com.vietnguyenwsilentium.ani-mime/custom-sprites',
   );
+  const mimeId = 'custom-1776007930810';
   const animimeSprites: Record<string, { frames: number; data: string }> = {};
-  for (const [status, info] of Object.entries(charlotte.sprites)) {
-    const filePath = path.join(spritesDir, (info as any).fileName);
-    const b64 = readFileSync(filePath).toString('base64');
-    animimeSprites[status] = { frames: (info as any).frames, data: b64 };
+  for (const [status, info] of Object.entries(charlotte)) {
+    const fileName = `${mimeId}-${status}.png`;
+    const b64 = readFileSync(path.join(spritesDir, fileName)).toString('base64');
+    animimeSprites[status] = { frames: info.frames, data: b64 };
   }
   const animimePayload = JSON.stringify({ version: 1, name: 'Charlotte', sprites: animimeSprites });
 
@@ -656,17 +674,20 @@ test('delete Charlotte then re-import from .animime file', async ({ page }) => {
     (window as any).__MOCK_READ_FILE_BYTES__ = encoder.encode(payload);
   }, animimePayload);
 
-  // --- Import via .animime button ---
+  // Navigate to Mime tab
+  await page.click('.sidebar-item:nth-child(2)');
+  await expect(page.locator('.settings-title')).toHaveText('Mime');
+
+  // Click import .animime button
   await page.click('[data-testid="import-animime-btn"]');
 
-  // Charlotte should reappear in the mime list
+  // Charlotte should appear in the mime list
   await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).toBeVisible();
 
   // Verify the imported mime was stored with correct frame counts
   const storedMimes = await page.evaluate(() => {
-    return (window as any).__TEST_EMIT__ && new Promise<any>((resolve) => {
-      // Read from the mock store
-      const stores = (window as any).__TAURI_INTERNALS__.invoke('plugin:store|load', { path: 'settings.json' })
+    return new Promise<any>((resolve) => {
+      (window as any).__TAURI_INTERNALS__.invoke('plugin:store|load', { path: 'settings.json' })
         .then((rid: number) => (window as any).__TAURI_INTERNALS__.invoke('plugin:store|get', { rid, key: 'customMimes' }))
         .then((val: any) => resolve(val ? val[0] : null));
     });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { tauriMockScript } from './tauri-mock';
+
+const __filename = fileURLToPath(import.meta.url);
+const __e2eDir = path.dirname(__filename);
 
 // Helper: inject mock before navigation so it's available when React boots.
 async function loadWithMock(page: import('@playwright/test').Page, path = '/') {
@@ -398,4 +404,88 @@ test('edit Charlotte sprite: rename and change busy frame range', async ({ page 
   const allNames = await page.locator('.pet-card-wrapper .pet-name').allTextContents();
   expect(allNames).toContain('Charlotte v2');
   expect(allNames).not.toContain('Charlotte');
+});
+
+// ---------------------------------------------------------------------------
+// 13. SmartImport Charlotte: auto-fill name and custom frame selection
+// ---------------------------------------------------------------------------
+test('SmartImport Charlotte with auto-fill name and frame selection', async ({ page }) => {
+  await loadWithMock(page, '/settings.html');
+
+  // Load Charlotte sprite sheet and inject as mock readFile result
+  const charlottePath = path.resolve(__e2eDir, '../src/__tests__/fixtures/sprites/charlotte/input.png');
+  const b64 = readFileSync(charlottePath).toString('base64');
+
+  await page.evaluate((data: string) => {
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    (window as any).__MOCK_READ_FILE_BYTES__ = bytes;
+    (window as any).__MOCK_DIALOG_RESULT__ = '/mock/sprites/Charlotte.png';
+  }, b64);
+
+  // Navigate to Mime tab
+  await page.click('.sidebar-item:nth-child(2)');
+  await expect(page.locator('.settings-title')).toHaveText('Mime');
+
+  // Click "Import Sheet" to trigger file dialog mock → SmartImport opens
+  await page.click('.pet-card.add-card:has-text("Import Sheet")');
+
+  // Wait for sprite sheet processing — frame assignments should appear
+  const frameAssign = page.locator('.smart-import-frame-assign');
+  await expect(frameAssign.first()).toBeVisible();
+  await expect(frameAssign).toHaveCount(7);
+
+  // Verify name is auto-filled as "Charlotte" (filename without extension)
+  const nameInput = page.locator('.smart-import .settings-input');
+  await expect(nameInput).toHaveValue('Charlotte');
+
+  // Frame ranges matching the Charlotte sprite sheet assignment
+  // (from screenshots: idle=1-5,51-55,57,58 busy=6-43 etc.)
+  const frameRanges: Record<string, { input: string; count: number }> = {
+    idle:          { input: '1-5,51-55,57,58', count: 12 },
+    busy:          { input: '6-43',            count: 38 },
+    service:       { input: '14-19',           count: 6 },
+    disconnected:  { input: '44-50',           count: 7 },
+    searching:     { input: '35-43',           count: 9 },
+    initializing:  { input: '6-13',            count: 8 },
+    visiting:      { input: '20-43',           count: 24 },
+  };
+  const statusOrder = ['idle', 'busy', 'service', 'disconnected', 'searching', 'initializing', 'visiting'];
+
+  // Edit frame ranges and verify thumbnails update
+  const frameInputs = page.locator('.smart-import-frame-input');
+  for (let i = 0; i < statusOrder.length; i++) {
+    const status = statusOrder[i];
+    const input = frameInputs.nth(i);
+    await input.clear();
+    await input.fill(frameRanges[status].input);
+    await input.blur(); // triggers thumbnail update
+  }
+
+  // Verify each status shows the correct number of frame thumbnails with numbers
+  for (let i = 0; i < statusOrder.length; i++) {
+    const status = statusOrder[i];
+    const assign = frameAssign.nth(i);
+    const thumbs = assign.locator('.smart-import-frame-thumb-item');
+    const nums = assign.locator('.smart-import-frame-num');
+
+    // Correct frame count
+    await expect(thumbs).toHaveCount(frameRanges[status].count);
+    // Each thumbnail has a frame number label
+    await expect(nums).toHaveCount(frameRanges[status].count);
+  }
+
+  // Verify first frame number for idle is "1"
+  const idleFirstNum = frameAssign.first().locator('.smart-import-frame-num').first();
+  await expect(idleFirstNum).toHaveText('1');
+
+  // Save the mime
+  const saveBtn = page.locator('.creator-btn.save');
+  await expect(saveBtn).toBeEnabled();
+  await saveBtn.click();
+
+  // SmartImport should close and Charlotte appears in mime list
+  await expect(page.locator('.smart-import')).not.toBeVisible();
+  await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).toBeVisible();
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { readFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tauriMockScript } from './tauri-mock';
@@ -488,4 +489,106 @@ test('SmartImport Charlotte with auto-fill name and frame selection', async ({ p
   // SmartImport should close and Charlotte appears in mime list
   await expect(page.locator('.smart-import')).not.toBeVisible();
   await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// 14. Export Charlotte as .animime file
+// ---------------------------------------------------------------------------
+test('export Charlotte mime as .animime file', async ({ page }) => {
+  await loadWithMock(page, '/settings.html');
+
+  const mimeId = 'custom-1776007930810';
+  const charlotte = {
+    id: mimeId,
+    name: 'Charlotte',
+    sprites: {
+      idle:          { fileName: `${mimeId}-idle.png`,          frames: 12 },
+      busy:          { fileName: `${mimeId}-busy.png`,          frames: 38 },
+      service:       { fileName: `${mimeId}-service.png`,       frames: 11 },
+      disconnected:  { fileName: `${mimeId}-disconnected.png`,  frames: 7 },
+      searching:     { fileName: `${mimeId}-searching.png`,     frames: 8 },
+      initializing:  { fileName: `${mimeId}-initializing.png`,  frames: 5 },
+      visiting:      { fileName: `${mimeId}-visiting.png`,      frames: 24 },
+    },
+  };
+
+  // Load real Charlotte sprite PNGs and inject as mock file map
+  const spritesDir = path.resolve(
+    os.homedir(),
+    'Library/Application Support/com.vietnguyenwsilentium.ani-mime/custom-sprites',
+  );
+  const fileMap: Record<string, string> = {};
+  for (const [status, info] of Object.entries(charlotte.sprites)) {
+    const filePath = path.join(spritesDir, (info as any).fileName);
+    fileMap[(info as any).fileName] = readFileSync(filePath).toString('base64');
+  }
+
+  await page.evaluate(({ fileMap, mimeId }) => {
+    // Inject per-file read map (base64 → Uint8Array)
+    const map: Record<string, Uint8Array> = {};
+    for (const [name, b64] of Object.entries(fileMap)) {
+      const binary = atob(b64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      map[name] = bytes;
+    }
+    (window as any).__MOCK_READ_FILE_MAP__ = map;
+
+    // Mock save dialog to return a path
+    (window as any).__MOCK_SAVE_DIALOG_RESULT__ = `/mock/export/Charlotte.animime`;
+  }, { fileMap, mimeId });
+
+  // Navigate to Mime tab
+  await page.click('.sidebar-item:nth-child(2)');
+  await expect(page.locator('.settings-title')).toHaveText('Mime');
+
+  // Inject Charlotte into custom mimes
+  await page.evaluate((data) => {
+    (window as any).__TEST_EMIT__('custom-mimes-changed', [data]);
+  }, charlotte);
+
+  // Charlotte should appear in the custom section
+  await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).toBeVisible();
+
+  // Hover to reveal export button, then click it
+  const charlotteWrapper = page.locator('.pet-card-wrapper', {
+    has: page.locator('.pet-name', { hasText: 'Charlotte' }),
+  });
+  await charlotteWrapper.hover();
+  await page.click(`[data-testid="export-mime-${mimeId}"]`);
+
+  // Wait for export to complete — writeFile should have been called
+  await page.waitForFunction(() => {
+    const files = (window as any).__MOCK_WRITTEN_FILES__;
+    return files && files.length > 0;
+  });
+
+  // Read and verify the exported .animime data
+  const exported = await page.evaluate(() => {
+    const files = (window as any).__MOCK_WRITTEN_FILES__;
+    const last = files[files.length - 1];
+    const raw = last.contents;
+    const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(Object.values(raw) as number[]);
+    const text = new TextDecoder().decode(bytes);
+    return { path: last.path, json: JSON.parse(text) };
+  });
+
+  // Verify export path
+  expect(exported.path).toContain('Charlotte.animime');
+
+  // Verify .animime structure
+  expect(exported.json.version).toBe(1);
+  expect(exported.json.name).toBe('Charlotte');
+
+  // Verify all 7 statuses with correct frame counts
+  const expectedFrames: Record<string, number> = {
+    idle: 12, busy: 38, service: 11, disconnected: 7,
+    searching: 8, initializing: 5, visiting: 24,
+  };
+  for (const [status, frames] of Object.entries(expectedFrames)) {
+    expect(exported.json.sprites[status]).toBeDefined();
+    expect(exported.json.sprites[status].frames).toBe(frames);
+    // Each sprite should have non-empty base64 data
+    expect(exported.json.sprites[status].data.length).toBeGreaterThan(0);
+  }
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -246,9 +246,11 @@ test('upload Charlotte as custom sprite via manual flow', async ({ page }) => {
   const creator = page.locator('.custom-creator');
   await expect(creator).toBeVisible();
 
-  // Save should be disabled initially (no name, no files selected)
   const saveBtn = creator.locator('.creator-btn.save');
-  await expect(saveBtn).toBeDisabled();
+
+  // Clicking Save without a name shows validation error
+  await saveBtn.click();
+  await expect(page.locator('.save-error')).toHaveText('Name is required');
 
   // Enter "Charlotte" as the mime name
   await creator.locator('.settings-input').fill('Charlotte');

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -594,3 +594,93 @@ test('export Charlotte mime as .animime file', async ({ page }) => {
     expect(exported.json.sprites[status].data.length).toBeGreaterThan(0);
   }
 });
+
+// ---------------------------------------------------------------------------
+// 15. Delete Charlotte then re-import from .animime file
+// ---------------------------------------------------------------------------
+test('delete Charlotte then re-import from .animime file', async ({ page }) => {
+  await loadWithMock(page, '/settings.html');
+
+  const mimeId = 'custom-1776007930810';
+  const charlotte = {
+    id: mimeId,
+    name: 'Charlotte',
+    sprites: {
+      idle:          { fileName: `${mimeId}-idle.png`,          frames: 12 },
+      busy:          { fileName: `${mimeId}-busy.png`,          frames: 38 },
+      service:       { fileName: `${mimeId}-service.png`,       frames: 11 },
+      disconnected:  { fileName: `${mimeId}-disconnected.png`,  frames: 7 },
+      searching:     { fileName: `${mimeId}-searching.png`,     frames: 8 },
+      initializing:  { fileName: `${mimeId}-initializing.png`,  frames: 5 },
+      visiting:      { fileName: `${mimeId}-visiting.png`,      frames: 24 },
+    },
+  };
+
+  // Navigate to Mime tab
+  await page.click('.sidebar-item:nth-child(2)');
+  await expect(page.locator('.settings-title')).toHaveText('Mime');
+
+  // Inject Charlotte into custom mimes
+  await page.evaluate((data) => {
+    (window as any).__TEST_EMIT__('custom-mimes-changed', [data]);
+  }, charlotte);
+  await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).toBeVisible();
+
+  // --- Delete Charlotte ---
+  const charlotteWrapper = page.locator('.pet-card-wrapper', {
+    has: page.locator('.pet-name', { hasText: 'Charlotte' }),
+  });
+  await charlotteWrapper.hover();
+  await page.click(`[data-testid="delete-mime-${mimeId}"]`);
+
+  // Charlotte should be gone
+  await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).not.toBeVisible();
+
+  // --- Build .animime payload from real sprite files ---
+  const spritesDir = path.resolve(
+    os.homedir(),
+    'Library/Application Support/com.vietnguyenwsilentium.ani-mime/custom-sprites',
+  );
+  const animimeSprites: Record<string, { frames: number; data: string }> = {};
+  for (const [status, info] of Object.entries(charlotte.sprites)) {
+    const filePath = path.join(spritesDir, (info as any).fileName);
+    const b64 = readFileSync(filePath).toString('base64');
+    animimeSprites[status] = { frames: (info as any).frames, data: b64 };
+  }
+  const animimePayload = JSON.stringify({ version: 1, name: 'Charlotte', sprites: animimeSprites });
+
+  // Set up mocks: dialog returns .animime path, readFile returns the payload bytes
+  await page.evaluate((payload: string) => {
+    (window as any).__MOCK_DIALOG_RESULT__ = '/mock/import/Charlotte.animime';
+    const encoder = new TextEncoder();
+    (window as any).__MOCK_READ_FILE_BYTES__ = encoder.encode(payload);
+  }, animimePayload);
+
+  // --- Import via .animime button ---
+  await page.click('[data-testid="import-animime-btn"]');
+
+  // Charlotte should reappear in the mime list
+  await expect(page.locator('.pet-card-wrapper .pet-name', { hasText: 'Charlotte' })).toBeVisible();
+
+  // Verify the imported mime was stored with correct frame counts
+  const storedMimes = await page.evaluate(() => {
+    return (window as any).__TEST_EMIT__ && new Promise<any>((resolve) => {
+      // Read from the mock store
+      const stores = (window as any).__TAURI_INTERNALS__.invoke('plugin:store|load', { path: 'settings.json' })
+        .then((rid: number) => (window as any).__TAURI_INTERNALS__.invoke('plugin:store|get', { rid, key: 'customMimes' }))
+        .then((val: any) => resolve(val ? val[0] : null));
+    });
+  });
+
+  expect(storedMimes).toBeTruthy();
+  expect(storedMimes.length).toBe(1);
+  expect(storedMimes[0].name).toBe('Charlotte');
+
+  const expectedFrames: Record<string, number> = {
+    idle: 12, busy: 38, service: 11, disconnected: 7,
+    searching: 8, initializing: 5, visiting: 24,
+  };
+  for (const [status, frames] of Object.entries(expectedFrames)) {
+    expect(storedMimes[0].sprites[status].frames).toBe(frames);
+  }
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -705,3 +705,44 @@ test('import Charlotte from .animime file', async ({ page }) => {
     expect(storedMimes[0].sprites[status].frames).toBe(frames);
   }
 });
+
+// ---------------------------------------------------------------------------
+// 17. Window auto-resizes to fit sprite content
+// ---------------------------------------------------------------------------
+test('window resizes to match sprite content, not fixed 500x220', async ({ page }) => {
+  await loadWithMock(page);
+
+  // Wait for initial render and auto-size
+  await expect(page.locator('[data-testid="app-container"]')).toBeVisible();
+
+  // Wait for at least one setSize call from the ResizeObserver
+  await page.waitForFunction(() => {
+    const sizes = (window as any).__MOCK_WINDOW_SIZES__;
+    return sizes && sizes.length > 0;
+  });
+
+  const lastSize = await page.evaluate(() => {
+    const sizes = (window as any).__MOCK_WINDOW_SIZES__;
+    const last = sizes[sizes.length - 1];
+    // Serialize through JSON to flatten class instances
+    const parsed = JSON.parse(JSON.stringify(last.value));
+    const logical = parsed.Logical ?? parsed;
+    return { width: logical.width, height: logical.height };
+  });
+
+  // Window should NOT be the old hardcoded 500x220
+  const isOldFixed = lastSize.width === 500 && lastSize.height === 220;
+  expect(isOldFixed).toBe(false);
+
+  // Window size should be positive and reasonable (content-driven)
+  expect(lastSize.width).toBeGreaterThan(0);
+  expect(lastSize.height).toBeGreaterThan(0);
+
+  // The container's actual size should match what was sent to setSize
+  const containerSize = await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="app-container"]') as HTMLElement;
+    return { width: el.offsetWidth, height: el.offsetHeight };
+  });
+  expect(lastSize.width).toBe(containerSize.width);
+  expect(lastSize.height).toBe(containerSize.height);
+});

--- a/e2e/tauri-mock.ts
+++ b/e2e/tauri-mock.ts
@@ -151,7 +151,7 @@ export const tauriMockScript = `
     if (cmd === 'plugin:fs|exists')     return false;
     if (cmd === 'plugin:fs|mkdir')      return null;
     if (cmd === 'plugin:fs|copy_file')  return null;
-    if (cmd === 'plugin:fs|read_file')  return new Uint8Array(0);
+    if (cmd === 'plugin:fs|read_file')  return window.__MOCK_READ_FILE_BYTES__ ?? new Uint8Array(0);
     if (cmd === 'plugin:fs|write_file') return null;
     if (cmd === 'plugin:fs|remove')     return null;
 

--- a/e2e/tauri-mock.ts
+++ b/e2e/tauri-mock.ts
@@ -146,13 +146,29 @@ export const tauriMockScript = `
 
     // Dialog plugin  ------------------------------------------------------
     if (cmd === 'plugin:dialog|open') return window.__MOCK_DIALOG_RESULT__ ?? null;
+    if (cmd === 'plugin:dialog|save') return window.__MOCK_SAVE_DIALOG_RESULT__ ?? null;
 
     // FS plugin (in-memory no-ops)  ---------------------------------------
     if (cmd === 'plugin:fs|exists')     return false;
     if (cmd === 'plugin:fs|mkdir')      return null;
     if (cmd === 'plugin:fs|copy_file')  return null;
-    if (cmd === 'plugin:fs|read_file')  return window.__MOCK_READ_FILE_BYTES__ ?? new Uint8Array(0);
-    if (cmd === 'plugin:fs|write_file') return null;
+    if (cmd === 'plugin:fs|read_file') {
+      // Support per-file map (keyed by filename suffix)
+      const p = (args && args.path) || '';
+      if (window.__MOCK_READ_FILE_MAP__) {
+        for (const [key, bytes] of Object.entries(window.__MOCK_READ_FILE_MAP__)) {
+          if (p.endsWith(key)) return bytes;
+        }
+      }
+      return window.__MOCK_READ_FILE_BYTES__ ?? new Uint8Array(0);
+    }
+    if (cmd === 'plugin:fs|write_file') {
+      // Tauri v2 FS sends data as args, path in _options.headers.path
+      if (!window.__MOCK_WRITTEN_FILES__) window.__MOCK_WRITTEN_FILES__ = [];
+      const filePath = _options?.headers?.path ? decodeURIComponent(_options.headers.path) : null;
+      window.__MOCK_WRITTEN_FILES__.push({ path: filePath, contents: args });
+      return null;
+    }
     if (cmd === 'plugin:fs|remove')     return null;
 
     // Log plugin  ---------------------------------------------------------

--- a/e2e/tauri-mock.ts
+++ b/e2e/tauri-mock.ts
@@ -134,7 +134,11 @@ export const tauriMockScript = `
 
     // Window plugin  -------------------------------------------------------
     if (cmd === 'plugin:window|start_dragging') return null;
-    if (cmd === 'plugin:window|set_size')       return null;
+    if (cmd === 'plugin:window|set_size') {
+      window.__MOCK_WINDOW_SIZES__ = window.__MOCK_WINDOW_SIZES__ || [];
+      window.__MOCK_WINDOW_SIZES__.push(args);
+      return null;
+    }
     if (cmd === 'plugin:window|inner_size')     return { width: 500, height: 220 };
     if (cmd === 'plugin:window|outer_size')     return { width: 500, height: 220 };
     if (cmd === 'plugin:window|inner_position') return { x: 0, y: 0 };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,14 @@ fn set_dock_visible(visible: bool, app: tauri::AppHandle) {
 }
 
 #[tauri::command]
+fn set_tray_visible(visible: bool, app: tauri::AppHandle) {
+    crate::app_log!("[app] set_tray_visible -> {}", visible);
+    if let Some(tray) = app.tray_by_id("main-tray") {
+        let _ = tray.set_visible(visible);
+    }
+}
+
+#[tauri::command]
 fn open_superpower(app: tauri::AppHandle) -> Result<(), String> {
     crate::app_log!("[app] opening superpower tool");
     if let Some(win) = app.get_webview_window("superpower") {
@@ -322,7 +330,7 @@ pub fn run() {
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible])
+        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible, set_tray_visible])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
 
@@ -427,7 +435,7 @@ pub fn run() {
                 .build(app)?;
             crate::app_log!("[app] tray icon created");
 
-            // Apply saved dock visibility preference
+            // Apply saved preferences
             {
                 let app_data_dir = app.path().app_data_dir()?;
                 let store_path = app_data_dir.join("settings.json");
@@ -437,6 +445,12 @@ pub fn run() {
                             if json.get("hideDock").and_then(|v| v.as_bool()).unwrap_or(false) {
                                 crate::app_log!("[app] restoring dock-hidden preference");
                                 platform::macos::set_dock_visibility(app.handle(), false);
+                            }
+                            if json.get("hideTray").and_then(|v| v.as_bool()).unwrap_or(false) {
+                                crate::app_log!("[app] restoring tray-hidden preference");
+                                if let Some(tray) = app.tray_by_id("main-tray") {
+                                    let _ = tray.set_visible(false);
+                                }
                             }
                         }
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,13 @@ fn clear_logs() {
 }
 
 #[tauri::command]
+fn open_log_dir(app: tauri::AppHandle) {
+    if let Ok(log_dir) = app.path().app_log_dir() {
+        let _ = std::process::Command::new("open").arg(&log_dir).spawn();
+    }
+}
+
+#[tauri::command]
 fn set_dev_mode(enabled: bool, app: tauri::AppHandle) {
     crate::app_log!("[dev] dev-mode-changed -> {}", enabled);
     let _ = app.emit("dev-mode-changed", enabled);
@@ -315,7 +322,7 @@ pub fn run() {
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible])
+        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,12 +24,12 @@ const VISIT_DURATION_SECS: u64 = 15;
 
 #[tauri::command]
 fn get_logs() -> Vec<logger::LogEntry> {
-    logger::get_all_logs()
+    logger::read_log_file(1000)
 }
 
 #[tauri::command]
 fn clear_logs() {
-    logger::clear_logs();
+    logger::clear_log_file();
 }
 
 #[tauri::command]
@@ -318,6 +318,11 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
+
+            // Tell our log reader where to find the log file
+            if let Ok(log_dir) = app.path().app_log_dir() {
+                logger::set_log_path(log_dir.join("ani-mime.log"));
+            }
 
             platform::macos::setup_macos_window(app);
             crate::app_log!("[app] macOS window configured");

--- a/src-tauri/src/logger.rs
+++ b/src-tauri/src/logger.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -62,10 +62,11 @@ pub fn read_log_file(last_n: usize) -> Vec<LogEntry> {
 
 pub fn clear_log_file() {
     let Some(path) = get_log_path() else { return };
+    // Note: tauri-plugin-log holds its own file handle with a cached current_size.
+    // After truncation, its size tracker will be stale, which may cause an early
+    // rotation on the next write. Acceptable for a dev-only tool.
     if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&path) {
         let _ = file.set_len(0);
-        let mut f = file;
-        let _ = f.seek(SeekFrom::Start(0));
     }
 }
 

--- a/src-tauri/src/logger.rs
+++ b/src-tauri/src/logger.rs
@@ -1,45 +1,80 @@
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::PathBuf;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
-const MAX_LOG_ENTRIES: usize = 1000;
-
 #[derive(Clone, Serialize)]
 pub struct LogEntry {
-    pub timestamp: u64,
-    pub level: &'static str,
+    pub timestamp: String,
+    pub level: String,
+    pub source: String,
     pub message: String,
 }
 
-static LOG_BUFFER: Mutex<Vec<LogEntry>> = Mutex::new(Vec::new());
+/// Cache the resolved log file path so we don't re-derive it on every poll.
+static LOG_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+pub fn set_log_path(path: PathBuf) {
+    *LOG_PATH.lock().unwrap() = Some(path);
+}
+
+fn get_log_path() -> Option<PathBuf> {
+    LOG_PATH.lock().unwrap().clone()
+}
+
+fn parse_log_line(line: &str) -> Option<LogEntry> {
+    // Format: [date][time][module][LEVEL] message
+    let rest = line.strip_prefix('[')?;
+    let (date, rest) = rest.split_once("][")?;
+    let (time, rest) = rest.split_once("][")?;
+    let (source, rest) = rest.split_once("][")?;
+    let (level_raw, message) = rest.split_once("] ")?;
+    Some(LogEntry {
+        timestamp: format!("{} {}", date, time),
+        level: level_raw.trim().to_lowercase(),
+        source: source.to_string(),
+        message: message.to_string(),
+    })
+}
+
+pub fn read_log_file(last_n: usize) -> Vec<LogEntry> {
+    let Some(path) = get_log_path() else {
+        return Vec::new();
+    };
+    let Ok(file) = std::fs::File::open(&path) else {
+        return Vec::new();
+    };
+    let reader = BufReader::new(file);
+    let entries: Vec<LogEntry> = reader
+        .lines()
+        .filter_map(|line| line.ok())
+        .filter_map(|line| parse_log_line(&line))
+        .collect();
+
+    // Return only the last N entries
+    if entries.len() > last_n {
+        entries[entries.len() - last_n..].to_vec()
+    } else {
+        entries
+    }
+}
+
+pub fn clear_log_file() {
+    let Some(path) = get_log_path() else { return };
+    if let Ok(file) = std::fs::OpenOptions::new().write(true).open(&path) {
+        let _ = file.set_len(0);
+        let mut f = file;
+        let _ = f.seek(SeekFrom::Start(0));
+    }
+}
 
 pub fn push_log(level: &'static str, msg: String) {
-    // Forward to log crate (tauri-plugin-log picks this up → file + stdout + webview)
     match level {
         "error" => log::error!("{}", msg),
         "warn" => log::warn!("{}", msg),
         _ => log::info!("{}", msg),
     }
-
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let mut buf = LOG_BUFFER.lock().unwrap();
-    buf.push(LogEntry { timestamp, level, message: msg });
-    let len = buf.len();
-    if len > MAX_LOG_ENTRIES {
-        buf.drain(..len - MAX_LOG_ENTRIES);
-    }
-}
-
-pub fn get_all_logs() -> Vec<LogEntry> {
-    LOG_BUFFER.lock().unwrap().clone()
-}
-
-pub fn clear_logs() {
-    LOG_BUFFER.lock().unwrap().clear();
 }
 
 #[macro_export]

--- a/src-tauri/src/logger.rs
+++ b/src-tauri/src/logger.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -42,22 +42,34 @@ pub fn read_log_file(last_n: usize) -> Vec<LogEntry> {
     let Some(path) = get_log_path() else {
         return Vec::new();
     };
-    let Ok(file) = std::fs::File::open(&path) else {
+    let Ok(mut file) = std::fs::File::open(&path) else {
         return Vec::new();
     };
+    let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
+    if file_size == 0 {
+        return Vec::new();
+    }
+
+    // Read only the tail of the file — estimate ~256 bytes per log line.
+    // If we seek past the start, the first line is likely partial;
+    // parse_log_line returns None for it, so it's filtered automatically.
+    let chunk = (last_n as u64).saturating_mul(256).min(file_size);
+    if chunk < file_size {
+        let _ = file.seek(SeekFrom::Start(file_size - chunk));
+    }
+
     let reader = BufReader::new(file);
-    let entries: Vec<LogEntry> = reader
+    let mut entries: Vec<LogEntry> = reader
         .lines()
         .filter_map(|line| line.ok())
         .filter_map(|line| parse_log_line(&line))
         .collect();
 
-    // Return only the last N entries
-    if entries.len() > last_n {
-        entries[entries.len() - last_n..].to_vec()
-    } else {
-        entries
+    let drain = entries.len().saturating_sub(last_n);
+    if drain > 0 {
+        entries.drain(..drain);
     }
+    entries
 }
 
 pub fn clear_log_file() {

--- a/src/components/AnimationPreview.tsx
+++ b/src/components/AnimationPreview.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import "../styles/settings.css";
 
 interface AnimationPreviewProps {
@@ -18,6 +19,12 @@ interface AnimationPreviewProps {
 export function AnimationPreview({ spriteUrl, frames, label, onClose }: AnimationPreviewProps) {
   const size = 96;
   const duration = frames * 100; // slightly slower than mascot for easier viewing
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
 
   return (
     <div className="anim-preview-overlay" onClick={onClose} data-testid="animation-preview">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -18,6 +18,7 @@ import type { Status } from "../types/status";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { appDataDir, join, resourceDir } from "@tauri-apps/api/path";
 import { openPath } from "@tauri-apps/plugin-opener";
+import { open } from "@tauri-apps/plugin-dialog";
 import { error as logError } from "@tauri-apps/plugin-log";
 import "../styles/settings.css";
 
@@ -78,6 +79,7 @@ export function Settings() {
   const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, deleteMime, exportMime, importMime } = useCustomMimes();
   const [tab, setTab] = useState<Tab>("general");
   const [creating, setCreating] = useState<false | "manual" | "smart">(false);
+  const [smartImportPath, setSmartImportPath] = useState<string | null>(null);
   const [editingMime, setEditingMime] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
@@ -563,12 +565,14 @@ export function Settings() {
                 </div>
               ) : creating === "smart" ? (
                 <SmartImport
+                  initialFilePath={smartImportPath ?? undefined}
                   onSave={async (mimeName, blobs) => {
                     const id = await addMimeFromBlobs(mimeName, blobs);
                     setPet(id);
                     setCreating(false);
+                    setSmartImportPath(null);
                   }}
-                  onCancel={handleCancelCreate}
+                  onCancel={() => { handleCancelCreate(); setSmartImportPath(null); }}
                 />
               ) : (
                 <>
@@ -625,7 +629,15 @@ export function Settings() {
                       <div className="add-icon">+</div>
                       <span className="pet-name">Manual</span>
                     </button>
-                    <button className="pet-card add-card" onClick={() => setCreating("smart")}>
+                    <button className="pet-card add-card" onClick={async () => {
+                      const result = await open({
+                        multiple: false,
+                        filters: [{ name: "Sprite Sheet", extensions: ["png", "gif", "jpg", "jpeg"] }],
+                      });
+                      if (!result) return;
+                      setSmartImportPath(result);
+                      setCreating("smart");
+                    }}>
                       <div className="add-icon">*</div>
                       <span className="pet-name">Import Sheet</span>
                     </button>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -9,6 +9,7 @@ import { useNickname } from "../hooks/useNickname";
 import { useAutoStart } from "../hooks/useAutoStart";
 import { useAutoUpdate } from "../hooks/useAutoUpdate";
 import { useDockVisible } from "../hooks/useDockVisible";
+import { useTrayVisible } from "../hooks/useTrayVisible";
 import { mimeCategories, getMimesByCategory } from "../constants/sprites";
 import { useScale } from "../hooks/useScale";
 import { useCustomMimes, ALL_STATUSES } from "../hooks/useCustomMimes";
@@ -75,6 +76,7 @@ export function Settings() {
   const { enabled: autoStartEnabled, setEnabled: setAutoStartEnabled } = useAutoStart();
   const { enabled: autoUpdateEnabled, setEnabled: setAutoUpdateEnabled } = useAutoUpdate();
   const { hidden: dockHidden, setHidden: setDockHidden } = useDockVisible();
+  const { hidden: trayHidden, setHidden: setTrayHidden } = useTrayVisible();
   const { scale, setScale, SCALE_PRESETS } = useScale();
   const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, deleteMime, exportMime, importMime } = useCustomMimes();
   const [tab, setTab] = useState<Tab>("general");
@@ -381,6 +383,19 @@ export function Settings() {
                   className={`toggle-switch ${dockHidden ? "active" : ""}`}
                   onClick={() => setDockHidden(!dockHidden)}
                   data-testid="hide-dock-toggle"
+                >
+                  <span className="toggle-knob" />
+                </button>
+              </div>
+              <div className="settings-row with-hint">
+                <div>
+                  <span className="settings-row-label">Show in Menu Bar</span>
+                  <span className="settings-row-hint">Show the tray icon in the macOS menu bar for quick access.</span>
+                </div>
+                <button
+                  className={`toggle-switch ${!trayHidden ? "active" : ""}`}
+                  onClick={() => setTrayHidden(!trayHidden)}
+                  data-testid="show-tray-toggle"
                 >
                   <span className="toggle-knob" />
                 </button>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -617,6 +617,7 @@ export function Settings() {
                             className="delete-mime-btn"
                             onClick={(e) => { e.stopPropagation(); handleDeleteCustom(m.id); }}
                             title="Delete"
+                            data-testid={`delete-mime-${m.id}`}
                           >
                             x
                           </button>

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { info, error as logError } from "@tauri-apps/plugin-log";
@@ -18,6 +18,7 @@ import { AnimationPreview } from "./AnimationPreview";
 interface SmartImportProps {
   onSave: (name: string, blobs: Record<Status, { blob: Uint8Array; frames: number }>) => Promise<void>;
   onCancel: () => void;
+  initialFilePath?: string;
 }
 
 const STATUS_LABELS: Record<Status, string> = {
@@ -65,7 +66,7 @@ function parseFrameInput(input: string, maxFrame: number): number[] {
   return [...indices].sort((a, b) => a - b);
 }
 
-export function SmartImport({ onSave, onCancel }: SmartImportProps) {
+export function SmartImport({ onSave, onCancel, initialFilePath }: SmartImportProps) {
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
   const [frames, setFrames] = useState<Frame[]>([]);
   const [frameInputs, setFrameInputs] = useState<Record<Status, string>>(() => {
@@ -81,18 +82,12 @@ export function SmartImport({ onSave, onCancel }: SmartImportProps) {
   const [allFramePreviews, setAllFramePreviews] = useState<string[]>([]);
   const [animPreview, setAnimPreview] = useState<{ url: string; frames: number; label: string } | null>(null);
 
-  const handlePickSheet = useCallback(async () => {
+  const processFile = useCallback(async (filePath: string) => {
     setError(null);
     try {
-      const result = await open({
-        multiple: false,
-        filters: [{ name: "Sprite Sheet", extensions: ["png", "gif", "jpg", "jpeg"] }],
-      });
-      if (!result) return;
-
-      setFileName(result.split("/").pop() ?? "");
-      const bytes = await readFile(result);
-      const ext = result.split(".").pop()?.toLowerCase() ?? "png";
+      setFileName(filePath.split("/").pop() ?? "");
+      const bytes = await readFile(filePath);
+      const ext = filePath.split(".").pop()?.toLowerCase() ?? "png";
       const mime = ext === "gif" ? "image/gif" : ext === "jpg" || ext === "jpeg" ? "image/jpeg" : "image/png";
       const blob = new Blob([bytes], { type: mime });
       const src = URL.createObjectURL(blob);
@@ -123,14 +118,32 @@ export function SmartImport({ onSave, onCancel }: SmartImportProps) {
       setFrameInputs(autoInputs as Record<Status, string>);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to load image";
-      logError(`[smart-import] handlePickSheet failed: ${msg}`);
+      logError(`[smart-import] processFile failed: ${msg}`);
       setError(msg);
     }
   }, []);
 
-  const handlePreview = useCallback(async (status: Status) => {
+  const handlePickSheet = useCallback(async () => {
+    const result = await open({
+      multiple: false,
+      filters: [{ name: "Sprite Sheet", extensions: ["png", "gif", "jpg", "jpeg"] }],
+    });
+    if (!result) return;
+    await processFile(result);
+  }, [processFile]);
+
+  const didAutoLoad = useRef(false);
+  useEffect(() => {
+    if (initialFilePath && !didAutoLoad.current) {
+      didAutoLoad.current = true;
+      processFile(initialFilePath);
+    }
+  }, [initialFilePath, processFile]);
+
+  const handlePreview = useCallback(async (status: Status, inputValue?: string) => {
     if (!canvas || frames.length === 0) return;
-    const indices = parseFrameInput(frameInputs[status], frames.length);
+    const value = inputValue ?? frameInputs[status];
+    const indices = parseFrameInput(value, frames.length);
     if (indices.length === 0) return;
 
     const strip = await createStripFromFrames(canvas, frames, indices);
@@ -139,6 +152,8 @@ export function SmartImport({ onSave, onCancel }: SmartImportProps) {
     if (animPreview?.url) URL.revokeObjectURL(animPreview.url);
     setAnimPreview({ url, frames: strip.frames, label: STATUS_LABELS[status] });
   }, [canvas, frames, frameInputs, animPreview]);
+
+
 
   const handleShowAllFrames = useCallback(() => {
     if (!canvas || frames.length === 0) return;
@@ -249,14 +264,9 @@ export function SmartImport({ onSave, onCancel }: SmartImportProps) {
                       value={frameInputs[status]}
                       placeholder="1-5"
                       onChange={(e) => setFrameInputs((prev) => ({ ...prev, [status]: e.target.value }))}
-                      onKeyDown={(e) => { if (e.key === "Enter") handlePreview(status); }}
+                      onKeyDown={(e) => { if (e.key === "Enter") handlePreview(status, e.currentTarget.value); }}
+                      onBlur={(e) => handlePreview(status, e.currentTarget.value)}
                     />
-                    <button
-                      className="smart-import-preview-btn"
-                      onClick={() => handlePreview(status)}
-                    >
-                      Preview
-                    </button>
                   </div>
                 </div>
               </div>

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -81,11 +81,18 @@ export function SmartImport({ onSave, onCancel, initialFilePath }: SmartImportPr
   const [showModal, setShowModal] = useState(false);
   const [allFramePreviews, setAllFramePreviews] = useState<string[]>([]);
   const [animPreview, setAnimPreview] = useState<{ url: string; frames: number; label: string } | null>(null);
+  const [frameThumbs, setFrameThumbs] = useState<Record<Status, { src: string; num: number }[]>>(() => {
+    const init: Record<string, { src: string; num: number }[]> = {};
+    for (const s of ALL_STATUSES) init[s] = [];
+    return init as Record<Status, { src: string; num: number }[]>;
+  });
 
   const processFile = useCallback(async (filePath: string) => {
     setError(null);
     try {
-      setFileName(filePath.split("/").pop() ?? "");
+      const rawName = filePath.split("/").pop() ?? "";
+      setFileName(rawName);
+      setName(rawName.replace(/\.[^.]+$/, ""));
       const bytes = await readFile(filePath);
       const ext = filePath.split(".").pop()?.toLowerCase() ?? "png";
       const mime = ext === "gif" ? "image/gif" : ext === "jpg" || ext === "jpeg" ? "image/jpeg" : "image/png";
@@ -116,6 +123,14 @@ export function SmartImport({ onSave, onCancel, initialFilePath }: SmartImportPr
         autoInputs[ALL_STATUSES[si]] = `${start}-${end}`;
       }
       setFrameInputs(autoInputs as Record<Status, string>);
+
+      // Generate initial thumbnails for auto-assigned frames
+      const initThumbs: Record<string, { src: string; num: number }[]> = {};
+      for (const s of ALL_STATUSES) {
+        const indices = parseFrameInput(autoInputs[s], allFrames.length);
+        initThumbs[s] = indices.map((i) => ({ src: getFramePreview(prepared, allFrames[i], 72), num: i + 1 }));
+      }
+      setFrameThumbs(initThumbs as Record<Status, { src: string; num: number }[]>);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to load image";
       logError(`[smart-import] processFile failed: ${msg}`);
@@ -140,10 +155,19 @@ export function SmartImport({ onSave, onCancel, initialFilePath }: SmartImportPr
     }
   }, [initialFilePath, processFile]);
 
+  const updateThumbs = useCallback((status: Status, inputValue?: string) => {
+    if (!canvas || frames.length === 0) return;
+    const value = inputValue ?? frameInputs[status];
+    const indices = parseFrameInput(value, frames.length);
+    const previews = indices.map((i) => ({ src: getFramePreview(canvas, frames[i], 72), num: i + 1 }));
+    setFrameThumbs((prev) => ({ ...prev, [status]: previews }));
+  }, [canvas, frames, frameInputs]);
+
   const handlePreview = useCallback(async (status: Status, inputValue?: string) => {
     if (!canvas || frames.length === 0) return;
     const value = inputValue ?? frameInputs[status];
     const indices = parseFrameInput(value, frames.length);
+    updateThumbs(status, value);
     if (indices.length === 0) return;
 
     const strip = await createStripFromFrames(canvas, frames, indices);
@@ -151,7 +175,7 @@ export function SmartImport({ onSave, onCancel, initialFilePath }: SmartImportPr
     const url = URL.createObjectURL(blob);
     if (animPreview?.url) URL.revokeObjectURL(animPreview.url);
     setAnimPreview({ url, frames: strip.frames, label: STATUS_LABELS[status] });
-  }, [canvas, frames, frameInputs, animPreview]);
+  }, [canvas, frames, frameInputs, animPreview, updateThumbs]);
 
 
 
@@ -264,11 +288,21 @@ export function SmartImport({ onSave, onCancel, initialFilePath }: SmartImportPr
                       value={frameInputs[status]}
                       placeholder="1-5"
                       onChange={(e) => setFrameInputs((prev) => ({ ...prev, [status]: e.target.value }))}
-                      onKeyDown={(e) => { if (e.key === "Enter") handlePreview(status, e.currentTarget.value); }}
-                      onBlur={(e) => handlePreview(status, e.currentTarget.value)}
+                      onBlur={(e) => updateThumbs(status, e.currentTarget.value)}
                     />
+                    <button className="smart-import-preview-btn" onClick={() => handlePreview(status)}>Preview</button>
                   </div>
                 </div>
+                {frameThumbs[status]?.length > 0 && (
+                  <div className="smart-import-frame-previews">
+                    {frameThumbs[status].map((thumb, i) => (
+                      <div key={i} className="smart-import-frame-thumb-item">
+                        <img src={thumb.src} alt={`Frame ${thumb.num}`} className="smart-import-frame-thumb" />
+                        <span className="smart-import-frame-num">{thumb.num}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/src/components/SuperpowerTool.tsx
+++ b/src/components/SuperpowerTool.tsx
@@ -93,6 +93,10 @@ function LogViewer() {
     setLogs([]);
   };
 
+  const handleOpenDir = () => {
+    invoke("open_log_dir");
+  };
+
   const warnCount = logs.filter((l) => l.level === "warn").length;
   const errorCount = logs.filter((l) => l.level === "error").length;
 
@@ -108,19 +112,21 @@ function LogViewer() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-          <div className="log-filter-group">
-            {(["all", "info", "debug", "warn", "error"] as LogFilter[]).map((f) => (
-              <button
-                key={f}
-                className={`log-filter-btn ${filter === f ? "active" : ""} ${f === "warn" && warnCount > 0 ? "has-warn" : ""} ${f === "error" && errorCount > 0 ? "has-error" : ""}`}
-                onClick={() => setFilter(f)}
-              >
-                {f === "all" ? "All" : f === "info" ? "Info" : f === "debug" ? "Debug" : f === "warn" ? `Warn${warnCount > 0 ? ` (${warnCount})` : ""}` : `Error${errorCount > 0 ? ` (${errorCount})` : ""}`}
-              </button>
-            ))}
-          </div>
+          <select
+            className="log-filter-select"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value as LogFilter)}
+            data-testid="log-filter-select"
+          >
+            <option value="all">All</option>
+            <option value="info">Info</option>
+            <option value="debug">Debug</option>
+            <option value="warn">{`Warn${warnCount > 0 ? ` (${warnCount})` : ""}`}</option>
+            <option value="error">{`Error${errorCount > 0 ? ` (${errorCount})` : ""}`}</option>
+          </select>
           <span className="log-count">{filtered.length}/{logs.length}</span>
-          <button className="log-btn" onClick={handleClear}>Clear</button>
+          <button className="log-btn" onClick={handleOpenDir} data-testid="log-open-dir-btn">Reveal in Finder</button>
+          <button className="log-btn" onClick={handleClear} data-testid="log-clear-btn">Clear</button>
         </div>
       </div>
       <div

--- a/src/components/SuperpowerTool.tsx
+++ b/src/components/SuperpowerTool.tsx
@@ -6,17 +6,18 @@ import "../styles/theme.css";
 import "../styles/superpower.css";
 
 interface LogEntry {
-  timestamp: number;
+  timestamp: string;
   level: string;
+  source: string;
   message: string;
 }
 
-type LogFilter = "all" | "info" | "warn" | "error";
+type LogFilter = "all" | "info" | "debug" | "warn" | "error";
 type MenuItem = "logs" | "scenarios";
 
-function formatTime(timestamp: number): string {
-  const date = new Date(timestamp * 1000);
-  return date.toLocaleTimeString("en-US", { hour12: false });
+function formatTime(timestamp: string): string {
+  const parts = timestamp.split(" ");
+  return parts.length > 1 ? parts[1] : timestamp;
 }
 
 const tagColorMap: Record<string, string> = {
@@ -40,10 +41,11 @@ function LogLevel({ level }: { level: string }) {
   return <span className={`log-level log-level-${level}`}>{level.toUpperCase()}</span>;
 }
 
-function parseLogTag(message: string): { tag: string; rest: string } {
+function parseLogTag(message: string, source: string): { tag: string; rest: string } {
   const match = message.match(/^\[(\w+)]\s*(.*)/);
   if (match) return { tag: match[1], rest: match[2] };
-  return { tag: "", rest: message };
+  const modName = source.split("::").pop() || source;
+  return { tag: modName, rest: message };
 }
 
 function LogViewer() {
@@ -107,13 +109,13 @@ function LogViewer() {
             onChange={(e) => setSearch(e.target.value)}
           />
           <div className="log-filter-group">
-            {(["all", "info", "warn", "error"] as LogFilter[]).map((f) => (
+            {(["all", "info", "debug", "warn", "error"] as LogFilter[]).map((f) => (
               <button
                 key={f}
                 className={`log-filter-btn ${filter === f ? "active" : ""} ${f === "warn" && warnCount > 0 ? "has-warn" : ""} ${f === "error" && errorCount > 0 ? "has-error" : ""}`}
                 onClick={() => setFilter(f)}
               >
-                {f === "all" ? "All" : f === "info" ? "Info" : f === "warn" ? `Warn${warnCount > 0 ? ` (${warnCount})` : ""}` : `Error${errorCount > 0 ? ` (${errorCount})` : ""}`}
+                {f === "all" ? "All" : f === "info" ? "Info" : f === "debug" ? "Debug" : f === "warn" ? `Warn${warnCount > 0 ? ` (${warnCount})` : ""}` : `Error${errorCount > 0 ? ` (${errorCount})` : ""}`}
               </button>
             ))}
           </div>
@@ -134,7 +136,7 @@ function LogViewer() {
           </div>
         )}
         {filtered.map((entry, i) => {
-          const { tag, rest } = parseLogTag(entry.message);
+          const { tag, rest } = parseLogTag(entry.message, entry.source);
           return (
             <div key={i} className={`log-entry log-entry-${entry.level}`}>
               <span className="log-time">{formatTime(entry.timestamp)}</span>

--- a/src/hooks/useTrayVisible.ts
+++ b/src/hooks/useTrayVisible.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect, useLayoutEffect } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { invoke } from "@tauri-apps/api/core";
+import { emit, listen } from "@tauri-apps/api/event";
+
+export function useTrayVisible() {
+  const [hidden, setHiddenState] = useState(false);
+
+  useLayoutEffect(() => {
+    load("settings.json").then(async (store) => {
+      const val = await store.get<boolean>("hideTray");
+      if (val !== null && val !== undefined) {
+        setHiddenState(val);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>("hide-tray-changed", (event) => {
+      setHiddenState(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const setHidden = async (next: boolean) => {
+    const store = await load("settings.json");
+    await store.set("hideTray", next);
+    await store.save();
+    await invoke("set_tray_visible", { visible: !next });
+    setHiddenState(next);
+    await emit("hide-tray-changed", next);
+  };
+
+  return { hidden, setHidden };
+}

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -772,6 +772,35 @@
   background: rgba(94, 92, 230, 0.3);
 }
 
+.smart-import-frame-previews {
+  display: flex;
+  gap: 3px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.smart-import-frame-thumb-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.smart-import-frame-thumb {
+  width: 36px;
+  height: 36px;
+  image-rendering: pixelated;
+  object-fit: contain;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.smart-import-frame-num {
+  font-size: 9px;
+  color: #8e8e93;
+  font-family: monospace;
+}
+
 /* All Frames Modal */
 .smart-import-modal-overlay {
   position: fixed;

--- a/src/styles/superpower.css
+++ b/src/styles/superpower.css
@@ -178,45 +178,32 @@
   opacity: 0.4;
 }
 
-.log-filter-group {
-  display: flex;
-  border-radius: 5px;
-  overflow: hidden;
-  border: 1px solid rgba(128, 128, 128, 0.3);
-}
-
-.log-filter-btn {
-  padding: 3px 8px;
-  font-size: 10px;
+.log-filter-select {
+  padding: 3px 6px;
+  font-size: 11px;
   font-weight: 500;
   font-family: inherit;
-  border: none;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 5px;
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
-  opacity: 0.5;
-  transition: background 0.15s, opacity 0.15s;
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='8' height='5' viewBox='0 0 8 5' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l3 3 3-3' stroke='%23888' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  padding-right: 20px;
 }
 
-.log-filter-btn:not(:last-child) {
-  border-right: 1px solid rgba(128, 128, 128, 0.2);
+.log-filter-select:hover {
+  background-color: rgba(128, 128, 128, 0.1);
 }
 
-.log-filter-btn:hover {
-  opacity: 0.8;
-}
-
-.log-filter-btn.active {
-  opacity: 1;
-  background: rgba(128, 128, 128, 0.15);
-}
-
-.log-filter-btn.has-warn {
-  color: #ff9f0a;
-}
-
-.log-filter-btn.has-error {
-  color: #ff3b30;
+.log-filter-select option {
+  background: var(--bg-primary, #1c1c1e);
+  color: var(--text-primary);
 }
 
 .log-count {
@@ -572,12 +559,6 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 8px;
-}
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 16px;
 }
 
 .bubble-test-row {

--- a/src/styles/superpower.css
+++ b/src/styles/superpower.css
@@ -289,6 +289,15 @@
   background: rgba(255, 59, 48, 0.12);
 }
 
+.log-entry-debug {
+  opacity: 0.6;
+}
+
+.log-level-debug {
+  color: #636366;
+  background: rgba(99, 99, 102, 0.15);
+}
+
 .log-time {
   color: var(--text-primary);
   opacity: 0.35;


### PR DESCRIPTION
## Summary
- Add **Reveal in Finder** button to the log toolbar — opens `~/Library/Logs/<bundle-id>/` in Finder via a new `open_log_dir` Tauri command
- Replace log level filter button group with a compact **dropdown select**
- Fix pre-existing orphaned CSS block that caused a PostCSS parse error at build time

## Test plan
- [ ] Open Superpower Tool → Logs tab
- [ ] Click "Reveal in Finder" → Finder opens the log directory
- [ ] Use the filter dropdown to switch between All / Info / Debug / Warn / Error
- [ ] Verify warn/error counts show in the dropdown options
- [ ] Verify Clear button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)