### PR TITLE
fix(shell): classify ssh as service

### DIFF
--- a/src-tauri/script/terminal-mirror.bash
+++ b/src-tauri/script/terminal-mirror.bash
@@ -18,7 +18,7 @@ _tm_is_claude() {
 # --- Command categorization ---
 _tm_classify() {
   local cmd="$1"
-  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|docker-compose|docker\ compose|up) ]]; then
+  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|docker-compose|docker\ compose|up|ssh) ]]; then
     echo "service"
   else
     echo "task"

--- a/src-tauri/script/terminal-mirror.fish
+++ b/src-tauri/script/terminal-mirror.fish
@@ -16,7 +16,7 @@ end
 # --- Command categorization ---
 function _tm_classify
     set -l cmd "$argv[1]"
-    if string match -rq '(^|\s|/)(start|dev|serve|watch|metro|docker-compose|docker compose|up)(\s|$)' -- "$cmd"
+    if string match -rq '(^|\s|/)(start|dev|serve|watch|metro|docker-compose|docker compose|up|ssh)(\s|$)' -- "$cmd"
         echo "service"
     else
         echo "task"

--- a/src-tauri/script/terminal-mirror.zsh
+++ b/src-tauri/script/terminal-mirror.zsh
@@ -21,7 +21,7 @@ _tm_is_claude() {
 # "task"    = normal command, stay busy until done
 _tm_classify() {
   local cmd="$1"
-  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|docker-compose|docker\ compose|up|run\ dev|run\ start|run\ serve)([[:space:]]|$) ]]; then
+  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|docker-compose|docker\ compose|up|run\ dev|run\ start|run\ serve|ssh)([[:space:]]|$) ]]; then
     echo "service"
   else
     echo "task"


### PR DESCRIPTION
## Summary
- Add `ssh` to the `_tm_classify` regex in all three shell hooks (zsh, bash, fish) so SSH sessions are treated as `service` instead of `task`.
- Without this, `ssh user@host` stayed `busy` for the entire remote session, leaving the pet visually "working" the whole time. Now it flashes blue then returns to idle via the 2s watchdog, matching `dev`/`serve`/`watch` behavior.

## Test plan
- [ ] Re-source shell script (`source ~/.zshrc` or new terminal).
- [ ] Run `ssh <host>` from zsh — pet flashes `service` then returns to `idle`.
- [ ] Repeat from bash and fish shells.
- [ ] Regression: confirm `dev`, `serve`, `docker compose up`, `bun run dev` still classify as `service`.
- [ ] Regression: confirm arbitrary commands (e.g. `ls`, `cargo build`) still classify as `task`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)