### PR TITLE
feat(session-list): collapsible group headers with persistent state

### DIFF
--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import type { Status } from "../types/status";
 import { fetchSessions, type SessionInfo } from "../hooks/useSessions";
 import { useSessionList } from "../hooks/useSessionList";
+import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import "../styles/status-pill.css";
 
 interface StatusPillProps {
@@ -198,6 +199,7 @@ export function StatusPill({ status, glow }: StatusPillProps) {
   const [groups, setGroups] = useState<Group[]>([]);
   const wrapRef = useRef<HTMLDivElement>(null);
   const { enabled: sessionListEnabled } = useSessionList();
+  const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
 
   const toggleOpen = async (e: React.MouseEvent) => {
     if (!sessionListEnabled) return; // feature disabled — pill is not clickable
@@ -286,13 +288,13 @@ export function StatusPill({ status, glow }: StatusPillProps) {
           {groups.length === 0 ? (
             <div className="session-empty">No active terminals</div>
           ) : (
-            groups.map((g) => (
-              <div
-                key={g.key}
-                className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
-                data-testid={`session-group-${g.key}`}
-              >
-                <div className="session-group-head">
+            groups.map((g) => {
+              const isCollapsed = collapsed.has(g.key);
+              const headContent = (
+                <>
+                  {!g.isClaudeFallback && (
+                    <span className="session-group-caret" aria-hidden="true" />
+                  )}
                   <span className={`dot small ${g.state}`} />
                   <span className="session-group-title-row">
                     <span className="session-group-title">
@@ -311,10 +313,37 @@ export function StatusPill({ status, glow }: StatusPillProps) {
                   {g.sessions.length > 1 && (
                     <span className="session-count">{g.sessions.length}</span>
                   )}
-                </div>
+                </>
+              );
+              return (
+              <div
+                key={g.key}
+                className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
+                data-testid={`session-group-${g.key}`}
+              >
+                {g.isClaudeFallback ? (
+                  <div className="session-group-head">{headContent}</div>
+                ) : (
+                  <button
+                    type="button"
+                    className={`session-group-head clickable ${isCollapsed ? "collapsed" : ""}`}
+                    data-testid={`session-group-head-${g.key}`}
+                    aria-expanded={!isCollapsed}
+                    aria-controls={`session-children-${g.key}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void toggleCollapsed(g.key);
+                    }}
+                  >
+                    {headContent}
+                  </button>
+                )}
 
-                {!g.isClaudeFallback && (
-                  <div className="session-children">
+                {!g.isClaudeFallback && !isCollapsed && (
+                  <div
+                    className="session-children"
+                    id={`session-children-${g.key}`}
+                  >
                     {g.sessions.map((s) => (
                       <button
                         key={s.pid}
@@ -344,7 +373,8 @@ export function StatusPill({ status, glow }: StatusPillProps) {
                   </div>
                 )}
               </div>
-            ))
+              );
+            })
           )}
         </div>
       )}

--- a/src/hooks/useCollapsedSessionGroups.ts
+++ b/src/hooks/useCollapsedSessionGroups.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect, useLayoutEffect, useCallback } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { emit, listen } from "@tauri-apps/api/event";
+
+const STORE_KEY = "collapsedSessionGroups";
+const EVENT = "collapsed-session-groups-changed";
+
+export function useCollapsedSessionGroups() {
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+
+  useLayoutEffect(() => {
+    load("settings.json").then(async (store) => {
+      const raw = await store.get<string[]>(STORE_KEY);
+      if (Array.isArray(raw)) setCollapsed(new Set(raw));
+    });
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<string[]>(EVENT, (event) => {
+      setCollapsed(new Set(event.payload ?? []));
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const toggle = useCallback(async (key: string) => {
+    const store = await load("settings.json");
+    const current = (await store.get<string[]>(STORE_KEY)) ?? [];
+    const next = new Set(current);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    const arr = Array.from(next);
+    await store.set(STORE_KEY, arr);
+    await store.save();
+    setCollapsed(next);
+    await emit(EVENT, arr);
+  }, []);
+
+  return { collapsed, toggle };
+}

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -102,6 +102,39 @@
   line-height: 1;
 }
 
+/* When the head is a real <button> (collapsible group) reset button chrome
+ * so it visually matches the non-collapsible div variant. */
+button.session-group-head {
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+button.session-group-head:hover {
+  background: var(--bg-pill-hover);
+}
+
+.session-group-caret {
+  flex-shrink: 0;
+  width: 0;
+  height: 0;
+  border-left: 4px solid currentColor;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  opacity: 0.5;
+  transform: rotate(90deg);
+  transition: transform 120ms ease;
+}
+
+.session-group-head.collapsed .session-group-caret {
+  transform: rotate(0deg);
+}
+
 /* Wraps the title + ? info icon so they sit together regardless of row width. */
 .session-group-title-row {
   flex: 1;

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -109,7 +109,7 @@ button.session-group-head {
   background: none;
   border: none;
   color: inherit;
-  font: inherit;
+  font-family: inherit;
   text-align: left;
   cursor: pointer;
   border-radius: 4px;

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -97,7 +97,7 @@
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 500;
   line-height: 1;
 }

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -97,7 +97,7 @@
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   line-height: 1;
 }

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -97,7 +97,7 @@
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 500;
   line-height: 1;
 }


### PR DESCRIPTION
## Summary
Make each group header in the StatusPill session-list dropdown a toggle that collapses/expands the shells underneath, and remember which groups are collapsed across dropdown opens.

## Behavior
- Click a group header → its shells hide/show
- Collapsed state is stored in `settings.json` under `collapsedSessionGroups` (array of group keys)
- Group keys are the working-dir path (stable across dropdown opens), so a project you collapsed stays collapsed the next time you pop the dropdown open
- A small caret indicator rotates between collapsed (▶) and expanded (▼)
- The Claude-code fallback group (legacy `pid=0`, no children to collapse) stays a plain `<div>` — no toggle

## Files
- `src/hooks/useCollapsedSessionGroups.ts` — new hook using the same `load` + `emit` + `listen` pattern as `useDockVisible` / `useAutoUpdate`
- `src/components/StatusPill.tsx` — group head is now a `<button type="button">` with `aria-expanded` / `aria-controls`; children render only when expanded
- `src/styles/status-pill.css` — button reset for the head, caret styles with rotation

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Manual: open dropdown, click a group header — shells disappear; click again — they reappear
- [ ] Manual: collapse a group, close dropdown, reopen — still collapsed
- [ ] Manual: collapse, quit app, relaunch — still collapsed (settings.json persists)
- [ ] Manual: Claude-code fallback group header is not clickable (no caret, no hover effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)