### PR TITLE
chore: release v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.15.5] - 2026-04-14
 
 ### Added
 - **MCP Server** — Claude Code can now interact with your desktop pet via Model Context Protocol (MCP) tools
@@ -14,6 +14,11 @@
 - New HTTP endpoints: `POST /mcp/say`, `POST /mcp/react`, `GET /mcp/pet-status`
 - New Tauri events: `mcp-say` (speech bubble), `mcp-react` (temporary animation override)
 - `pet`, `nickname`, `started_at` fields added to `AppState` for MCP status reporting
+- **Smart Import frame selection** — preserve frame order and support directional ranges
+- **Local Network permission** — request button in Settings for network access
+
+### Fixed
+- Shadow clone effect now works on custom mascots
 
 ## [0.15.4] - 2026-04-14
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.15.4",
+  "version": "0.15.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.15.4"
+version = "0.15.5"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -734,7 +734,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.15.4{devMode && " (Dev Mode)"}
+                  Version 0.15.5{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.15.5 across all 4 files (package.json, Cargo.toml, tauri.conf.json, Settings.tsx)
- Update CHANGELOG with entries for PRs #58, #70, #71

## What's new in v0.15.5
- **MCP Server** — Claude Code interacts with desktop pet via MCP tools (`pet_say`, `pet_react`, `pet_status`)
- **Smart Import frame selection** — preserve frame order and support directional ranges
- **Local Network permission** — request button in Settings
- **Fix:** Shadow clone effect now works on custom mascots

## Post-merge
- [ ] Tag `v0.15.5` on main
- [ ] Wait for CI to build DMGs
- [ ] Update Homebrew cask with new SHA256s

🤖 Generated with [Claude Code](https://claude.com/claude-code)