### PR TITLE
fix(effects): disable setShadow restore to prevent dark outline

### DIFF
--- a/src/effects/EffectOverlay.tsx
+++ b/src/effects/EffectOverlay.tsx
@@ -106,7 +106,7 @@ export function EffectOverlay({ onActiveChange }: EffectOverlayProps) {
           win.setSize(new LogicalSize(w, h)),
         ]);
         unpinRootContent();
-        await win.setShadow(true);
+        // await win.setShadow(true);
         savedWindowRef.current = null;
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Disable `win.setShadow(true)` in the shadow-clone effect restore path
- macOS renders visible dark lines around the pet and status pill when the window shadow is re-enabled after the effect resizes the transparent borderless window back to normal

## Test plan
- [ ] Trigger busy status to activate shadow-clone effect
- [ ] Verify no dark outline/border appears around the pet and status pill after the effect ends
- [ ] Verify the shadow-clone animation still plays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)