### PR TITLE
chore: release v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.15.4] - 2026-04-14
+
+### Added
+- **Pluggable effect system** — modular architecture for visual effects on the mascot
+- **Shadow Clone animation** — Naruto-style kage bunshin effect triggered on busy status
+- **Editable Smart Import** — re-edit previously imported custom mimes instead of starting from scratch
+- **Smart Import metadata persistence** — source sheet and frame inputs saved for later editing
+- **Source sheet cleanup** — deleting a custom mime also removes its source sheet file
+
+### Changed
+- Sprite animation engine upgraded from strip-only to 2D grid sheet support via `requestAnimationFrame`
+
+### Fixed
+- Dark outline artifact on transparent window after shadow-clone effect restores window shadow
+- `smartImportMeta` preserved through manual editor path
+- `arrayBuffer` rejection properly propagated in Smart Import canvas encoder
+
+### Tests
+- Smart Import edit-mode smoke tests and e2e round-trip assertions
+
 ## [0.15.3] - 2026-04-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.15.3",
+  "version": "0.15.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.15.3"
+version = "0.15.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -720,7 +720,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.15.3{devMode && " (Dev Mode)"}
+                  Version 0.15.4{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.15.4 across all 4 files + Cargo.lock
- Update CHANGELOG.md

### What's in v0.15.4
- **Pluggable effect system** with shadow clone animation on busy status
- **Editable Smart Import** — re-edit previously imported custom mimes
- **2D grid sprite sheet support** via requestAnimationFrame
- **Fix:** dark outline artifact on transparent window after effect restore
- **Fix:** smartImportMeta preserved through manual editor path
- **Fix:** arrayBuffer rejection propagation in Smart Import

## Test plan
- [ ] Verify version shows `0.15.4` in Settings → About
- [ ] Merge → tag `v0.15.4` → CI builds DMGs
- [ ] Update Homebrew cask after CI completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)