### PR TITLE
chore: release v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.16.2] - 2026-04-18
+
+### Fixed
+- **Claude Code session detection for the new `claude.exe` binary** — newer Claude Code releases ship a compiled single-file binary named `claude.exe` (with `claude` as a PATH symlink). `proc_scan` was still matching only `"claude"`, so on the owning shell's row the claude icon disappeared, the label showed `"claude.exe"`, and the claude session was dropped as a zombie every 2s — making the pet's busy/idle mirror flap instead of sticking on busy while Claude worked. `is_claude()` now matches both `"claude"` and `"claude.exe"`.
+- **`ssh` classified as a service** — long-running SSH sessions were stuck on `busy` for the full connection, keeping the pet visually working the entire time. `ssh` now flashes service then returns to idle, matching `dev` / `serve` / `watch` etc.
+
+### Added
+- **`DEV` badge over the mascot** when running via `bun run tauri dev`. The badge is driven by Vite's build-time `import.meta.env.DEV` flag, so it tree-shakes out of release builds — zero visual change for installed-app users. Makes it easy to tell the running dev build apart from the installed `/Applications/Ani-Mime.app` at a glance.
+
 ## [0.16.1] - 2026-04-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.16.1"
+version = "0.16.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { StatusPill } from "./components/StatusPill";
 import { SpeechBubble } from "./components/SpeechBubble";
 import { VisitorDog } from "./components/VisitorDog";
 import { DevTag } from "./components/DevTag";
+import { DevBuildBadge } from "./components/DevBuildBadge";
 import { EffectOverlay } from "./effects";
 import { useStatus } from "./hooks/useStatus";
 import { useDrag } from "./hooks/useDrag";
@@ -89,6 +90,7 @@ function App() {
       <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
       {status !== "visiting" && <Mascot status={status} />}
       {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
+      <DevBuildBadge />
       <StatusPill status={status} glow={visible} />
       {devMode && <DevTag />}
       {visitors.map((v, i) => (

--- a/src/components/DevBuildBadge.tsx
+++ b/src/components/DevBuildBadge.tsx
@@ -1,0 +1,12 @@
+import "../styles/dev-build-badge.css";
+
+/** Renders only in `bun run tauri dev` builds — Vite sets
+ *  `import.meta.env.DEV` to true there and false for `vite build` (release). */
+export function DevBuildBadge() {
+  if (!import.meta.env.DEV) return null;
+  return (
+    <div className="dev-build-badge" data-testid="dev-build-badge" aria-hidden="true">
+      DEV
+    </div>
+  );
+}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -787,7 +787,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.16.1{devMode && " (Dev Mode)"}
+                  Version 0.16.2{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>

--- a/src/styles/dev-build-badge.css
+++ b/src/styles/dev-build-badge.css
@@ -1,0 +1,23 @@
+/* Centered over the 128×scale mascot tile. Container padding-top/left = 20px
+   (see app.css), mascot is 128 * var(--sprite-scale) — so the mascot center
+   sits at (20 + 64·s, 20 + 64·s) within .container. */
+.dev-build-badge {
+  position: absolute;
+  top: calc(20px + 64px * var(--sprite-scale, 1));
+  left: calc(20px + 64px * var(--sprite-scale, 1));
+  transform: translate(-50%, -50%);
+  padding: 4px 12px;
+  font-family: "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 2px;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(94, 92, 230, 0.35);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 6px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  z-index: 5;
+}


### PR DESCRIPTION
## Summary

Patch release bundling the two fixes merged since v0.16.1 plus a small dev-only convenience.

**Fixed**
- `fix(proc-scan): detect claude.exe as claude` (#84) — restores the claude icon, `claude` label, and busy/idle mirror on the owning shell row for the new single-file Claude Code binary.
- `fix(shell): classify ssh as service` (#83) — stops `ssh` sessions from keeping the pet stuck on busy.

**Added**
- `feat(dev): show DEV badge over mascot in tauri dev builds` — translucent label overlaid on the mascot when `import.meta.env.DEV` is true. Tree-shakes out of release builds, zero runtime impact for installed users.

## Version bumps
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src/components/Settings.tsx` → `0.16.2`
- `Cargo.lock` regenerated via `cargo check`
- `CHANGELOG.md` entry for `[0.16.2] - 2026-04-18`

## Test plan
- [x] `cargo check` in `src-tauri/` passes.
- [x] `npx tsc --noEmit` passes.
- [x] Dev build manually verified: no `[proc_scan] dropping zombie session pid=<claude-pid>` lines; `ssh` flashes service then idle; DEV badge appears only in `bun run tauri dev` and disappears in the release build.
- [ ] After merge: tag `v0.16.2`, CI builds aarch64 + x86_64 DMGs.
- [ ] After CI: Homebrew cask (`vietnguyenhoangw/homebrew-ani-mime`) bumped with new version + SHA256s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)