### PR TITLE
feat: add shadow clone animation on busy transition

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,11 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-set-size",
+    "core:window:allow-set-position",
+    "core:window:allow-set-shadow",
+    "core:window:allow-outer-position",
+    "core:window:allow-outer-size",
+    "core:window:allow-scale-factor",
     "core:event:default",
     "opener:default",
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,9 @@ import { usePet } from "./hooks/usePet";
 import { useScale } from "./hooks/useScale";
 import { useDevMode } from "./hooks/useDevMode";
 import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
-import { useRef } from "react";
+import { useRef, useState, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow, LogicalSize, LogicalPosition } from "@tauri-apps/api/window";
 import { Menu, MenuItem } from "@tauri-apps/api/menu";
 import "./styles/theme.css";
 import "./styles/app.css";
@@ -31,8 +32,50 @@ function App() {
   const { scale } = useScale();
   const devMode = useDevMode();
   const containerRef = useRef<HTMLDivElement>(null);
+  const [cloneActive, setCloneActive] = useState(false);
+  const savedWindowRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
   useTheme();
-  useWindowAutoSize(containerRef);
+  useWindowAutoSize(containerRef, cloneActive);
+
+  const handleCloneEffectChange = useCallback(async (active: boolean) => {
+    try {
+      const win = getCurrentWindow();
+
+      if (active) {
+        setCloneActive(true);
+
+        const factor = await win.scaleFactor();
+        const physPos = await win.outerPosition();
+        const physSize = await win.outerSize();
+
+        const logX = physPos.x / factor;
+        const logY = physPos.y / factor;
+        const logW = physSize.width / factor;
+        const logH = physSize.height / factor;
+
+        savedWindowRef.current = { x: logX, y: logY, w: logW, h: logH };
+
+        const expandedSize = 1200;
+        const shiftX = (expandedSize - logW) / 2;
+        const shiftY = (expandedSize - logH) / 2;
+
+        await win.setShadow(false);
+        await win.setPosition(new LogicalPosition(logX - shiftX, logY - shiftY));
+        await win.setSize(new LogicalSize(expandedSize, expandedSize));
+      } else {
+        if (savedWindowRef.current) {
+          const { x, y, w, h } = savedWindowRef.current;
+          await win.setPosition(new LogicalPosition(x, y));
+          await win.setSize(new LogicalSize(w, h));
+          await win.setShadow(true);
+          savedWindowRef.current = null;
+        }
+        setCloneActive(false);
+      }
+    } catch (err) {
+      console.error("[clone] error:", err);
+    }
+  }, []);
 
   const onContextMenu = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -78,13 +121,13 @@ function App() {
     <div
       ref={containerRef}
       data-testid="app-container"
-      className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""}`}
+      className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${devMode ? "dev-border" : ""}`}
       onMouseDown={onMouseDown}
       onContextMenu={onContextMenu}
     >
       {scenario && <div data-testid="scenario-badge" className="scenario-badge">SCENARIO</div>}
       <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
-      {status !== "visiting" && <Mascot status={status} />}
+      {status !== "visiting" && <Mascot status={status} onCloneEffectChange={handleCloneEffectChange} />}
       {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
       <StatusPill status={status} glow={visible} />
       {devMode && <DevTag />}

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -5,13 +5,18 @@ import { usePet } from "../hooks/usePet";
 import { useGlow } from "../hooks/useGlow";
 import { useScale } from "../hooks/useScale";
 import { useCustomMimes } from "../hooks/useCustomMimes";
+import { ShadowCloneEffect } from "./ShadowCloneEffect";
+import { useShadowClone } from "../hooks/useShadowClone";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { error as logError } from "@tauri-apps/plugin-log";
 import "../styles/mascot.css";
 
+const CLONE_DURATION_MS = 2000;
+
 interface MascotProps {
   status: Status;
+  onCloneEffectChange?: (active: boolean) => void;
 }
 
 const FRAME_BASE_PX = 128;
@@ -34,19 +39,47 @@ function inferGrid(w: number, h: number, frames: number) {
   return { framePx: h, cols: Math.max(1, Math.round(w / Math.max(1, h))), rows: 1 };
 }
 
-export function Mascot({ status }: MascotProps) {
+export function Mascot({ status, onCloneEffectChange }: MascotProps) {
   const { pet } = usePet();
   const { mode: glowMode } = useGlow();
   const { scale } = useScale();
   const { mimes } = useCustomMimes();
+  const { enabled: shadowCloneEnabled } = useShadowClone();
   const [frozen, setFrozen] = useState(false);
   const [customSpriteUrl, setCustomSpriteUrl] = useState<string | null>(null);
   const [sheetDims, setSheetDims] = useState<{ w: number; h: number } | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const spriteRef = useRef<HTMLDivElement>(null);
 
+  // Shadow clone state
+  const [cloneActive, setCloneActive] = useState(false);
+  const prevStatusRef = useRef(status);
+  const cloneTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
   const isCustom = pet.startsWith("custom-");
   const customMime = isCustom ? mimes.find((m) => m.id === pet) : null;
+
+  // Detect transition to busy — trigger shadow clone effect
+  useEffect(() => {
+    const prevStatus = prevStatusRef.current;
+    prevStatusRef.current = status;
+
+    if (status === "busy" && prevStatus !== "busy" && shadowCloneEnabled) {
+      setCloneActive(true);
+      onCloneEffectChange?.(true);
+
+      cloneTimerRef.current = setTimeout(() => {
+        setCloneActive(false);
+        onCloneEffectChange?.(false);
+      }, CLONE_DURATION_MS);
+    } else if (status !== "busy" && cloneActive) {
+      clearTimeout(cloneTimerRef.current);
+      setCloneActive(false);
+      onCloneEffectChange?.(false);
+    }
+
+    return () => clearTimeout(cloneTimerRef.current);
+  }, [status]);
 
   useEffect(() => {
     clearTimeout(timerRef.current);
@@ -156,6 +189,19 @@ export function Mascot({ status }: MascotProps) {
     return () => cancelAnimationFrame(raf);
   }, [layout, frames, frameSize, frozen]);
 
+  // Resolve busy sprite for shadow clones (clones use the working sprite)
+  let busySpriteUrl = spriteUrl;
+  let busyFrames = frames;
+  if (cloneActive && !isCustom) {
+    const spriteMap = getSpriteMap(pet);
+    const busySprite = spriteMap["busy"];
+    busyFrames = busySprite.frames;
+    busySpriteUrl = new URL(
+      `../assets/sprites/${busySprite.file}`,
+      import.meta.url
+    ).href;
+  }
+
   if (isCustom && !customSpriteUrl) return null;
 
   // Display each source cell at frameSize (128 * scale). Background is scaled
@@ -164,16 +210,25 @@ export function Mascot({ status }: MascotProps) {
   const sheetHeight = layout ? layout.rows * frameSize : frameSize;
 
   return (
-    <div
-      ref={spriteRef}
-      data-testid="mascot-sprite"
-      className={`sprite ${frozen ? "frozen" : ""} ${glowMode !== "off" ? `glow-${glowMode}` : ""}`}
-      style={{
-        backgroundImage: `url(${spriteUrl})`,
-        width: frameSize,
-        height: frameSize,
-        backgroundSize: `${sheetWidth}px ${sheetHeight}px`,
-      }}
-    />
+    <div className="mascot-wrapper" data-testid="mascot-wrapper">
+      <div
+        ref={spriteRef}
+        data-testid="mascot-sprite"
+        className={`sprite ${frozen ? "frozen" : ""} ${glowMode !== "off" ? `glow-${glowMode}` : ""}`}
+        style={{
+          backgroundImage: `url(${spriteUrl})`,
+          width: frameSize,
+          height: frameSize,
+          backgroundSize: `${sheetWidth}px ${sheetHeight}px`,
+        }}
+      />
+      {cloneActive && busySpriteUrl && (
+        <ShadowCloneEffect
+          spriteUrl={busySpriteUrl}
+          frames={busyFrames}
+          frameSize={frameSize}
+        />
+      )}
+    </div>
   );
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -12,6 +12,7 @@ import { useDockVisible } from "../hooks/useDockVisible";
 import { useTrayVisible } from "../hooks/useTrayVisible";
 import { mimeCategories, getMimesByCategory } from "../constants/sprites";
 import { useScale } from "../hooks/useScale";
+import { useShadowClone } from "../hooks/useShadowClone";
 import { useCustomMimes, ALL_STATUSES } from "../hooks/useCustomMimes";
 import { SmartImport } from "./SmartImport";
 import { AnimationPreview } from "./AnimationPreview";
@@ -78,6 +79,7 @@ export function Settings() {
   const { hidden: dockHidden, setHidden: setDockHidden } = useDockVisible();
   const { hidden: trayHidden, setHidden: setTrayHidden } = useTrayVisible();
   const { scale, setScale, SCALE_PRESETS } = useScale();
+  const { enabled: shadowCloneEnabled, setEnabled: setShadowCloneEnabled } = useShadowClone();
   const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, deleteMime, exportMime, importMime } = useCustomMimes();
   const [tab, setTab] = useState<Tab>("general");
   const [creating, setCreating] = useState<false | "manual" | "smart">(false);
@@ -338,6 +340,16 @@ export function Settings() {
                     </button>
                   ))}
                 </div>
+              </div>
+              <div className="settings-row">
+                <span className="settings-row-label">Shadow Clone Effect</span>
+                <button
+                  data-testid="shadow-clone-toggle"
+                  className={`toggle-switch ${shadowCloneEnabled ? "active" : ""}`}
+                  onClick={() => setShadowCloneEnabled(!shadowCloneEnabled)}
+                >
+                  <span className="toggle-knob" />
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/ShadowCloneEffect.tsx
+++ b/src/components/ShadowCloneEffect.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+import "../styles/shadow-clone.css";
+
+interface ShadowCloneEffectProps {
+  spriteUrl: string;
+  frames: number;
+  frameSize: number;
+}
+
+const TOTAL_EFFECT_MS = 2000;
+
+interface CloneData {
+  id: string;
+  targetX: number;
+  targetY: number;
+  rotation: number;
+  delay: number;
+  duration: number;
+}
+
+function generateClones(count: number): CloneData[] {
+  return Array.from({ length: count }, (_, i): CloneData => {
+    const angle = Math.random() * 2 * Math.PI;
+    const distance = 80 + Math.random() * 220;
+    const delay = i * 20;
+    return {
+      id: `clone-${i}`,
+      targetX: Math.cos(angle) * distance,
+      targetY: Math.sin(angle) * distance,
+      rotation: -20 + Math.random() * 40,
+      delay,
+      duration: TOTAL_EFFECT_MS - delay,
+    };
+  });
+}
+
+export function ShadowCloneEffect({
+  spriteUrl,
+  frames,
+  frameSize,
+}: ShadowCloneEffectProps) {
+  const clones = useMemo(() => generateClones(50), []);
+
+  return (
+    <div className="shadow-clone-container" data-testid="shadow-clone-effect">
+      <div className="shadow-clone-origin">
+        {clones.map((clone) => (
+          <div
+            key={clone.id}
+            className="shadow-clone-wrapper"
+            style={
+              {
+                "--clone-x": `${clone.targetX}px`,
+                "--clone-y": `${clone.targetY}px`,
+                "--clone-rotation": `${clone.rotation}deg`,
+                "--clone-delay": `${clone.delay}ms`,
+                "--clone-duration": `${clone.duration}ms`,
+              } as React.CSSProperties
+            }
+          >
+            <div
+              className="shadow-clone-sprite"
+              style={{
+                backgroundImage: `url(${spriteUrl})`,
+                width: frameSize,
+                height: frameSize,
+                backgroundSize: `${frames * frameSize}px ${frameSize}px`,
+                "--clone-sprite-steps": frames,
+                "--clone-sprite-width": `${frames * frameSize}px`,
+                "--clone-sprite-duration": `${frames * 80}ms`,
+              } as React.CSSProperties}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useShadowClone.ts
+++ b/src/hooks/useShadowClone.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useLayoutEffect } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { emit, listen } from "@tauri-apps/api/event";
+
+const STORE_FILE = "settings.json";
+const STORE_KEY = "shadowCloneEnabled";
+const EVENT_NAME = "shadow-clone-enabled-changed";
+
+export function useShadowClone() {
+  const [enabled, setEnabledState] = useState(true);
+
+  useLayoutEffect(() => {
+    load(STORE_FILE).then(async (store) => {
+      const val = await store.get<boolean>(STORE_KEY);
+      if (val !== null && val !== undefined) {
+        setEnabledState(val);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>(EVENT_NAME, (event) => {
+      setEnabledState(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const setEnabled = async (next: boolean) => {
+    setEnabledState(next);
+    const store = await load(STORE_FILE);
+    await store.set(STORE_KEY, next);
+    await store.save();
+    await emit(EVENT_NAME, next);
+  };
+
+  return { enabled, setEnabled };
+}

--- a/src/hooks/useWindowAutoSize.ts
+++ b/src/hooks/useWindowAutoSize.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 
 /**
@@ -7,15 +7,26 @@ import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
  * boundary matches the visible content (sprite + pill + bubble etc.)
  */
 export function useWindowAutoSize(
-  contentRef: React.RefObject<HTMLElement | null>
+  contentRef: React.RefObject<HTMLElement | null>,
+  paused = false
 ) {
+  // Ref is updated synchronously during render, so observers
+  // created in a previous effect can check it immediately —
+  // even before useEffect cleanup runs and disconnects them.
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+
   useEffect(() => {
+    if (paused) return;
+
     const el = contentRef.current;
     if (!el) return;
 
     const win = getCurrentWindow();
 
     const updateSize = () => {
+      if (pausedRef.current) return;
+
       const el = contentRef.current;
       if (!el) return;
 
@@ -40,5 +51,5 @@ export function useWindowAutoSize(
       resizeObs.disconnect();
       mutationObs.disconnect();
     };
-  }, [contentRef]);
+  }, [contentRef, paused]);
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -57,3 +57,15 @@ body {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
 }
+
+/* Dev mode: show draggable container boundary */
+.container.dev-border {
+  border: 1px dashed rgba(94, 92, 230, 0.6);
+  border-radius: 2px;
+}
+
+/* Dev mode: show shadow clone area boundary */
+.container.dev-border .shadow-clone-container {
+  border: 1px dashed rgba(230, 92, 92, 0.6);
+  border-radius: 2px;
+}

--- a/src/styles/mascot.css
+++ b/src/styles/mascot.css
@@ -1,7 +1,12 @@
+/* --- Mascot wrapper (positions clone effect) --- */
+.mascot-wrapper {
+  position: relative;
+  align-self: center;
+  margin-bottom: 4px;
+}
+
 /* --- Sprite (animation driven by JS rAF in Mascot.tsx) --- */
 .sprite {
-  margin-bottom: 4px;
-  align-self: center;
   image-rendering: pixelated;
   background-repeat: no-repeat;
   filter: none;

--- a/src/styles/shadow-clone.css
+++ b/src/styles/shadow-clone.css
@@ -1,0 +1,102 @@
+/* --- Shadow Clone (Kage Bunshin) effect --- */
+.shadow-clone-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 800px;
+  height: 800px;
+  pointer-events: none;
+  z-index: 10;
+  overflow: visible;
+  -webkit-mask-image: radial-gradient(circle 380px at center, black 60%, transparent 95%);
+  mask-image: radial-gradient(circle 380px at center, black 60%, transparent 95%);
+}
+
+.shadow-clone-origin {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+}
+
+.shadow-clone-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
+  animation: clone-burst var(--clone-duration) ease-out forwards;
+  animation-delay: var(--clone-delay);
+}
+
+.shadow-clone-sprite {
+  image-rendering: pixelated;
+  background-repeat: no-repeat;
+  animation: clone-sprite-play var(--clone-sprite-duration) steps(var(--clone-sprite-steps), end) infinite;
+}
+
+@keyframes clone-sprite-play {
+  from { background-position: 0 0; }
+  to { background-position: calc(-1 * var(--clone-sprite-width)) 0; }
+}
+
+.shadow-clone-smoke {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  border-radius: 50%;
+  z-index: 20;
+  background:
+    radial-gradient(ellipse 60% 50% at 30% 40%, rgba(255, 255, 255, 0.7) 0%, transparent 70%),
+    radial-gradient(ellipse 50% 60% at 70% 50%, rgba(240, 240, 240, 0.6) 0%, transparent 65%),
+    radial-gradient(ellipse 70% 55% at 50% 60%, rgba(220, 220, 220, 0.5) 0%, transparent 60%),
+    radial-gradient(circle at 50% 50%, rgba(200, 200, 200, 0.3) 0%, transparent 70%);
+  opacity: 0;
+  animation: smoke-poof 0.7s ease-out forwards;
+  animation-delay: calc(var(--clone-delay) + 1000ms);
+  filter: blur(2px);
+}
+
+@keyframes clone-burst {
+  0% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0.8);
+    opacity: 0;
+  }
+  5% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  15% {
+    transform: translate(-50%, -50%) translate(var(--clone-x), var(--clone-y)) rotate(var(--clone-rotation)) scale(0.9);
+    opacity: 1;
+  }
+  60% {
+    transform: translate(-50%, -50%) translate(var(--clone-x), var(--clone-y)) rotate(var(--clone-rotation)) scale(0.85);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0.5);
+    opacity: 0;
+  }
+}
+
+@keyframes smoke-poof {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.2) rotate(0deg);
+  }
+  20% {
+    opacity: 0.8;
+    transform: translate(-50%, -55%) scale(0.8) rotate(5deg);
+  }
+  50% {
+    opacity: 0.5;
+    transform: translate(-50%, -65%) scale(1.2) rotate(-3deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -80%) scale(1.6) rotate(8deg);
+  }
+}


### PR DESCRIPTION
## Summary
- 50 animated shadow clones burst outward from the mascot when transitioning to busy state (Naruto-style Kage Bunshin)
- Clones use the busy/working sprite with full frame animation, appear sequentially, then converge back to the mascot
- Window temporarily expands to 1200x1200 to accommodate the effect, with radial CSS mask for smooth edge fading
- On/off toggle added in Settings > Appearance > Shadow Clone Effect (default: on)
- Dev mode shows debug borders for both the drag container and clone effect area

## Files changed
- **New**: `ShadowCloneEffect.tsx`, `useShadowClone.ts`, `shadow-clone.css`
- **Modified**: `Mascot.tsx`, `App.tsx`, `Settings.tsx`, `useWindowAutoSize.ts`, `mascot.css`, `app.css`, `default.json` (Tauri permissions)

## Test plan
- [ ] Run `bun run tauri dev` and trigger a busy transition — verify 50 clones burst out and return
- [ ] Toggle off in Settings > Appearance > Shadow Clone Effect — verify no clones on next busy transition
- [ ] Verify mascot position stays stable during the window expand/restore cycle
- [ ] Check that the effect works with different pets (rottweiler, dalmatian, samurai, hancock)
- [ ] Check that custom mimes still work correctly with the mascot-wrapper change