### PR TITLE
fix(proc-scan): detect claude.exe as claude

### DIFF
--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -416,9 +416,15 @@ fn is_shell(name: &str) -> bool {
 }
 
 fn is_claude(proc: &ProcInfo) -> bool {
-    // libproc's `p_comm` returns "node" for Claude Code (which is a Node app),
-    // so we check both the kernel name and argv[0] basename.
-    proc.name == "claude" || argv0_basename(&proc.argv0) == "claude"
+    // Claude Code has shipped under two executable names:
+    //   • "node" — older Node-shipped CLI (real name is via argv[0])
+    //   • "claude.exe" — newer single-file compiled binary at
+    //     ~/.../@anthropic-ai/claude-code/bin/claude.exe, with a `claude`
+    //     symlink in PATH. p_comm reflects the real file, not the symlink.
+    fn is_claude_name(s: &str) -> bool {
+        s == "claude" || s == "claude.exe"
+    }
+    is_claude_name(&proc.name) || is_claude_name(argv0_basename(&proc.argv0))
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- Newer Claude Code releases ship a compiled single-file binary at `~/.../@anthropic-ai/claude-code/bin/claude.exe` with a `claude` symlink in PATH; macOS `p_comm` reflects the real file, so `proc_pid::name()` returns `"claude.exe"`.
- `is_claude()` only matched `"claude"`, so on the owning shell's row the claude icon disappeared, the label showed `"claude.exe"`, and the claude session was dropped as a zombie every 2s — making the pet's busy/idle mirror flap instead of sticking on busy while Claude worked.
- Fix: match both `"claude"` and `"claude.exe"` as exec name or argv[0] basename.

## Test plan
- [x] `cargo check` in `src-tauri/` passes.
- [x] With the new build running, `tail -f` on the Tauri log shows no `[proc_scan] dropping zombie session pid=<claude-pid>` entries.
- [x] While Claude is working, `/debug` shows the claude PID in `Sessions` with `ui=busy` persisting across proc_scan ticks (no idle oscillation).
- [x] Session dropdown shows the owning shell with the `claude` label + claude icon, and the dot mirrors busy when Claude is running a tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)