### PR TITLE
chore: release v0.16.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,29 @@ permissions:
   contents: write
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release with auto-generated notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists, skipping create"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "Ani-Mime $GITHUB_REF_NAME" \
+              --notes "$(gh api repos/${{ github.repository }}/releases/generate-notes \
+                -f tag_name="$GITHUB_REF_NAME" \
+                --jq .body)"
+          fi
+
   build:
+    needs: create-release
     strategy:
       matrix:
         include:
@@ -42,7 +64,6 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Ani-Mime ${{ github.ref_name }}"
-          releaseBody: "See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
           releaseDraft: false
           prerelease: false
           args: --target ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.16.3] - 2026-04-18
+
+### Added
+- **Claude Code plugin manager tab** in Settings — view, enable, disable, and manage installed Claude Code plugins directly from Ani-Mime. (#86, @thanh-dong)
+
+### Changed
+- **GitHub release notes are now auto-generated from merged PRs** via `gh release create --generate-notes`. The release page shows a "What's Changed" list linking every PR + author since the previous tag, plus a "Full Changelog" compare link. `CHANGELOG.md` remains the curated long-form history.
+
 ## [0.16.2] - 2026-04-18
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,10 @@ After editing `Cargo.toml`, run `cargo check` in `src-tauri/` to regenerate `Car
 2. **Commit**: `chore: release vX.Y.Z`
 3. **PR → merge to main** (branch protection requires PR)
 4. **Tag on main**: `git tag vX.Y.Z && git push origin vX.Y.Z`
-5. **CI builds automatically** — triggered by `v*` tag push, builds aarch64 + x86_64 DMGs
+5. **CI builds automatically** — triggered by `v*` tag push:
+   - `create-release` job runs first: calls `gh release create --notes "$(gh api .../releases/generate-notes)"` to publish the GitHub release with an auto-generated "What's Changed" list of PRs merged since the previous tag, plus a **Full Changelog** compare link
+   - `build` matrix then builds aarch64 + x86_64 DMGs and uploads them to that same release
+   - Write PR titles in conventional-commit style (`feat:`, `fix:`, `chore:`, etc.) — they become the release-note bullet text verbatim
 6. **Update Homebrew cask** after CI publishes DMG artifacts:
    - Download both DMGs: `gh release download vX.Y.Z --pattern "*.dmg"`
    - Compute hashes: `shasum -a 256 *.dmg`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.16.2"
+version = "0.16.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1009,7 +1009,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.16.2{devMode && " (Dev Mode)"}
+                  Version 0.16.3{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.16.3 across all 4 required files (package.json, Cargo.toml, tauri.conf.json, Settings.tsx)
- Switch GitHub release notes to auto-generate from merged PRs via `gh release create --generate-notes` (new `create-release` job in `release.yml`, runs before the build matrix)
- Document the new release-notes flow in `CLAUDE.md`
- CHANGELOG entry for 0.16.3 (plugin manager tab + release-notes workflow change)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `cd src-tauri && cargo check` passes (Cargo.lock regenerated)
- [ ] After merge + tag push: verify `create-release` job publishes the release with an auto-generated "What's Changed" list and "Full Changelog" link
- [ ] Both DMGs (aarch64 + x64) upload to the same release
- [ ] Update Homebrew cask with new SHA256s once DMGs are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)