### PR TITLE
feat(smart-import): add post-import frame editor (remove + drag reorder)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,8 @@
         "visible": false,
         "decorations": true,
         "transparent": false,
-        "center": true
+        "center": true,
+        "dragDropEnabled": false
       },
       {
         "label": "superpower",

--- a/src/__tests__/components/SmartImport.test.tsx
+++ b/src/__tests__/components/SmartImport.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { SmartImport } from "../../components/SmartImport";
+import { SmartImport, serializeFrames } from "../../components/SmartImport";
 
 // Stub the sprite-sheet processor so the test doesn't need a real canvas pipeline
 vi.mock("../../utils/spriteSheetProcessor", () => ({
@@ -27,5 +27,23 @@ describe("SmartImport", () => {
       />
     );
     expect(screen.getByTestId("smart-import-pick")).toBeInTheDocument();
+  });
+});
+
+describe("serializeFrames", () => {
+  it("returns empty string for empty array", () => {
+    expect(serializeFrames([])).toBe("");
+  });
+  it("collapses ascending runs", () => {
+    expect(serializeFrames([1, 2, 3, 4])).toBe("1-4");
+  });
+  it("preserves descending runs as a-b", () => {
+    expect(serializeFrames([3, 2, 1])).toBe("3-1");
+  });
+  it("joins mixed singletons and runs", () => {
+    expect(serializeFrames([1, 3, 4, 5, 7])).toBe("1,3-5,7");
+  });
+  it("keeps duplicates as singletons", () => {
+    expect(serializeFrames([2, 2, 3])).toBe("2,2,3");
   });
 });

--- a/src/__tests__/components/SmartImport.test.tsx
+++ b/src/__tests__/components/SmartImport.test.tsx
@@ -98,15 +98,12 @@ describe("SmartImport frame editor", () => {
     });
   });
 
-  it("reorders frames within a group via drag-drop", async () => {
+  it("moves a frame from busy to idle on drop (cross-group move)", async () => {
     render(<SmartImport onSave={vi.fn()} onCancel={vi.fn()} initialFilePath="/fake.png" />);
-    // Remove a frame first so idle has only 1; instead seed by dragging between existing lists.
-    // Use busy list (which has frame 2) into idle (which has frame 1).
     const source = await screen.findByTestId("frame-chip-busy-2");
     const target = await screen.findByTestId("frame-chip-idle-1");
     const dataTransfer = makeDT();
     fireEvent.dragStart(source, { dataTransfer });
-    // drop before idle-1
     fireEvent.dragOver(target, { dataTransfer, clientX: 0 });
     fireEvent.drop(target, { dataTransfer });
     await waitFor(() => {
@@ -114,5 +111,27 @@ describe("SmartImport frame editor", () => {
       const nums = [...list.querySelectorAll(".smart-import-frame-num")].map((n) => n.textContent);
       expect(nums).toEqual(["2", "1"]);
     });
+    // source lost it
+    expect(screen.queryByTestId("frame-chip-busy-2")).toBeNull();
   });
+
+  it("copies a frame when Alt is held during drop", async () => {
+    render(<SmartImport onSave={vi.fn()} onCancel={vi.fn()} initialFilePath="/fake.png" />);
+    const source = await screen.findByTestId("frame-chip-busy-2");
+    const target = await screen.findByTestId("frame-chip-idle-1");
+    const dataTransfer = makeDT();
+    fireEvent.dragStart(source, { dataTransfer });
+    fireEvent.dragOver(target, { dataTransfer, clientX: 0 });
+    // Simulate Alt-held: testing-library doesn't reliably propagate altKey
+    // through drag events, so set dropEffect directly (production sets this
+    // during dragOver when e.altKey is true).
+    dataTransfer.dropEffect = "copy";
+    fireEvent.drop(target, { dataTransfer });
+    await waitFor(() => {
+      expect(screen.getByTestId("frame-chip-idle-2")).toBeInTheDocument();
+    });
+    // source kept it
+    expect(screen.getByTestId("frame-chip-busy-2")).toBeInTheDocument();
+  });
+
 });

--- a/src/__tests__/components/SmartImport.test.tsx
+++ b/src/__tests__/components/SmartImport.test.tsx
@@ -115,6 +115,18 @@ describe("SmartImport frame editor", () => {
     expect(screen.queryByTestId("frame-chip-busy-2")).toBeNull();
   });
 
+  it("normalizes text input on blur and rebuilds thumbs", async () => {
+    render(<SmartImport onSave={vi.fn()} onCancel={vi.fn()} initialFilePath="/fake.png" />);
+    await screen.findByTestId("frame-list-idle");
+    const input = screen.getAllByPlaceholderText("1-5")[0] as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "1,2,3" } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(input.value).toBe("1-3"));
+    expect(screen.getByTestId("frame-chip-idle-1")).toBeInTheDocument();
+    expect(screen.getByTestId("frame-chip-idle-2")).toBeInTheDocument();
+    expect(screen.getByTestId("frame-chip-idle-3")).toBeInTheDocument();
+  });
+
   it("copies a frame when Alt is held during drop", async () => {
     render(<SmartImport onSave={vi.fn()} onCancel={vi.fn()} initialFilePath="/fake.png" />);
     const source = await screen.findByTestId("frame-chip-busy-2");

--- a/src/__tests__/components/SmartImport.test.tsx
+++ b/src/__tests__/components/SmartImport.test.tsx
@@ -1,15 +1,55 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { SmartImport, serializeFrames } from "../../components/SmartImport";
 
 // Stub the sprite-sheet processor so the test doesn't need a real canvas pipeline
-vi.mock("../../utils/spriteSheetProcessor", () => ({
-  loadImage: vi.fn(),
-  prepareCanvas: vi.fn(),
-  detectRows: vi.fn(),
-  extractFrames: vi.fn(),
-  getFramePreview: vi.fn(),
-  createStripFromFrames: vi.fn(),
+vi.mock("../../utils/spriteSheetProcessor", () => {
+  const fakeCanvas = () => document.createElement("canvas");
+  const fakeFrames = Array.from({ length: 7 }, (_, i) => ({
+    index: i, x1: 0, y1: 0, x2: 10, y2: 10,
+  }));
+  return {
+    loadImage: vi.fn(async () => ({} as HTMLImageElement)),
+    prepareCanvas: vi.fn(() => ({ canvas: fakeCanvas(), ctx: null })),
+    removeSmallComponents: vi.fn(),
+    detectRows: vi.fn(() => [{ top: 0, bottom: 10, spans: [{ x1: 0, x2: 10 }] }]),
+    extractFrames: vi.fn(() => fakeFrames),
+    getFramePreview: vi.fn((_c: HTMLCanvasElement, f: { index: number }) => `data:fake-${f.index + 1}`),
+    createStripFromFrames: vi.fn(async () => ({ blob: new Uint8Array([0]), frames: 1 })),
+  };
+});
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readFile: vi.fn(async () => new Uint8Array([137, 80, 78, 71])),
 }));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+
+vi.mock("@tauri-apps/plugin-log", () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+// jsdom lacks createObjectURL
+beforeAll(() => {
+  if (!URL.createObjectURL) {
+    (URL as any).createObjectURL = vi.fn(() => "blob://fake");
+    (URL as any).revokeObjectURL = vi.fn();
+  }
+});
+
+/** Fake dataTransfer compatible with fireEvent drag events. */
+function makeDT() {
+  const data: Record<string, string> = {};
+  return {
+    data,
+    setData(k: string, v: string) { data[k] = v; },
+    getData(k: string) { return data[k] ?? ""; },
+    effectAllowed: "",
+    dropEffect: "",
+    types: [] as string[],
+  } as any;
+}
 
 describe("SmartImport", () => {
   it("renders the dropzone when no file is loaded", () => {
@@ -45,5 +85,16 @@ describe("serializeFrames", () => {
   });
   it("keeps duplicates as singletons", () => {
     expect(serializeFrames([2, 2, 3])).toBe("2,2,3");
+  });
+});
+
+describe("SmartImport frame editor", () => {
+  it("removes a frame when × is clicked", async () => {
+    render(<SmartImport onSave={vi.fn()} onCancel={vi.fn()} initialFilePath="/fake.png" />);
+    const btn = await screen.findByTestId("frame-remove-idle-1");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(screen.queryByTestId("frame-chip-idle-1")).toBeNull();
+    });
   });
 });

--- a/src/__tests__/components/SmartImport.test.tsx
+++ b/src/__tests__/components/SmartImport.test.tsx
@@ -97,4 +97,22 @@ describe("SmartImport frame editor", () => {
       expect(screen.queryByTestId("frame-chip-idle-1")).toBeNull();
     });
   });
+
+  it("reorders frames within a group via drag-drop", async () => {
+    render(<SmartImport onSave={vi.fn()} onCancel={vi.fn()} initialFilePath="/fake.png" />);
+    // Remove a frame first so idle has only 1; instead seed by dragging between existing lists.
+    // Use busy list (which has frame 2) into idle (which has frame 1).
+    const source = await screen.findByTestId("frame-chip-busy-2");
+    const target = await screen.findByTestId("frame-chip-idle-1");
+    const dataTransfer = makeDT();
+    fireEvent.dragStart(source, { dataTransfer });
+    // drop before idle-1
+    fireEvent.dragOver(target, { dataTransfer, clientX: 0 });
+    fireEvent.drop(target, { dataTransfer });
+    await waitFor(() => {
+      const list = screen.getByTestId("frame-list-idle");
+      const nums = [...list.querySelectorAll(".smart-import-frame-num")].map((n) => n.textContent);
+      expect(nums).toEqual(["2", "1"]);
+    });
+  });
 });

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -53,7 +53,7 @@ const STATUS_DESCRIPTIONS: Record<Status, string> = {
 };
 
 /** Parse "1-5" or "1,2,3,5,6" into 0-based indices. Preserves order and duplicates. Ranges are directional: 3-1 → 3,2,1. */
-function parseFrameInput(input: string, maxFrame: number): number[] {
+export function parseFrameInput(input: string, maxFrame: number): number[] {
   const indices: number[] = [];
   for (const part of input.split(",")) {
     const trimmed = part.trim();
@@ -78,6 +78,30 @@ function parseFrameInput(input: string, maxFrame: number): number[] {
     }
   }
   return indices;
+}
+
+/** Inverse of parseFrameInput. Collapses consecutive runs; preserves direction. */
+export function serializeFrames(nums: number[]): string {
+  if (nums.length === 0) return "";
+  const parts: string[] = [];
+  let i = 0;
+  while (i < nums.length) {
+    let j = i;
+    const prevDup = i > 0 && nums[i - 1] === nums[i];
+    const step = prevDup
+      ? 0
+      : nums[i + 1] === nums[i] + 1
+      ? 1
+      : nums[i + 1] === nums[i] - 1
+      ? -1
+      : 0;
+    if (step !== 0) {
+      while (j + 1 < nums.length && nums[j + 1] === nums[j] + step) j++;
+    }
+    parts.push(j === i ? `${nums[i]}` : `${nums[i]}-${nums[j]}`);
+    i = j + 1;
+  }
+  return parts.join(",");
 }
 
 export function SmartImport({

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -456,7 +456,7 @@ export function SmartImport({
                         className={cls}
                         data-testid={`frame-chip-${status}-${thumb.num}`}
                       >
-                        <img src={thumb.src} alt={`Frame ${thumb.num}`} className="smart-import-frame-thumb" />
+                        <img src={thumb.src} alt={`Frame ${thumb.num}`} className="smart-import-frame-thumb" draggable={false} />
                         <span className="smart-import-frame-num">{thumb.num}</span>
                         <button
                           type="button"

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -377,11 +377,30 @@ export function SmartImport({
                   </div>
                 </div>
                 {frameThumbs[status]?.length > 0 && (
-                  <div className="smart-import-frame-previews">
+                  <div
+                    className="smart-import-frame-previews"
+                    data-testid={`frame-list-${status}`}
+                  >
                     {frameThumbs[status].map((thumb, i) => (
-                      <div key={i} className="smart-import-frame-thumb-item">
+                      <div
+                        key={`${thumb.num}-${i}`}
+                        className="smart-import-frame-thumb-item"
+                        data-testid={`frame-chip-${status}-${thumb.num}`}
+                      >
                         <img src={thumb.src} alt={`Frame ${thumb.num}`} className="smart-import-frame-thumb" />
                         <span className="smart-import-frame-num">{thumb.num}</span>
+                        <button
+                          type="button"
+                          className="smart-import-frame-thumb-remove"
+                          aria-label={`Remove frame ${thumb.num}`}
+                          data-testid={`frame-remove-${status}-${thumb.num}`}
+                          onClick={() => {
+                            const next = frameThumbs[status].filter((_, idx) => idx !== i).map((t) => t.num);
+                            applyFramesChange(status, next);
+                          }}
+                        >
+                          ×
+                        </button>
                       </div>
                     ))}
                   </div>

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -258,7 +258,7 @@ export function SmartImport({
     const raw = e.dataTransfer.getData("application/x-frame");
     if (!raw) return;
     const data = JSON.parse(raw) as { sourceStatus: Status; index: number; num: number };
-    const copy = e.altKey;
+    const copy = e.altKey || e.dataTransfer.dropEffect === "copy";
     const insertAt = dropTarget?.status === status ? dropTarget.index : frameThumbs[status].length;
 
     if (data.sourceStatus === status) {

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -132,6 +132,7 @@ export function SmartImport({
     for (const s of ALL_STATUSES) init[s] = [];
     return init as Record<Status, { src: string; num: number }[]>;
   });
+  const previewCache = useRef<Map<number, string>>(new Map());
 
   const processFile = useCallback(async (filePath: string) => {
     setError(null);
@@ -153,6 +154,7 @@ export function SmartImport({
       const prepared = prepareCanvas(img).canvas;
       removeSmallComponents(prepared);
       setCanvas(prepared);
+      previewCache.current.clear();
 
       const detected = detectRows(prepared);
       if (detected.length === 0) {
@@ -210,19 +212,26 @@ export function SmartImport({
     }
   }, [initialFilePath, processFile]);
 
-  const updateThumbs = useCallback((status: Status, inputValue?: string) => {
+  const applyFramesChange = useCallback((status: Status, nextNums: number[]) => {
     if (!canvas || frames.length === 0) return;
-    const value = inputValue ?? frameInputs[status];
-    const indices = parseFrameInput(value, frames.length);
-    const previews = indices.map((i) => ({ src: getFramePreview(canvas, frames[i], 72), num: i + 1 }));
-    setFrameThumbs((prev) => ({ ...prev, [status]: previews }));
-  }, [canvas, frames, frameInputs]);
+    const cache = previewCache.current;
+    const thumbs = nextNums.map((num) => {
+      let src = cache.get(num);
+      if (!src) {
+        src = getFramePreview(canvas, frames[num - 1], 72);
+        cache.set(num, src);
+      }
+      return { src, num };
+    });
+    setFrameThumbs((prev) => ({ ...prev, [status]: thumbs }));
+    setFrameInputs((prev) => ({ ...prev, [status]: serializeFrames(nextNums) }));
+  }, [canvas, frames]);
 
   const handlePreview = useCallback(async (status: Status, inputValue?: string) => {
     if (!canvas || frames.length === 0) return;
     const value = inputValue ?? frameInputs[status];
     const indices = parseFrameInput(value, frames.length);
-    updateThumbs(status, value);
+    applyFramesChange(status, indices.map((i) => i + 1));
     if (indices.length === 0) return;
 
     const strip = await createStripFromFrames(canvas, frames, indices);
@@ -230,7 +239,7 @@ export function SmartImport({
     const url = URL.createObjectURL(blob);
     if (animPreview?.url) URL.revokeObjectURL(animPreview.url);
     setAnimPreview({ url, frames: strip.frames, label: STATUS_LABELS[status] });
-  }, [canvas, frames, frameInputs, animPreview, updateThumbs]);
+  }, [canvas, frames, frameInputs, animPreview, applyFramesChange]);
 
 
 
@@ -359,7 +368,10 @@ export function SmartImport({
                       value={frameInputs[status]}
                       placeholder="1-5"
                       onChange={(e) => setFrameInputs((prev) => ({ ...prev, [status]: e.target.value }))}
-                      onBlur={(e) => updateThumbs(status, e.currentTarget.value)}
+                      onBlur={(e) => {
+                        const nums = parseFrameInput(e.currentTarget.value, frames.length).map((i) => i + 1);
+                        applyFramesChange(status, nums);
+                      }}
                     />
                     <button className="smart-import-preview-btn" onClick={() => handlePreview(status)}>Preview</button>
                   </div>

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -133,6 +133,8 @@ export function SmartImport({
     return init as Record<Status, { src: string; num: number }[]>;
   });
   const previewCache = useRef<Map<number, string>>(new Map());
+  const [dragging, setDragging] = useState<{ status: Status; index: number } | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ status: Status; index: number } | null>(null);
 
   const processFile = useCallback(async (filePath: string) => {
     setError(null);
@@ -226,6 +228,61 @@ export function SmartImport({
     setFrameThumbs((prev) => ({ ...prev, [status]: thumbs }));
     setFrameInputs((prev) => ({ ...prev, [status]: serializeFrames(nextNums) }));
   }, [canvas, frames]);
+
+  const onChipDragStart = (status: Status, index: number) => (e: React.DragEvent) => {
+    const payload = { sourceStatus: status, index, num: frameThumbs[status][index].num };
+    e.dataTransfer.setData("application/x-frame", JSON.stringify(payload));
+    e.dataTransfer.effectAllowed = "copyMove";
+    setDragging({ status, index });
+  };
+
+  const onChipDragOver = (status: Status, index: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = e.altKey ? "copy" : "move";
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const after = e.clientX - rect.left > rect.width / 2;
+    setDropTarget({ status, index: after ? index + 1 : index });
+  };
+
+  const onListDragOver = (status: Status) => (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = e.altKey ? "copy" : "move";
+    setDropTarget((prev) => {
+      if (prev && prev.status === status) return prev;
+      return { status, index: frameThumbs[status].length };
+    });
+  };
+
+  const onListDrop = (status: Status) => (e: React.DragEvent) => {
+    e.preventDefault();
+    const raw = e.dataTransfer.getData("application/x-frame");
+    if (!raw) return;
+    const data = JSON.parse(raw) as { sourceStatus: Status; index: number; num: number };
+    const copy = e.altKey;
+    const insertAt = dropTarget?.status === status ? dropTarget.index : frameThumbs[status].length;
+
+    if (data.sourceStatus === status) {
+      const nums = frameThumbs[status].map((t) => t.num);
+      const [m] = nums.splice(data.index, 1);
+      nums.splice(insertAt > data.index ? insertAt - 1 : insertAt, 0, m);
+      applyFramesChange(status, nums);
+    } else {
+      const dst = frameThumbs[status].map((t) => t.num);
+      dst.splice(insertAt, 0, data.num);
+      applyFramesChange(status, dst);
+      if (!copy) {
+        const src = frameThumbs[data.sourceStatus].map((t) => t.num).filter((_, i) => i !== data.index);
+        applyFramesChange(data.sourceStatus, src);
+      }
+    }
+    setDragging(null);
+    setDropTarget(null);
+  };
+
+  const onDragEnd = () => {
+    setDragging(null);
+    setDropTarget(null);
+  };
 
   const handlePreview = useCallback(async (status: Status, inputValue?: string) => {
     if (!canvas || frames.length === 0) return;
@@ -378,13 +435,25 @@ export function SmartImport({
                 </div>
                 {frameThumbs[status]?.length > 0 && (
                   <div
-                    className="smart-import-frame-previews"
+                    className={`smart-import-frame-previews${dropTarget?.status === status ? " drop-target" : ""}`}
                     data-testid={`frame-list-${status}`}
+                    onDragOver={onListDragOver(status)}
+                    onDrop={onListDrop(status)}
                   >
-                    {frameThumbs[status].map((thumb, i) => (
+                    {frameThumbs[status].map((thumb, i) => {
+                      const isDragging = dragging?.status === status && dragging.index === i;
+                      const dropSide =
+                        dropTarget?.status === status && dropTarget.index === i ? "before" :
+                        dropTarget?.status === status && dropTarget.index === i + 1 ? "after" : null;
+                      const cls = `smart-import-frame-thumb-item${isDragging ? " dragging" : ""}${dropSide ? ` drop-${dropSide}` : ""}`;
+                      return (
                       <div
                         key={`${thumb.num}-${i}`}
-                        className="smart-import-frame-thumb-item"
+                        draggable
+                        onDragStart={onChipDragStart(status, i)}
+                        onDragOver={onChipDragOver(status, i)}
+                        onDragEnd={onDragEnd}
+                        className={cls}
                         data-testid={`frame-chip-${status}-${thumb.num}`}
                       >
                         <img src={thumb.src} alt={`Frame ${thumb.num}`} className="smart-import-frame-thumb" />
@@ -402,7 +471,8 @@ export function SmartImport({
                           ×
                         </button>
                       </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -820,6 +820,14 @@
 
 .smart-import-frame-thumb-item {
   cursor: grab;
+  user-select: none;
+  -webkit-user-drag: element;
+}
+
+.smart-import-frame-thumb-item img,
+.smart-import-frame-thumb-item span {
+  -webkit-user-drag: none;
+  pointer-events: none;
 }
 
 .smart-import-frame-thumb-item:active {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -793,6 +793,29 @@
   flex-direction: column;
   align-items: center;
   gap: 2px;
+  position: relative;
+}
+
+.smart-import-frame-thumb-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(20, 20, 20, 0.95);
+  color: #eee;
+  font-size: 11px;
+  line-height: 12px;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms;
+}
+
+.smart-import-frame-thumb-item:hover .smart-import-frame-thumb-remove {
+  opacity: 1;
 }
 
 .smart-import-frame-thumb {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -818,6 +818,32 @@
   opacity: 1;
 }
 
+.smart-import-frame-thumb-item {
+  cursor: grab;
+}
+
+.smart-import-frame-thumb-item:active {
+  cursor: grabbing;
+}
+
+.smart-import-frame-thumb-item.dragging {
+  opacity: 0.4;
+}
+
+.smart-import-frame-thumb-item.drop-before {
+  box-shadow: -2px 0 0 0 #4af;
+}
+
+.smart-import-frame-thumb-item.drop-after {
+  box-shadow: 2px 0 0 0 #4af;
+}
+
+.smart-import-frame-previews.drop-target {
+  outline: 1px dashed rgba(74, 170, 255, 0.4);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .smart-import-frame-thumb {
   width: 36px;
   height: 36px;


### PR DESCRIPTION
## Summary

After smart-importing a sprite sheet, users couldn't edit the auto-assigned frames — only re-type the `1-5` ranges. This adds direct manipulation on the frame thumbnails while keeping the text input for power users.

- **Remove frame** — hover a thumb → `×` button → click to remove from a status group
- **Drag to reorder** within a status group
- **Drag between status groups** — default = move, hold **Option/Alt** = copy
- **Text ↔ visual stay in sync** — text normalizes on blur (`1,2,3` → `1-3`), drag/remove reserializes text
- Native HTML5 DnD, no new dependencies

## Why

Users need to fine-tune frame assignments without re-editing sprite sheets or retyping ranges. Auto-assign is a starting point, not the final state.

## Implementation notes

- Central mutator `applyFramesChange(status, number[])` keeps `frameThumbs` (visual) and `frameInputs` (text) in sync from the same source array
- `serializeFrames(number[]): string` is the inverse of existing `parseFrameInput` — collapses runs, preserves direction
- Frame preview thumbs cached per-frame in a `useRef<Map>` to avoid recomputing canvas crops on every drop
- Tauri 2 defaults to intercepting drops for file-drop; disabled on Settings window via `"dragDropEnabled": false`
- `<img>` inside chip marked `draggable={false}` so the parent chip owns the drag source (prevents native image-drag hijack)

## Test plan

### Automated
- [x] `bun run test -- SmartImport` → 11/11 pass (incl. new serialize + remove + cross-group move + alt-copy + text-sync tests)
- [x] `bun run test -- Settings` → 14/14 pass (existing coverage intact)
- [x] `bunx tsc --noEmit` clean

### Manual (macOS, `bun run tauri dev`)
- [x] Settings → Smart Import → pick sprite sheet → per-status thumbs show with `×` on hover
- [x] Click × → thumb removed, text input reserializes (e.g. `1-5` → `1-2,4-5`)
- [x] Drag thumb within Idle → reorder, text updates
- [x] Drag Idle → Busy (plain) → source loses, target gains
- [x] Drag Idle → Busy holding Option → both keep
- [x] Type `1,2,3` + blur → normalizes to `1-3`, thumbs match
- [x] Preview button still plays current order per status
- [x] Save → reopen → edit → frame assignments preserved

## Files changed

- `src/components/SmartImport.tsx` — state refactor + DnD handlers + remove UI
- `src/styles/settings.css` — thumb chrome (remove btn, drag states, drop indicator)
- `src/__tests__/components/SmartImport.test.tsx` — unit coverage for new interactions
- `src-tauri/tauri.conf.json` — disable Tauri drag-drop interception on Settings window