### PR TITLE
chore: release v0.16.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,15 @@ jobs:
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             echo "Release $GITHUB_REF_NAME already exists, skipping create"
           else
+            # Strip the "chore: release vX.Y.Z" PR bullet — it's noise in the
+            # user-facing changelog, every release has one by definition.
+            notes=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+              -f tag_name="$GITHUB_REF_NAME" \
+              --jq .body \
+              | grep -v -E '^\* chore: release v[0-9]' || true)
             gh release create "$GITHUB_REF_NAME" \
               --title "Ani-Mime $GITHUB_REF_NAME" \
-              --notes "$(gh api repos/${{ github.repository }}/releases/generate-notes \
-                -f tag_name="$GITHUB_REF_NAME" \
-                --jq .body)"
+              --notes "$notes"
           fi
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.16.4] - 2026-04-19
+
+### Added
+- **Install Updates Automatically** toggle in Settings (default ON) — when enabled, a detected new version runs `brew upgrade --cask ani-mime` directly instead of showing the Later/Changelog/Update Now dialog. Disable the toggle to restore the confirmation dialog. Manual menu checks always show the dialog. (#88)
+- **Collapsible session groups** in the status-pill dropdown. Click a group header to hide its shells; the collapsed state is persisted in `settings.json` under `collapsedSessionGroups` and restored on the next dropdown open. (#90)
+
+### Fixed
+- Hook rows and the event-name label in the Claude Code settings tab now align with plugin rows and other row content (removed the `padding-left: 8px` override on `.claude-hook-row`, added horizontal padding to `.claude-hook-header`). (#89)
+- Empty-state messages in the Claude Code tab ("No plugins installed", "No MCP servers registered", "No custom commands", "No hooks configured") now render inside the same grey card container as populated lists, keeping visual rhythm. (#89)
+
+### Changed
+- Release notes auto-generator now filters out `chore: release vX.Y.Z` PRs so each release's "What's Changed" list only shows real feature/fix PRs.
+
 ## [0.16.3] - 2026-04-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,8 @@ After editing `Cargo.toml`, run `cargo check` in `src-tauri/` to regenerate `Car
 3. **PR → merge to main** (branch protection requires PR)
 4. **Tag on main**: `git tag vX.Y.Z && git push origin vX.Y.Z`
 5. **CI builds automatically** — triggered by `v*` tag push:
-   - `create-release` job runs first: calls `gh release create --notes "$(gh api .../releases/generate-notes)"` to publish the GitHub release with an auto-generated "What's Changed" list of PRs merged since the previous tag, plus a **Full Changelog** compare link
+   - `create-release` job runs first: calls `gh release create --notes "$(gh api .../releases/generate-notes | grep -v '^\* chore: release v[0-9]')"` to publish the GitHub release with an auto-generated "What's Changed" list of PRs merged since the previous tag, plus a **Full Changelog** compare link
+   - The `grep -v` filter strips the `chore: release vX.Y.Z` PR bullet — every release has one by definition and it's noise in the user-facing changelog. If you add any other PR-title patterns that should always be hidden from release notes (docs-only churn, CI-only tweaks, etc.), extend the grep pattern in `release.yml`
    - `build` matrix then builds aarch64 + x86_64 DMGs and uploads them to that same release
    - Write PR titles in conventional-commit style (`feat:`, `fix:`, `chore:`, etc.) — they become the release-note bullet text verbatim
 6. **Update Homebrew cask** after CI publishes DMG artifacts:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.16.3",
+  "version": "0.16.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.16.3"
+version = "0.16.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1026,7 +1026,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.16.3{devMode && " (Dev Mode)"}
+                  Version 0.16.4{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Bumps version to 0.16.4 across all 4 required files (package.json, Cargo.toml, tauri.conf.json, Settings.tsx)
- Adds CHANGELOG.md entry for 0.16.4 covering the merged features and fixes (#88 auto-install, #89 settings polish, #90 collapsible session groups)
- Filters `chore: release vX.Y.Z` PRs out of the auto-generated release notes via `grep -v` in `release.yml` — keeps the public "What's Changed" clean
- Documents the filter in CLAUDE.md release guideline for future bumps

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes
- [ ] After merge + tag push: verify the release page's "What's Changed" list does **not** include the `chore: release v0.16.4` PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)