### PR TITLE
feat(updater): add "Install Updates Automatically" toggle (default on)

### DIFF
--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -57,6 +57,20 @@ pub fn check_for_updates(app_handle: tauri::AppHandle) {
             }
         }
 
+        // Auto-install (default true): skip dialog and run brew upgrade directly
+        // Only explicit `false` in settings.json falls back to the confirmation dialog
+        let auto_install = std::fs::read_to_string(&store_path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+            .and_then(|j| j.get("autoInstallEnabled").and_then(|v| v.as_bool()))
+            .unwrap_or(true);
+
+        if auto_install {
+            crate::app_log!("[updater] auto-install enabled — updating to v{} without prompt", latest);
+            update_now(&app_handle);
+            return;
+        }
+
         show_update_dialog(&app_handle, current, &latest);
     });
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -8,6 +8,7 @@ import { useGlow, type GlowMode } from "../hooks/useGlow";
 import { useNickname } from "../hooks/useNickname";
 import { useAutoStart } from "../hooks/useAutoStart";
 import { useAutoUpdate } from "../hooks/useAutoUpdate";
+import { useAutoInstall } from "../hooks/useAutoInstall";
 import { useDockVisible } from "../hooks/useDockVisible";
 import { useTrayVisible } from "../hooks/useTrayVisible";
 import { useSessionList } from "../hooks/useSessionList";
@@ -80,6 +81,7 @@ export function Settings() {
   const { nickname, setNickname } = useNickname();
   const { enabled: autoStartEnabled, setEnabled: setAutoStartEnabled } = useAutoStart();
   const { enabled: autoUpdateEnabled, setEnabled: setAutoUpdateEnabled } = useAutoUpdate();
+  const { enabled: autoInstallEnabled, setEnabled: setAutoInstallEnabled } = useAutoInstall();
   const { hidden: dockHidden, setHidden: setDockHidden } = useDockVisible();
   const { hidden: trayHidden, setHidden: setTrayHidden } = useTrayVisible();
   const { enabled: sessionListEnabled, setEnabled: setSessionListEnabled } = useSessionList();
@@ -406,6 +408,21 @@ export function Settings() {
                 <button
                   className={`toggle-switch ${autoUpdateEnabled ? "active" : ""}`}
                   onClick={() => setAutoUpdateEnabled(!autoUpdateEnabled)}
+                  data-testid="settings-auto-update-toggle"
+                >
+                  <span className="toggle-knob" />
+                </button>
+              </div>
+              <div className="settings-row with-hint">
+                <div>
+                  <span className="settings-row-label">Install Updates Automatically</span>
+                  <span className="settings-row-hint">When enabled, new versions install without asking. A Terminal window will run the Homebrew upgrade and the app will restart.</span>
+                </div>
+                <button
+                  className={`toggle-switch ${autoInstallEnabled ? "active" : ""}`}
+                  onClick={() => setAutoInstallEnabled(!autoInstallEnabled)}
+                  disabled={!autoUpdateEnabled}
+                  data-testid="settings-auto-install-toggle"
                 >
                   <span className="toggle-knob" />
                 </button>

--- a/src/hooks/useAutoInstall.ts
+++ b/src/hooks/useAutoInstall.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useLayoutEffect } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { emit, listen } from "@tauri-apps/api/event";
+
+export function useAutoInstall() {
+  const [enabled, setEnabledState] = useState(true);
+
+  useLayoutEffect(() => {
+    load("settings.json").then(async (store) => {
+      const val = await store.get<boolean>("autoInstallEnabled");
+      if (val !== null && val !== undefined) {
+        setEnabledState(val);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>("auto-install-changed", (event) => {
+      setEnabledState(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const setEnabled = async (next: boolean) => {
+    const store = await load("settings.json");
+    await store.set("autoInstallEnabled", next);
+    await store.save();
+    setEnabledState(next);
+    await emit("auto-install-changed", next);
+  };
+
+  return { enabled, setEnabled };
+}


### PR DESCRIPTION
## Summary
- Adds a new Settings toggle **Install Updates Automatically** (default ON) so detected new versions install via `brew upgrade --cask ani-mime` without showing the Later/Changelog/Update Now dialog.
- Existing **Automatically Check for Updates** toggle is unchanged; new toggle is nested under it and disabled when check-for-updates is off.
- Manual update check from the menu always shows the dialog — only the automatic on-launch check respects this setting.

## Behavior
| autoUpdateEnabled | autoInstallEnabled | On-launch behavior |
|---|---|---|
| on | on (default) | Check → if new version → silently run brew upgrade + restart |
| on | off | Check → if new version → show existing dialog |
| off | — | No check, nothing happens |

Defaults to ON for all users (new installs and existing users upgrading without the key).

## Files
- `src/hooks/useAutoInstall.ts` — new hook mirroring `useAutoUpdate` pattern
- `src/components/Settings.tsx` — new toggle row under the check-for-updates row
- `src-tauri/src/updater.rs` — read `autoInstallEnabled` after detecting a newer version; call `update_now` directly when true

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes
- [ ] Manual: toggle UI responds, persists in `settings.json`, disables when check-for-updates is off
- [ ] Manual: with auto-install on and a newer release published, confirm the dialog is skipped and Terminal runs the upgrade
- [ ] Manual: with auto-install off, confirm the dialog still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)