### PR TITLE
Refactor log reader + SmartImport UX + grid-based sprite rendering

### DIFF
--- a/scripts/repack_grid.py
+++ b/scripts/repack_grid.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Repack a horizontal sprite strip into a 2D grid that fits inside texture limits.
+
+WebKit (Tauri's macOS webview) downsamples textures wider than ~8192px, which
+breaks pixel-aligned frame stepping. This script slices a wide strip into
+fixed-size frames and re-lays them out in a cols×rows grid.
+
+Usage:
+    python3 scripts/repack_grid.py <input.png> <frames> [--frame-size 128]
+                                   [--max-width 4096] [--out <path>]
+
+If --out is omitted, the input file is overwritten (a .bak is created first).
+"""
+
+import argparse, math, os, shutil, sys
+from PIL import Image
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("input", help="Path to wide sprite strip PNG")
+    ap.add_argument("frames", type=int, help="Number of frames in the strip")
+    ap.add_argument("--frame-size", type=int, default=128, help="Frame width/height in pixels (default: 128)")
+    ap.add_argument("--max-width", type=int, default=4096, help="Max output width in pixels (default: 4096)")
+    ap.add_argument("--out", help="Output path (default: overwrite input with .bak backup)")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.input):
+        print(f"Error: {args.input} not found", file=sys.stderr); sys.exit(1)
+
+    img = Image.open(args.input).convert("RGBA")
+    fs = args.frame_size
+    n = args.frames
+
+    if img.width != n * fs or img.height != fs:
+        print(f"Warning: expected {n*fs}x{fs}, got {img.width}x{img.height}. Continuing anyway.", file=sys.stderr)
+
+    cols = max(1, args.max_width // fs)
+    rows = math.ceil(n / cols)
+    print(f"input:  {img.width}x{img.height} ({n} frames at {fs}px)")
+    print(f"output: {cols * fs}x{rows * fs} ({cols} cols × {rows} rows)")
+
+    out = Image.new("RGBA", (cols * fs, rows * fs), (0, 0, 0, 0))
+    for i in range(n):
+        sx = i * fs
+        crop = img.crop((sx, 0, sx + fs, fs))
+        dx, dy = (i % cols) * fs, (i // cols) * fs
+        out.paste(crop, (dx, dy))
+
+    dest = args.out or args.input
+    if not args.out:
+        bak = args.input + ".bak"
+        if not os.path.exists(bak):
+            shutil.copy(args.input, bak)
+            print(f"backup: {bak}")
+    out.save(dest)
+    print(f"wrote:  {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__tests__/components/Mascot.test.tsx
+++ b/src/__tests__/components/Mascot.test.tsx
@@ -55,11 +55,11 @@ describe("Mascot", () => {
     expect(sprite).not.toHaveClass("frozen");
   });
 
-  it("sets CSS custom properties for sprite animation", () => {
+  it("sets backgroundSize to the full sheet (frames × frame size) before image loads", () => {
     const { container } = render(<Mascot status="idle" />);
     const sprite = container.querySelector(".sprite") as HTMLElement;
-    // The idle rottweiler has 8 frames
-    expect(sprite.style.getPropertyValue("--sprite-steps")).toBe("8");
+    // The idle rottweiler has 8 frames at 128px — fallback before naturalWidth is known
+    expect(sprite.style.backgroundSize).toBe("1024px 128px");
   });
 
   describe("auto-freeze timer", () => {

--- a/src/components/AnimationPreview.tsx
+++ b/src/components/AnimationPreview.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import "../styles/settings.css";
 
 interface AnimationPreviewProps {
-  /** Object URL or data URL of the sprite strip */
+  /** Object URL or data URL of the sprite sheet */
   spriteUrl: string;
-  /** Number of frames in the strip */
+  /** Number of frames in the sheet */
   frames: number;
   /** Label shown in the header */
   label: string;
@@ -12,19 +12,75 @@ interface AnimationPreviewProps {
   onClose: () => void;
 }
 
+const FRAME_DURATION_MS = 100; // slightly slower than mascot for easier viewing
+const CANDIDATE_FRAME_SIZES = [128, 96, 64, 48, 32, 16];
+
+function inferGrid(w: number, h: number, frames: number) {
+  for (const fp of CANDIDATE_FRAME_SIZES) {
+    if (w % fp === 0 && h % fp === 0) {
+      const cols = w / fp;
+      const rows = h / fp;
+      if (cols * rows >= frames) return { framePx: fp, cols, rows };
+    }
+  }
+  return { framePx: h, cols: Math.max(1, Math.round(w / Math.max(1, h))), rows: 1 };
+}
+
 /**
- * Mini popup overlay that plays a sprite-strip animation,
- * using the same CSS stepping technique as the Mascot component.
+ * Mini popup overlay that plays a sprite-sheet animation. Drives frames via
+ * rAF and reads the source sheet's dimensions to handle both flat strips and
+ * 2D grids — same approach as the Mascot component.
  */
 export function AnimationPreview({ spriteUrl, frames, label, onClose }: AnimationPreviewProps) {
   const size = 96;
-  const duration = frames * 100; // slightly slower than mascot for easier viewing
+  const spriteRef = useRef<HTMLDivElement>(null);
+  const [sheetDims, setSheetDims] = useState<{ w: number; h: number } | null>(null);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [onClose]);
+
+  useEffect(() => {
+    setSheetDims(null);
+    if (!spriteUrl) return;
+    let cancelled = false;
+    const img = new Image();
+    img.onload = () => {
+      if (!cancelled) setSheetDims({ w: img.naturalWidth, h: img.naturalHeight });
+    };
+    img.src = spriteUrl;
+    return () => { cancelled = true; };
+  }, [spriteUrl]);
+
+  const layout = sheetDims ? inferGrid(sheetDims.w, sheetDims.h, frames) : null;
+
+  useEffect(() => {
+    const el = spriteRef.current;
+    if (!el || !layout || frames < 1) return;
+    const { cols } = layout;
+    let raf = 0, frame = 0, last = performance.now();
+    const setPos = (idx: number) => {
+      const sx = (idx % cols) * size;
+      const sy = Math.floor(idx / cols) * size;
+      el.style.backgroundPosition = `-${sx}px -${sy}px`;
+    };
+    setPos(0);
+    const tick = (t: number) => {
+      if (t - last >= FRAME_DURATION_MS) {
+        frame = (frame + 1) % frames;
+        setPos(frame);
+        last = t;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [layout, frames, size]);
+
+  const sheetWidth = layout ? layout.cols * size : frames * size;
+  const sheetHeight = layout ? layout.rows * size : size;
 
   return (
     <div className="anim-preview-overlay" onClick={onClose} data-testid="animation-preview">
@@ -36,17 +92,15 @@ export function AnimationPreview({ spriteUrl, frames, label, onClose }: Animatio
         </div>
         <div className="anim-preview-body">
           <div
+            ref={spriteRef}
             data-testid="anim-preview-sprite"
             className="anim-preview-sprite"
             style={{
               backgroundImage: `url(${spriteUrl})`,
               width: size,
               height: size,
-              "--sprite-steps": frames,
-              "--sprite-width": `${frames * size}px`,
-              "--sprite-height": `${size}px`,
-              "--sprite-duration": `${duration}ms`,
-            } as React.CSSProperties}
+              backgroundSize: `${sheetWidth}px ${sheetHeight}px`,
+            }}
           />
         </div>
       </div>

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -14,6 +14,26 @@ interface MascotProps {
   status: Status;
 }
 
+const FRAME_BASE_PX = 128;
+const FRAME_DURATION_MS = 80;
+const CANDIDATE_FRAME_SIZES = [128, 96, 64, 48, 32, 16];
+
+/** Infer the source frame size + grid layout from sheet dims and frame count.
+ * Built-in pets use 64px cells in flat strips; custom mimes use 128px in grids
+ * up to 4096px wide. Picks the largest frame size that divides both axes
+ * cleanly and gives enough cells for `frames`. */
+function inferGrid(w: number, h: number, frames: number) {
+  for (const fp of CANDIDATE_FRAME_SIZES) {
+    if (w % fp === 0 && h % fp === 0) {
+      const cols = w / fp;
+      const rows = h / fp;
+      if (cols * rows >= frames) return { framePx: fp, cols, rows };
+    }
+  }
+  // Fallback: treat as a flat strip
+  return { framePx: h, cols: Math.max(1, Math.round(w / Math.max(1, h))), rows: 1 };
+}
+
 export function Mascot({ status }: MascotProps) {
   const { pet } = usePet();
   const { mode: glowMode } = useGlow();
@@ -21,7 +41,9 @@ export function Mascot({ status }: MascotProps) {
   const { mimes } = useCustomMimes();
   const [frozen, setFrozen] = useState(false);
   const [customSpriteUrl, setCustomSpriteUrl] = useState<string | null>(null);
+  const [sheetDims, setSheetDims] = useState<{ w: number; h: number } | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const spriteRef = useRef<HTMLDivElement>(null);
 
   const isCustom = pet.startsWith("custom-");
   const customMime = isCustom ? mimes.find((m) => m.id === pet) : null;
@@ -82,25 +104,76 @@ export function Mascot({ status }: MascotProps) {
     ).href;
   }
 
-  const frameSize = 128 * scale;
-  const lastFrameOffset = (frames - 1) * frameSize;
+  const frameSize = FRAME_BASE_PX * scale;
+
+  // Read sheet dimensions when URL changes (needed to compute grid layout)
+  useEffect(() => {
+    setSheetDims(null);
+    if (!spriteUrl) return;
+    let cancelled = false;
+    const img = new Image();
+    img.onload = () => {
+      if (!cancelled) setSheetDims({ w: img.naturalWidth, h: img.naturalHeight });
+    };
+    img.src = spriteUrl;
+    return () => { cancelled = true; };
+  }, [spriteUrl]);
+
+  // Drive frame animation via rAF; supports 1×N strips and M×N grids,
+  // and any source frame size (built-ins are 64px, custom packer uses 128px).
+  // Using JS instead of CSS steps() avoids the WebKit ~8192px texture limit.
+  const layout = sheetDims ? inferGrid(sheetDims.w, sheetDims.h, frames) : null;
+
+  useEffect(() => {
+    const el = spriteRef.current;
+    if (!el || !layout || frames < 1) return;
+
+    const { cols } = layout;
+    const lastIdx = Math.max(0, frames - 1);
+
+    const setPos = (idx: number) => {
+      const sx = (idx % cols) * frameSize;
+      const sy = Math.floor(idx / cols) * frameSize;
+      el.style.backgroundPosition = `-${sx}px -${sy}px`;
+    };
+
+    if (frozen) {
+      setPos(lastIdx);
+      return;
+    }
+
+    let raf = 0, frame = 0, last = performance.now();
+    setPos(0);
+    const tick = (t: number) => {
+      if (t - last >= FRAME_DURATION_MS) {
+        frame = (frame + 1) % frames;
+        setPos(frame);
+        last = t;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [layout, frames, frameSize, frozen]);
 
   if (isCustom && !customSpriteUrl) return null;
 
+  // Display each source cell at frameSize (128 * scale). Background is scaled
+  // up from its native frame_px (64 or 128) to that display size.
+  const sheetWidth = layout ? layout.cols * frameSize : frames * frameSize;
+  const sheetHeight = layout ? layout.rows * frameSize : frameSize;
+
   return (
     <div
+      ref={spriteRef}
       data-testid="mascot-sprite"
       className={`sprite ${frozen ? "frozen" : ""} ${glowMode !== "off" ? `glow-${glowMode}` : ""}`}
       style={{
         backgroundImage: `url(${spriteUrl})`,
         width: frameSize,
         height: frameSize,
-        "--sprite-steps": frames,
-        "--sprite-width": `${frames * frameSize}px`,
-        "--sprite-height": `${frameSize}px`,
-        "--sprite-duration": `${frames * 80}ms`,
-        ...(frozen ? { backgroundPosition: `-${lastFrameOffset}px 0` } : {}),
-      } as React.CSSProperties}
+        backgroundSize: `${sheetWidth}px ${sheetHeight}px`,
+      }}
     />
   );
 }

--- a/src/styles/mascot.css
+++ b/src/styles/mascot.css
@@ -1,11 +1,9 @@
-/* --- Sprite animation --- */
+/* --- Sprite (animation driven by JS rAF in Mascot.tsx) --- */
 .sprite {
   margin-bottom: 4px;
   align-self: center;
   image-rendering: pixelated;
   background-repeat: no-repeat;
-  background-size: var(--sprite-width) var(--sprite-height);
-  animation: sprite-play var(--sprite-duration) steps(var(--sprite-steps), end) infinite;
   filter: none;
 }
 
@@ -15,13 +13,4 @@
 
 .sprite.glow-dark {
   filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.8)) drop-shadow(0 0 8px rgba(0, 0, 0, 0.5));
-}
-
-.sprite.frozen {
-  animation: none;
-}
-
-@keyframes sprite-play {
-  from { background-position: 0 0; }
-  to { background-position: calc(-1 * var(--sprite-width)) 0; }
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -946,14 +946,8 @@
   background: repeating-conic-gradient(rgba(0,0,0,0.04) 0% 25%, transparent 0% 50%) 50% / 16px 16px;
 }
 
+/* Animation driven by JS rAF in AnimationPreview.tsx */
 .anim-preview-sprite {
   image-rendering: pixelated;
   background-repeat: no-repeat;
-  background-size: var(--sprite-width) var(--sprite-height);
-  animation: anim-preview-play var(--sprite-duration) steps(var(--sprite-steps), end) infinite;
-}
-
-@keyframes anim-preview-play {
-  from { background-position: 0 0; }
-  to { background-position: calc(-1 * var(--sprite-width)) 0; }
 }

--- a/src/utils/spriteSheetProcessor.ts
+++ b/src/utils/spriteSheetProcessor.ts
@@ -1,4 +1,13 @@
 const FRAME_SIZE = 128;
+// WebKit downsamples textures wider than ~8192px, breaking pixel-aligned frame
+// stepping. Cap each row at 4096px (32 frames) and wrap into a 2D grid.
+const MAX_SHEET_WIDTH = 4096;
+
+function gridLayout(frameCount: number) {
+  const cols = Math.max(1, Math.floor(MAX_SHEET_WIDTH / FRAME_SIZE));
+  const rows = Math.max(1, Math.ceil(frameCount / cols));
+  return { cols, rows, width: cols * FRAME_SIZE, height: rows * FRAME_SIZE };
+}
 const BG_TOLERANCE = 30;
 const ALPHA_THRESHOLD = 10;
 const MIN_GAP = 5;
@@ -280,9 +289,10 @@ export async function createStripFromFrames(
     throw new Error("No frames selected");
   }
 
+  const { cols, width, height } = gridLayout(selected.length);
   const stripCanvas = document.createElement("canvas");
-  stripCanvas.width = FRAME_SIZE * selected.length;
-  stripCanvas.height = FRAME_SIZE;
+  stripCanvas.width = width;
+  stripCanvas.height = height;
   const stripCtx = stripCanvas.getContext("2d")!;
   stripCtx.imageSmoothingEnabled = false;
 
@@ -301,11 +311,13 @@ export async function createStripFromFrames(
     const scaledH = Math.round(cropH * scale);
     const ox = Math.round((FRAME_SIZE - scaledW) / 2);
     const oy = Math.round((FRAME_SIZE - scaledH) / 2);
+    const cellX = (i % cols) * FRAME_SIZE;
+    const cellY = Math.floor(i / cols) * FRAME_SIZE;
 
     stripCtx.drawImage(
       canvas,
       f.x1 + bbox.x1, f.y1 + bbox.y1, cropW, cropH,
-      i * FRAME_SIZE + ox, oy, scaledW, scaledH
+      cellX + ox, cellY + oy, scaledW, scaledH
     );
   }
 
@@ -332,10 +344,11 @@ export async function createStrip(
     throw new Error("No sprites found in selected rows");
   }
 
-  // Create output strip canvas
+  // Create output sheet canvas (grid layout to stay under WebKit texture limit)
+  const { cols, width, height } = gridLayout(sprites.length);
   const stripCanvas = document.createElement("canvas");
-  stripCanvas.width = FRAME_SIZE * sprites.length;
-  stripCanvas.height = FRAME_SIZE;
+  stripCanvas.width = width;
+  stripCanvas.height = height;
   const stripCtx = stripCanvas.getContext("2d")!;
   stripCtx.imageSmoothingEnabled = false; // pixelated scaling
 
@@ -356,12 +369,14 @@ export async function createStrip(
     const scaledH = Math.round(cropH * scale);
     const ox = Math.round((FRAME_SIZE - scaledW) / 2);
     const oy = Math.round((FRAME_SIZE - scaledH) / 2);
+    const cellX = (i % cols) * FRAME_SIZE;
+    const cellY = Math.floor(i / cols) * FRAME_SIZE;
 
-    // Draw the cropped sprite scaled into the frame
+    // Draw the cropped sprite scaled into the cell
     stripCtx.drawImage(
       canvas,
       s.x1 + bbox.x1, s.y1 + bbox.y1, cropW, cropH,
-      i * FRAME_SIZE + ox, oy, scaledW, scaledH
+      cellX + ox, cellY + oy, scaledW, scaledH
     );
   }
 


### PR DESCRIPTION
## Summary

Three related refactors that landed together on this branch:

### 1. File-based log reader
- Replace the in-memory log ring buffer with a tail-read off `ani-mime.log` (the file `tauri-plugin-log` already writes).
- `logger.rs` seeks to the end of the file and reads only the last ~N×256 bytes — never loads the full log.
- `LogViewer` / `SuperpowerTool` updated for the new file-based format (source + level), with debug-level styling.

### 2. SmartImport UX
- Open the file picker directly instead of a landing page.
- Auto-preview on blur; show frame thumbnails for each status row; "Show all frames" modal.
- Save button is always enabled (validation happens on click); clearer error surface.
- Keep export/import of `.animime` files roundtripping cleanly.

### 3. Sprite animation via rAF + 2D grid sheets
WebKit (Tauri's macOS webview) downsamples textures wider than ~8192px, which broke pixel-aligned stepping for mimes with many frames. This branch:
- Switches `Mascot` and `AnimationPreview` from CSS `steps()` to a `requestAnimationFrame` loop that walks a 2D grid.
- Caps generated sheets at 4096px wide; `spriteSheetProcessor` emits `cols × rows` grids via a shared `gridLayout` helper.
- Both 64px built-in strips and 128px custom-packer grids animate correctly because layout is inferred from `naturalWidth/Height`.
- `scripts/repack_grid.py` repacks existing wide strip PNGs into grids.

## Test plan
- [ ] `npx tsc --noEmit` — frontend typecheck clean
- [ ] `cd src-tauri && cargo check` — backend typecheck clean
- [ ] `bun run test` — unit tests pass (`Mascot.test.tsx` updated for new sheet-size assertion)
- [ ] `bunx playwright test -c e2e/playwright.config.ts --project=chromium` — e2e pass (Charlotte import/export/delete, window auto-resize)
- [ ] Manual: drag a >32-frame custom mime, confirm animation plays smoothly with no texture blurring
- [ ] Manual: open Superpower tool, confirm log lines tail live and debug lines are styled