### PR TITLE
chore: release v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.15.3] - 2026-04-13
+
+### Added
+- **Log file reader** — replace in-memory log buffer with log file tail-reader; LogViewer updated for file-based format with source and debug level
+- **SmartImport UX improvements** — direct file picker, auto-preview on blur, frame thumbnails with numbered overlays
+- **Reveal in Finder** button in Superpower log toolbar to open the log directory
+- **Show in Menu Bar** toggle in Settings to control tray icon visibility
+
+### Changed
+- Log level filter buttons replaced with compact dropdown select in Superpower toolbar
+
+### Performance
+- Tail-read log file instead of loading entirely — seeks to end and reads only the last N x 256 bytes
+
+### Fixed
+- Orphaned CSS block in `superpower.css` causing PostCSS parse error
+
+### Tests
+- SmartImport Charlotte flow with frame selection (e2e)
+- Charlotte export with real sprite fixtures (e2e)
+- Delete and re-import Charlotte via `.animime` file (e2e)
+- Window auto-resize to fit sprite content (e2e)
+- Split delete and import mime into separate tests (e2e)
+
+### Docs
+- Add e2e run guidance and tauri mock reference to CLAUDE.md
+
 ## [0.15.2] - 2026-04-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.15.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.15.2"
+version = "0.15.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -688,7 +688,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.15.2{devMode && " (Dev Mode)"}
+                  Version 0.15.3{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
Bump version to 0.15.3 and update CHANGELOG.

### Highlights
- **Log file reader** — replace in-memory buffer with tail-read from disk
- **SmartImport UX** — direct file picker, auto-preview, frame thumbnails
- **Reveal in Finder** button in Superpower log toolbar
- **Show in Menu Bar** toggle for tray icon visibility
- **Log filter dropdown** replaces button group
- **Performance** — tail-read seeks to end, reads only last N x 256 bytes
- **5 new e2e tests** for SmartImport, export, delete/reimport, window resize

See [CHANGELOG.md](CHANGELOG.md) for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)