### PR TITLE
feat: add pluggable effect system with shadow clone animation

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,11 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-set-size",
+    "core:window:allow-set-position",
+    "core:window:allow-set-shadow",
+    "core:window:allow-outer-position",
+    "core:window:allow-outer-size",
+    "core:window:allow-scale-factor",
     "core:event:default",
     "opener:default",
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { StatusPill } from "./components/StatusPill";
 import { SpeechBubble } from "./components/SpeechBubble";
 import { VisitorDog } from "./components/VisitorDog";
 import { DevTag } from "./components/DevTag";
+import { EffectOverlay } from "./effects";
 import { useStatus } from "./hooks/useStatus";
 import { useDrag } from "./hooks/useDrag";
 import { useTheme } from "./hooks/useTheme";
@@ -14,7 +15,7 @@ import { usePet } from "./hooks/usePet";
 import { useScale } from "./hooks/useScale";
 import { useDevMode } from "./hooks/useDevMode";
 import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Menu, MenuItem } from "@tauri-apps/api/menu";
 import "./styles/theme.css";
@@ -31,8 +32,9 @@ function App() {
   const { scale } = useScale();
   const devMode = useDevMode();
   const containerRef = useRef<HTMLDivElement>(null);
+  const [effectActive, setEffectActive] = useState(false);
   useTheme();
-  useWindowAutoSize(containerRef);
+  useWindowAutoSize(containerRef, effectActive);
 
   const onContextMenu = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -83,6 +85,7 @@ function App() {
       onContextMenu={onContextMenu}
     >
       {scenario && <div data-testid="scenario-badge" className="scenario-badge">SCENARIO</div>}
+      <EffectOverlay onActiveChange={setEffectActive} />
       <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
       {status !== "visiting" && <Mascot status={status} />}
       {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -12,6 +12,7 @@ import { useDockVisible } from "../hooks/useDockVisible";
 import { useTrayVisible } from "../hooks/useTrayVisible";
 import { mimeCategories, getMimesByCategory } from "../constants/sprites";
 import { useScale } from "../hooks/useScale";
+import { effects, useEffectEnabled } from "../effects";
 import { useCustomMimes, ALL_STATUSES } from "../hooks/useCustomMimes";
 import { SmartImport } from "./SmartImport";
 import { AnimationPreview } from "./AnimationPreview";
@@ -339,6 +340,9 @@ export function Settings() {
                   ))}
                 </div>
               </div>
+              {effects.map((effect) => (
+                <EffectToggle key={effect.id} effectId={effect.id} name={effect.name} />
+              ))}
             </div>
           </div>
           <div className="settings-section">
@@ -751,6 +755,22 @@ export function Settings() {
           />
         )}
       </main>
+    </div>
+  );
+}
+
+function EffectToggle({ effectId, name }: { effectId: string; name: string }) {
+  const { enabled, setEnabled } = useEffectEnabled(effectId);
+  return (
+    <div className="settings-row">
+      <span className="settings-row-label">{name}</span>
+      <button
+        data-testid={`effect-toggle-${effectId}`}
+        className={`toggle-switch ${enabled ? "active" : ""}`}
+        onClick={() => setEnabled(!enabled)}
+      >
+        <span className="toggle-knob" />
+      </button>
     </div>
   );
 }

--- a/src/effects/EffectOverlay.tsx
+++ b/src/effects/EffectOverlay.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { getCurrentWindow, LogicalSize, LogicalPosition } from "@tauri-apps/api/window";
+import { useStatus } from "../hooks/useStatus";
+import { usePet } from "../hooks/usePet";
+import { useScale } from "../hooks/useScale";
+import { getSpriteMap } from "../constants/sprites";
+import { useEffectEnabled } from "./useEffectEnabled";
+import { effects } from "./index";
+import type { EffectDefinition } from "./types";
+
+interface EffectOverlayProps {
+  onActiveChange?: (active: boolean) => void;
+}
+
+interface ActiveEffect {
+  definition: EffectDefinition;
+  spriteUrl: string;
+  frames: number;
+  frameSize: number;
+}
+
+/** Pin #root content to its current position so window resize doesn't shift it. */
+function pinRootContent() {
+  const root = document.getElementById("root");
+  if (!root) return;
+  const container = root.firstElementChild as HTMLElement | null;
+  if (!container) return;
+
+  const rootRect = root.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  const offsetX = containerRect.left - rootRect.left;
+  const offsetY = containerRect.top - rootRect.top;
+
+  root.style.alignItems = "flex-start";
+  root.style.justifyContent = "flex-start";
+  root.style.paddingLeft = `${offsetX}px`;
+  root.style.paddingTop = `${offsetY}px`;
+}
+
+/** Restore #root to its default centered layout. */
+function unpinRootContent() {
+  const root = document.getElementById("root");
+  if (!root) return;
+  root.style.alignItems = "";
+  root.style.justifyContent = "";
+  root.style.paddingLeft = "";
+  root.style.paddingTop = "";
+}
+
+export function EffectOverlay({ onActiveChange }: EffectOverlayProps) {
+  const { status } = useStatus();
+  const { pet } = usePet();
+  const { scale } = useScale();
+
+  const [activeEffect, setActiveEffect] = useState<ActiveEffect | null>(null);
+  const [windowReady, setWindowReady] = useState(false);
+  const prevStatusRef = useRef(status);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const savedWindowRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
+
+  const expandWindow = useCallback(async (size: number) => {
+    try {
+      const win = getCurrentWindow();
+      const factor = await win.scaleFactor();
+      const physPos = await win.outerPosition();
+      const physSize = await win.outerSize();
+
+      const logX = physPos.x / factor;
+      const logY = physPos.y / factor;
+      const logW = physSize.width / factor;
+      const logH = physSize.height / factor;
+
+      savedWindowRef.current = { x: logX, y: logY, w: logW, h: logH };
+
+      // Pin content position BEFORE resizing to prevent centering shift
+      pinRootContent();
+
+      const shiftX = (size - logW) / 2;
+      const shiftY = (size - logH) / 2;
+
+      await win.setShadow(false);
+      await Promise.all([
+        win.setPosition(new LogicalPosition(logX - shiftX, logY - shiftY)),
+        win.setSize(new LogicalSize(size, size)),
+      ]);
+
+      // Re-center content now that window is at final size
+      unpinRootContent();
+      setWindowReady(true);
+    } catch (err) {
+      console.error("[effects] expand error:", err);
+      unpinRootContent();
+      setWindowReady(true);
+    }
+  }, []);
+
+  const restoreWindow = useCallback(async () => {
+    try {
+      const win = getCurrentWindow();
+      if (savedWindowRef.current) {
+        const { x, y, w, h } = savedWindowRef.current;
+
+        pinRootContent();
+        await Promise.all([
+          win.setPosition(new LogicalPosition(x, y)),
+          win.setSize(new LogicalSize(w, h)),
+        ]);
+        unpinRootContent();
+        await win.setShadow(true);
+        savedWindowRef.current = null;
+      }
+    } catch (err) {
+      console.error("[effects] restore error:", err);
+      unpinRootContent();
+    }
+  }, []);
+
+  const stopEffect = useCallback(() => {
+    clearTimeout(timerRef.current);
+    setActiveEffect(null);
+    setWindowReady(false);
+    onActiveChange?.(false);
+    restoreWindow();
+  }, [onActiveChange, restoreWindow]);
+
+  useEffect(() => {
+    const prevStatus = prevStatusRef.current;
+    prevStatusRef.current = status;
+
+    if (activeEffect && status !== activeEffect.definition.trigger) {
+      stopEffect();
+      return;
+    }
+
+    if (prevStatus === status) return;
+
+    const matchingEffect = effects.find((e) => e.trigger === status);
+    if (!matchingEffect) return;
+
+    const isCustom = pet.startsWith("custom-");
+    if (isCustom) return;
+
+    const spriteMap = getSpriteMap(pet);
+    const sprite = spriteMap[status];
+    const spriteUrl = new URL(
+      `../assets/sprites/${sprite.file}`,
+      import.meta.url
+    ).href;
+    const frameSize = 128 * scale;
+
+    // Pause auto-size BEFORE rendering the effect
+    onActiveChange?.(true);
+
+    // Expand window (pinning prevents content shift)
+    if (matchingEffect.expandWindow) {
+      expandWindow(matchingEffect.expandWindow);
+    } else {
+      setWindowReady(true);
+    }
+
+    setActiveEffect({
+      definition: matchingEffect,
+      spriteUrl,
+      frames: sprite.frames,
+      frameSize,
+    });
+
+    timerRef.current = setTimeout(stopEffect, matchingEffect.duration);
+
+    return () => clearTimeout(timerRef.current);
+  }, [status]);
+
+  if (!activeEffect || !windowReady) return null;
+
+  return (
+    <EffectRunner effect={activeEffect} onDisabled={stopEffect} />
+  );
+}
+
+interface EffectRunnerProps {
+  effect: ActiveEffect;
+  onDisabled: () => void;
+}
+
+function EffectRunner({ effect, onDisabled }: EffectRunnerProps) {
+  const { enabled } = useEffectEnabled(effect.definition.id);
+
+  useEffect(() => {
+    if (!enabled) onDisabled();
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  const Component = effect.definition.component;
+  return (
+    <Component
+      spriteUrl={effect.spriteUrl}
+      frames={effect.frames}
+      frameSize={effect.frameSize}
+    />
+  );
+}

--- a/src/effects/README.md
+++ b/src/effects/README.md
@@ -1,0 +1,103 @@
+# Effects System
+
+Plug-and-play visual effects that trigger on status transitions.
+
+## Adding a New Effect
+
+### 1. Create the effect folder
+
+```
+src/effects/my-effect/
+  index.ts
+  MyEffect.tsx
+  my-effect.css
+```
+
+### 2. Create the visual component
+
+`MyEffect.tsx` receives `EffectProps` and renders the animation:
+
+```tsx
+import type { EffectProps } from "../types";
+import "./my-effect.css";
+
+export function MyEffect({ spriteUrl, frames, frameSize }: EffectProps) {
+  return (
+    <div className="my-effect-container">
+      {/* Your animation here */}
+    </div>
+  );
+}
+```
+
+**Props provided automatically:**
+| Prop | Type | Description |
+|------|------|-------------|
+| `spriteUrl` | `string` | URL of the sprite sheet for the trigger status |
+| `frames` | `number` | Number of frames in the sprite sheet |
+| `frameSize` | `number` | Pixel size of each frame (128 * scale) |
+
+### 3. Define the effect
+
+`index.ts` exports an `EffectDefinition`:
+
+```ts
+import type { EffectDefinition } from "../types";
+import { MyEffect } from "./MyEffect";
+
+export const myEffect: EffectDefinition = {
+  id: "my-effect",        // Unique ID (used as settings key)
+  name: "My Effect",      // Display name in Settings
+  trigger: "busy",        // Status that triggers this effect
+  duration: 2000,         // How long the effect plays (ms)
+  expandWindow: 1200,     // Optional: expand window to this size (px)
+  component: MyEffect,
+};
+```
+
+**`trigger`** — which status transition activates the effect. One of: `"busy"`, `"idle"`, `"service"`, `"disconnected"`, `"searching"`, `"initializing"`, `"visiting"`.
+
+**`expandWindow`** — if set, the window temporarily expands to this square size to give the effect room. Omit if the effect fits within the normal window.
+
+**`duration`** — the effect auto-dismisses after this many milliseconds. The window restores to its original size/position when the effect ends.
+
+### 4. Register it
+
+Add one line to `src/effects/index.ts`:
+
+```ts
+import { myEffect } from "./my-effect";
+
+export const effects: EffectDefinition[] = [
+  shadowCloneEffect,
+  myEffect,             // <-- add here
+];
+```
+
+That's it. The effect now:
+- Triggers automatically on the matching status transition
+- Has an on/off toggle in Settings > Appearance
+- Expands/restores the window if `expandWindow` is set
+- Settings persist across restarts
+
+## Architecture
+
+```
+EffectOverlay (App.tsx)
+  ├── Detects status transitions
+  ├── Finds matching effect from registry
+  ├── Expands window if needed
+  └── EffectRunner
+        ├── Checks if effect is enabled (settings)
+        ├── Renders effect component
+        └── Auto-dismisses after duration
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `types.ts` | `EffectDefinition` and `EffectProps` interfaces |
+| `index.ts` | Effect registry — add new effects here |
+| `useEffectEnabled.ts` | Generic hook for per-effect on/off setting |
+| `EffectOverlay.tsx` | Orchestrator: status detection, window management, rendering |

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,0 +1,11 @@
+import type { EffectDefinition } from "./types";
+export type { EffectDefinition, EffectProps } from "./types";
+export { useEffectEnabled } from "./useEffectEnabled";
+export { EffectOverlay } from "./EffectOverlay";
+
+// --- Registered effects (add new effects here) ---
+import { shadowCloneEffect } from "./shadow-clone";
+
+export const effects: EffectDefinition[] = [
+  shadowCloneEffect,
+];

--- a/src/effects/shadow-clone/ShadowCloneEffect.tsx
+++ b/src/effects/shadow-clone/ShadowCloneEffect.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import type { EffectProps } from "../types";
+import "./shadow-clone.css";
+
+const TOTAL_EFFECT_MS = 2000;
+
+interface CloneData {
+  id: string;
+  targetX: number;
+  targetY: number;
+  rotation: number;
+  delay: number;
+  duration: number;
+}
+
+function generateClones(count: number): CloneData[] {
+  return Array.from({ length: count }, (_, i): CloneData => {
+    const angle = Math.random() * 2 * Math.PI;
+    const distance = 150 + Math.random() * 150;
+    const delay = i * 20;
+    return {
+      id: `clone-${i}`,
+      targetX: Math.cos(angle) * distance,
+      targetY: Math.sin(angle) * distance,
+      rotation: -20 + Math.random() * 40,
+      delay,
+      duration: TOTAL_EFFECT_MS - delay,
+    };
+  });
+}
+
+export function ShadowCloneEffect({
+  spriteUrl,
+  frames,
+  frameSize,
+}: EffectProps) {
+  const clones = useMemo(() => generateClones(50), []);
+
+  return (
+    <div className="shadow-clone-container" data-testid="shadow-clone-effect">
+      <div className="shadow-clone-origin">
+        {clones.map((clone) => (
+          <div
+            key={clone.id}
+            className="shadow-clone-wrapper"
+            style={
+              {
+                "--clone-x": `${clone.targetX}px`,
+                "--clone-y": `${clone.targetY}px`,
+                "--clone-rotation": `${clone.rotation}deg`,
+                "--clone-delay": `${clone.delay}ms`,
+                "--clone-duration": `${clone.duration}ms`,
+              } as React.CSSProperties
+            }
+          >
+            <div
+              className="shadow-clone-sprite"
+              style={{
+                backgroundImage: `url(${spriteUrl})`,
+                width: frameSize,
+                height: frameSize,
+                backgroundSize: `${frames * frameSize}px ${frameSize}px`,
+                "--clone-sprite-steps": frames,
+                "--clone-sprite-width": `${frames * frameSize}px`,
+                "--clone-sprite-duration": `${frames * 80}ms`,
+              } as React.CSSProperties}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/effects/shadow-clone/index.ts
+++ b/src/effects/shadow-clone/index.ts
@@ -1,0 +1,11 @@
+import type { EffectDefinition } from "../types";
+import { ShadowCloneEffect } from "./ShadowCloneEffect";
+
+export const shadowCloneEffect: EffectDefinition = {
+  id: "shadow-clone",
+  name: "Shadow Clone",
+  trigger: "busy",
+  duration: 2000,
+  expandWindow: 1200,
+  component: ShadowCloneEffect,
+};

--- a/src/effects/shadow-clone/shadow-clone.css
+++ b/src/effects/shadow-clone/shadow-clone.css
@@ -1,0 +1,106 @@
+/* --- Shadow Clone (Kage Bunshin) effect --- */
+.shadow-clone-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 800px;
+  height: 800px;
+  pointer-events: none;
+  z-index: 1;
+  overflow: visible;
+  -webkit-mask-image: radial-gradient(circle 380px at center, black 60%, transparent 95%);
+  mask-image: radial-gradient(circle 380px at center, black 60%, transparent 95%);
+}
+
+.shadow-clone-origin {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+}
+
+.shadow-clone-wrapper {
+  position: absolute;
+  top: -20px;
+  left: 10px;
+  transform: translate(-50%, -50%);
+  animation: clone-burst var(--clone-duration) ease-out forwards;
+  animation-delay: var(--clone-delay);
+}
+
+.shadow-clone-sprite {
+  image-rendering: pixelated;
+  background-repeat: no-repeat;
+  animation: clone-sprite-play var(--clone-sprite-duration) steps(var(--clone-sprite-steps), end) infinite;
+}
+
+@keyframes clone-sprite-play {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: calc(-1 * var(--clone-sprite-width)) 0;
+  }
+}
+
+.shadow-clone-smoke {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  border-radius: 50%;
+  z-index: 20;
+  background:
+    radial-gradient(ellipse 60% 50% at 30% 40%, rgba(255, 255, 255, 0.7) 0%, transparent 70%),
+    radial-gradient(ellipse 50% 60% at 70% 50%, rgba(240, 240, 240, 0.6) 0%, transparent 65%),
+    radial-gradient(ellipse 70% 55% at 50% 60%, rgba(220, 220, 220, 0.5) 0%, transparent 60%),
+    radial-gradient(circle at 50% 50%, rgba(200, 200, 200, 0.3) 0%, transparent 70%);
+  opacity: 0;
+  animation: smoke-poof 0.7s ease-out forwards;
+  animation-delay: calc(var(--clone-delay) + 1000ms);
+  filter: blur(2px);
+}
+
+@keyframes clone-burst {
+  0% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0.8);
+    opacity: 1;
+  }
+  5% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  15% {
+    transform: translate(-50%, -50%) translate(var(--clone-x), var(--clone-y)) rotate(var(--clone-rotation)) scale(0.9);
+    opacity: 1;
+  }
+  60% {
+    transform: translate(-50%, -50%) translate(var(--clone-x), var(--clone-y)) rotate(var(--clone-rotation)) scale(0.85);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) translate(0, 0) rotate(0deg) scale(0.5);
+    opacity: 0;
+  }
+}
+
+@keyframes smoke-poof {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.2) rotate(0deg);
+  }
+  20% {
+    opacity: 0.8;
+    transform: translate(-50%, -55%) scale(0.8) rotate(5deg);
+  }
+  50% {
+    opacity: 0.5;
+    transform: translate(-50%, -65%) scale(1.2) rotate(-3deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -80%) scale(1.6) rotate(8deg);
+  }
+}

--- a/src/effects/types.ts
+++ b/src/effects/types.ts
@@ -1,0 +1,16 @@
+import type { Status } from "../types/status";
+
+export interface EffectProps {
+  spriteUrl: string;
+  frames: number;
+  frameSize: number;
+}
+
+export interface EffectDefinition {
+  id: string;
+  name: string;
+  trigger: Status;
+  duration: number;
+  expandWindow?: number;
+  component: React.ComponentType<EffectProps>;
+}

--- a/src/effects/useEffectEnabled.ts
+++ b/src/effects/useEffectEnabled.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useLayoutEffect } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { emit, listen } from "@tauri-apps/api/event";
+
+const STORE_FILE = "settings.json";
+
+function storeKey(effectId: string) {
+  return `effect_${effectId}_enabled`;
+}
+
+function eventName(effectId: string) {
+  return `effect-${effectId}-changed`;
+}
+
+export function useEffectEnabled(effectId: string) {
+  const [enabled, setEnabledState] = useState(true);
+
+  useLayoutEffect(() => {
+    load(STORE_FILE).then(async (store) => {
+      const val = await store.get<boolean>(storeKey(effectId));
+      if (val !== null && val !== undefined) {
+        setEnabledState(val);
+      }
+    });
+  }, [effectId]);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>(eventName(effectId), (event) => {
+      setEnabledState(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [effectId]);
+
+  const setEnabled = async (next: boolean) => {
+    setEnabledState(next);
+    const store = await load(STORE_FILE);
+    await store.set(storeKey(effectId), next);
+    await store.save();
+    await emit(eventName(effectId), next);
+  };
+
+  return { enabled, setEnabled };
+}

--- a/src/hooks/useWindowAutoSize.ts
+++ b/src/hooks/useWindowAutoSize.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 
 /**
@@ -7,15 +7,26 @@ import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
  * boundary matches the visible content (sprite + pill + bubble etc.)
  */
 export function useWindowAutoSize(
-  contentRef: React.RefObject<HTMLElement | null>
+  contentRef: React.RefObject<HTMLElement | null>,
+  paused = false
 ) {
+  // Ref is updated synchronously during render, so observers
+  // created in a previous effect can check it immediately —
+  // even before useEffect cleanup runs and disconnects them.
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+
   useEffect(() => {
+    if (paused) return;
+
     const el = contentRef.current;
     if (!el) return;
 
     const win = getCurrentWindow();
 
     const updateSize = () => {
+      if (pausedRef.current) return;
+
       const el = contentRef.current;
       if (!el) return;
 
@@ -40,5 +51,5 @@ export function useWindowAutoSize(
       resizeObs.disconnect();
       mutationObs.disconnect();
     };
-  }, [contentRef]);
+  }, [contentRef, paused]);
 }


### PR DESCRIPTION
## Summary
- Introduces a modular **effect system** (`src/effects/`) — plug-and-play visual effects triggered on status transitions
- Adding a new effect = create a folder + add 1 line to the registry. No changes to App, Mascot, or Settings needed
- Includes **Shadow Clone** effect: 50 animated clones burst from mascot on busy transition, then return
- On/off toggle auto-generated in Settings > Appearance for each registered effect
- Window temporarily expands to accommodate effects, with content pinning to prevent mascot flicker

## Architecture
```
src/effects/
  types.ts              — EffectDefinition + EffectProps interfaces
  index.ts              — registry (add 1 line per new effect)
  useEffectEnabled.ts   — generic settings hook for any effect
  EffectOverlay.tsx     — orchestrator (status detection, window mgmt)
  README.md             — guide for adding new effects
  shadow-clone/
    index.ts            — effect definition
    ShadowCloneEffect.tsx
    shadow-clone.css
```

## Modified existing files (minimal)
- `App.tsx` — +5 lines (import + render EffectOverlay)
- `useWindowAutoSize.ts` — add `paused` param to prevent resize during effects
- `Settings.tsx` — dynamic EffectToggle from registry
- `default.json` — Tauri window permissions

## Test plan
- [ ] `bun run tauri dev` — trigger busy transition, verify 50 clones burst out and return
- [ ] Toggle off in Settings > Appearance > Shadow Clone — verify no clones on next busy
- [ ] Verify mascot position stability during window expand/restore
- [ ] Test with different pets (rottweiler, dalmatian, samurai, hancock)