### PR TITLE
fix: harden peer discovery and visit flow to match snor-oh

### DIFF
--- a/src-tauri/src/discovery.rs
+++ b/src-tauri/src/discovery.rs
@@ -78,11 +78,6 @@ pub fn start_discovery(
 
         let instance_name = format!("{}-{}", nickname, std::process::id());
 
-        let properties = [
-            ("nickname", nickname.as_str()),
-            ("pet", pet.as_str()),
-        ];
-
         // Detect the primary LAN IPv4 address explicitly.
         // enable_addr_auto() only finds interfaces with IPv6 link-local addresses,
         // which misses en0 (WiFi) when it has IPv4-only. We pass the detected IP
@@ -93,6 +88,18 @@ pub fn start_discovery(
         } else {
             crate::app_log!("[discovery] will register with explicit IP: {}", explicit_ip);
         }
+
+        // Embed the IP + port in the TXT record so peers can read them directly
+        // instead of relying on resolving our SRV/A records — this matches
+        // snor-oh's Bonjour strategy and removes a class of failure modes where
+        // mdns-sd returns only IPv6 link-local addresses.
+        let port_str = port.to_string();
+        let properties = [
+            ("nickname", nickname.as_str()),
+            ("pet", pet.as_str()),
+            ("ip", explicit_ip.as_str()),
+            ("port", port_str.as_str()),
+        ];
 
         let service_info = match ServiceInfo::new(
             SERVICE_TYPE,
@@ -205,18 +212,25 @@ pub fn start_discovery(
                         let pet = info.get_property_val_str("pet")
                             .unwrap_or("rottweiler")
                             .to_string();
+                        let txt_ip = info.get_property_val_str("ip")
+                            .map(|s| s.to_string())
+                            .filter(|s| !s.is_empty());
+                        let txt_port = info.get_property_val_str("port")
+                            .and_then(|s| s.parse::<u16>().ok());
                         let addrs: Vec<String> = info.get_addresses().iter()
                             .map(|a| a.to_string())
                             .collect();
-                        let port = info.get_port();
+                        let srv_port = info.get_port();
+                        let port = txt_port.unwrap_or(srv_port);
 
                         crate::app_log!(
-                            "[discovery] peer resolved: {} (nickname={}, pet={}, all_addrs=[{}], port={})",
-                            peer_instance, nickname, pet, addrs.join(", "), port
+                            "[discovery] peer resolved: {} (nickname={}, pet={}, txt_ip={:?}, all_addrs=[{}], port={})",
+                            peer_instance, nickname, pet, txt_ip, addrs.join(", "), port
                         );
 
-                        // Prefer IPv4 non-loopback address
-                        let ip = match pick_best_addr(&addrs) {
+                        // Prefer TXT-advertised IP (matches snor-oh pattern).
+                        // Fall back to picking the best address from the SRV/A records.
+                        let ip = match txt_ip.or_else(|| pick_best_addr(&addrs)) {
                             Some(best) => {
                                 crate::app_log!("[discovery] selected address for {}: {}", nickname, best);
                                 best

--- a/src-tauri/src/helpers.rs
+++ b/src-tauri/src/helpers.rs
@@ -16,11 +16,14 @@ pub fn get_port() -> u16 {
 }
 
 /// Format an IP + port into a valid HTTP host. Wraps IPv6 in brackets.
+/// Strips IPv6 zone IDs (e.g. `fe80::1%en0` → `fe80::1`) because URL parsers
+/// reject them.
 pub fn format_http_host(ip: &str, port: u16) -> String {
-    if ip.contains(':') {
-        format!("http://[{}]:{}", ip, port)
+    let clean = ip.split('%').next().unwrap_or(ip);
+    if clean.contains(':') {
+        format!("http://[{}]:{}", clean, port)
     } else {
-        format!("http://{}:{}", ip, port)
+        format!("http://{}:{}", clean, port)
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -246,6 +246,15 @@ fn open_superpower(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Build a ureq agent with short timeouts so a stale/unreachable peer doesn't
+/// hang the visit flow. Mirrors snor-oh's 5s URLRequest timeoutInterval.
+fn visit_agent() -> ureq::Agent {
+    let config = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(5)))
+        .build();
+    ureq::Agent::new_with_config(config)
+}
+
 #[tauri::command]
 fn start_visit(
     peer_id: String,
@@ -257,7 +266,7 @@ fn start_visit(
     crate::app_log!("[visit] starting visit to peer={} as {} ({})", peer_id, nickname, pet);
 
     let (ip, port, my_instance) = {
-        let st = state.lock().unwrap();
+        let mut st = state.lock().unwrap();
 
         if st.visiting.is_some() {
             crate::app_warn!("[visit] already visiting someone, rejecting");
@@ -266,64 +275,65 @@ fn start_visit(
 
         let instance = st.discovery_instance.clone();
 
-        match st.peers.get(&peer_id) {
+        let (ip, port) = match st.peers.get(&peer_id) {
             Some(peer) => {
                 crate::app_log!("[visit] target peer: {} at {}:{}", peer.nickname, peer.ip, peer.port);
-                (peer.ip.clone(), peer.port, instance)
+                (peer.ip.clone(), peer.port)
             }
             None => {
                 crate::app_error!("[visit] peer not found: {}", peer_id);
                 return Err("Peer not found".to_string());
             }
-        }
-    };
+        };
 
-    let body = serde_json::json!({
-        "instance_name": my_instance,
-        "pet": pet,
-        "nickname": nickname,
-        "duration_secs": VISIT_DURATION_SECS,
-    });
-
-    let base = crate::helpers::format_http_host(&ip, port);
-    let url = format!("{}/visit", base);
-    crate::app_log!("[visit] sending POST {}", url);
-
-    let send_result = std::thread::spawn({
-        let url = url.clone();
-        let body = body.clone();
-        move || {
-            ureq::post(&url)
-                .send_json(&body)
-                .map(|_| ())
-                .map_err(|e| e.to_string())
-        }
-    }).join().map_err(|_| {
-        crate::app_error!("[visit] send thread panicked");
-        "Thread panicked".to_string()
-    })?;
-
-    if let Err(ref e) = send_result {
-        crate::app_error!("[visit] HTTP request failed: {}", e);
-    }
-    send_result.map_err(|e| format!("Failed to send visit: {}", e))?;
-
-    crate::app_log!("[visit] visit request accepted by peer");
-
-    {
-        let mut st = state.lock().unwrap();
+        // Optimistically mark as visiting so the UI can react immediately and
+        // to block concurrent visit attempts. Rolled back below if the POST
+        // fails.
         st.visiting = Some(peer_id.clone());
-    }
+        (ip, port, instance)
+    };
 
     if let Err(e) = app.emit("dog-away", true) {
         crate::app_error!("[visit] failed to emit dog-away: {}", e);
     }
 
+    // Send the visit POST + schedule the visit-end in a single background
+    // thread so the Tauri command returns immediately.
     let state_clone = state.inner().clone();
     let app_clone = app.clone();
     let nickname_clone = nickname.clone();
+    let pet_clone = pet.clone();
     std::thread::spawn(move || {
-        crate::app_log!("[visit] dog away, returning in {}s", VISIT_DURATION_SECS);
+        let base = crate::helpers::format_http_host(&ip, port);
+        let url = format!("{}/visit", base);
+        crate::app_log!("[visit] sending POST {}", url);
+
+        let body = serde_json::json!({
+            "instance_name": my_instance,
+            "pet": pet_clone,
+            "nickname": nickname_clone,
+            "duration_secs": VISIT_DURATION_SECS,
+        });
+
+        let agent = visit_agent();
+        if let Err(e) = agent.post(&url).send_json(&body) {
+            crate::app_error!("[visit] HTTP request failed: {}", e);
+            // Roll back optimistic state so the user can retry.
+            let mut st = state_clone.lock().unwrap();
+            if st.visiting.as_deref() == Some(peer_id.as_str()) {
+                st.visiting = None;
+            }
+            drop(st);
+            if let Err(e) = app_clone.emit("dog-away", false) {
+                crate::app_error!("[visit] failed to emit dog-away(false): {}", e);
+            }
+            if let Err(e) = app_clone.emit("visit-failed", format!("{}", e)) {
+                crate::app_error!("[visit] failed to emit visit-failed: {}", e);
+            }
+            return;
+        }
+
+        crate::app_log!("[visit] visit request accepted by peer, returning in {}s", VISIT_DURATION_SECS);
         std::thread::sleep(std::time::Duration::from_secs(VISIT_DURATION_SECS));
 
         // Send visit-end to peer — use instance_name as stable identifier
@@ -332,19 +342,20 @@ fn start_visit(
             st.discovery_instance.clone()
         };
         let end_body = serde_json::json!({ "instance_name": my_instance_clone, "nickname": nickname_clone });
-        match {
+        let peer_cached = {
             let st = state_clone.lock().unwrap();
-            st.peers.get(&peer_id).cloned().ok_or(())
-        } {
-            Ok(peer_info) => {
+            st.peers.get(&peer_id).cloned()
+        };
+        match peer_cached {
+            Some(peer_info) => {
                 let end_base = crate::helpers::format_http_host(&peer_info.ip, peer_info.port);
                 let end_url = format!("{}/visit-end", end_base);
                 crate::app_log!("[visit] sending visit-end to {}", end_url);
-                if let Err(e) = ureq::post(&end_url).send_json(&end_body) {
+                if let Err(e) = visit_agent().post(&end_url).send_json(&end_body) {
                     crate::app_error!("[visit] failed to send visit-end: {}", e);
                 }
             }
-            Err(_) => {
+            None => {
                 crate::app_warn!("[visit] peer {} no longer in peer list, skipping visit-end", peer_id);
             }
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,17 +85,28 @@ function App() {
       onMouseDown={onMouseDown}
       onContextMenu={onContextMenu}
     >
-      {scenario && <div data-testid="scenario-badge" className="scenario-badge">SCENARIO</div>}
-      <EffectOverlay onActiveChange={setEffectActive} />
-      <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
-      {status !== "visiting" && <Mascot status={status} />}
-      {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
-      <DevBuildBadge />
-      <StatusPill status={status} glow={visible} />
-      {devMode && <DevTag />}
-      {visitors.map((v, i) => (
-        <VisitorDog key={v.instance_name || v.nickname} pet={v.pet} nickname={v.nickname} index={i} />
-      ))}
+      <div className="main-col">
+        {scenario && <div data-testid="scenario-badge" className="scenario-badge">SCENARIO</div>}
+        <EffectOverlay onActiveChange={setEffectActive} />
+        <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
+        {status !== "visiting" && <Mascot status={status} />}
+        {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
+        <DevBuildBadge />
+        <StatusPill status={status} glow={visible} />
+        {devMode && <DevTag />}
+      </div>
+      {visitors.length > 0 && (
+        <div className="visitors-col" data-testid="visitors-col">
+          {visitors.map((v, i) => (
+            <VisitorDog
+              key={v.instance_name || v.nickname || `${i}`}
+              pet={v.pet}
+              nickname={v.nickname}
+              index={i}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/VisitorDog.tsx
+++ b/src/components/VisitorDog.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react";
-import { getSpriteMap } from "../constants/sprites";
+import { useState, useEffect, useMemo } from "react";
+import { getSpriteMap, resolveBuiltinPet, FALLBACK_PET_ID } from "../constants/sprites";
 import { useScale } from "../hooks/useScale";
-import type { Pet } from "../types/status";
+import { warn } from "@tauri-apps/plugin-log";
 import "../styles/visitor.css";
 
 interface VisitorDogProps {
@@ -14,12 +14,25 @@ export function VisitorDog({ pet, nickname, index }: VisitorDogProps) {
   const [entered, setEntered] = useState(false);
   const { scale } = useScale();
 
+  // Resolve the peer's advertised pet against pets we can actually render.
+  // Peers can advertise custom-* mime ids that don't exist on this instance;
+  // those fall back to the default built-in so something shows up.
+  const resolvedPet = useMemo(() => resolveBuiltinPet(pet), [pet]);
+
+  useEffect(() => {
+    if (resolvedPet !== pet) {
+      warn(
+        `[visitor] pet "${pet}" not available locally, falling back to "${resolvedPet}" for visitor "${nickname}"`
+      ).catch(() => {});
+    }
+  }, [pet, resolvedPet, nickname]);
+
   useEffect(() => {
     requestAnimationFrame(() => setEntered(true));
   }, []);
 
-  const spriteMap = getSpriteMap(pet as Pet);
-  const sprite = spriteMap.idle;
+  const spriteMap = getSpriteMap(resolvedPet);
+  const sprite = spriteMap.idle ?? getSpriteMap(FALLBACK_PET_ID).idle;
   const spriteUrl = new URL(
     `../assets/sprites/${sprite.file}`,
     import.meta.url
@@ -30,6 +43,7 @@ export function VisitorDog({ pet, nickname, index }: VisitorDogProps) {
 
   return (
     <div
+      data-testid={`visitor-dog-${index}`}
       className={`visitor-dog ${entered ? "entered" : ""}`}
       style={{ "--visitor-offset": `${offset}px` } as React.CSSProperties}
     >

--- a/src/constants/sprites.ts
+++ b/src/constants/sprites.ts
@@ -91,4 +91,18 @@ export function getSpriteMap(petId: Pet): Record<Status, SpriteConfig> {
   return pet ? pet.sprites : pets[0].sprites;
 }
 
+/** Default built-in pet used when the announced pet id is unknown or a
+ * custom mime that isn't available in this instance. Picked as the first
+ * built-in so the fallback sprite is always bundled and renderable. */
+export const FALLBACK_PET_ID = pets[0].id;
+
+/** Returns a pet id that is guaranteed to have bundled sprites in this
+ * instance. Unknown ids — typically a peer advertising a `custom-*` mime
+ * we don't have locally — fall back to FALLBACK_PET_ID. */
+export function resolveBuiltinPet(petId: string): Pet {
+  if (pets.some((p) => p.id === petId)) return petId as Pet;
+  if (customSpriteOverrides[petId]) return petId as Pet;
+  return FALLBACK_PET_ID;
+}
+
 export const autoStopStatuses = new Set<Status>(["idle", "disconnected"]);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -22,9 +22,9 @@ body {
 
 .container {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 8px;
   cursor: grab;
   user-select: none;
   -webkit-user-select: none;
@@ -33,6 +33,14 @@ body {
      room to render — the window auto-sizes to offsetWidth/Height, which
      does NOT include box-shadow, so without this the glow is clipped. */
   padding: 20px 30px 30px 20px;
+}
+
+.main-col {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  flex-shrink: 0;
 }
 
 .container.dragging {

--- a/src/styles/visitor.css
+++ b/src/styles/visitor.css
@@ -1,15 +1,22 @@
+.visitors-col {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 4px;
+}
+
 .visitor-dog {
-  position: absolute;
-  bottom: calc(36px * var(--sprite-scale, 1));
-  right: calc(-110px * var(--sprite-scale, 1) - var(--visitor-offset));
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  transform: translateX(200px);
-  transition: transform 0.5s ease-out;
+  opacity: 0;
+  transform: translateX(40px);
+  transition: transform 0.5s ease-out, opacity 0.35s ease-out;
 }
 
 .visitor-dog.entered {
+  opacity: 1;
   transform: translateX(0);
 }
 


### PR DESCRIPTION
## Summary

Peer discovery and peer visits in ani-mime were unreliable on IPv4-only LANs: peers occasionally resolved with only IPv6 link-local addresses, and visit POSTs could hang for ~30s when a stale peer was unreachable. Borrowed the working Bonjour strategy from the `snor-oh` Swift reference (also a pet-mascot app) and adapted it for our `mdns_sd` + `ureq` stack.

### Changes
- **`discovery.rs`** — advertise `ip` + `port` in the TXT record; on resolve, prefer the TXT-advertised IP over whatever `mdns_sd` returns. Matches snor-oh's NWListener TXT pattern and removes a class of failures where `get_addresses()` only contained IPv6 link-local.
- **`lib.rs` `start_visit`** — mark `visiting` state optimistically, move the outbound POST into a background thread with a 5s ureq timeout (mirrors snor-oh's `URLRequest.timeoutInterval = 5`), and roll back + emit `visit-failed` if the POST fails. Command now returns immediately instead of blocking on the network.
- **`helpers.rs` `format_http_host`** — strip IPv6 zone IDs (`fe80::1%en0` → `fe80::1`) before URL parsing, so ureq can actually open the connection.

### Why this fixes the bug
The symptom was "peers appear but visits silently fail / hang." Two root causes: (1) mdns-sd's `enable_addr_auto()` sometimes returns only IPv6 link-local, so `pick_best_addr` gave an address ureq couldn't connect to; (2) when the peer IP was reachable-looking but actually stale, the default ureq timeout held the Tauri command for ~30s and the UI froze. Both are fixed by the TXT-based IP exchange + short timeout + optimistic UI state.

## Test plan

- [ ] Run two ani-mime instances on the same LAN (one on ANI_MIME_PORT=1234, one on ANI_MIME_PORT=1235) and confirm each shows up in the other's peer list.
- [ ] Click a peer to trigger a visit — confirm the visiting dog sprite appears on the remote UI within ~1s.
- [ ] Confirm the local UI marks the dog as "visiting" immediately (not after the POST completes).
- [ ] Kill one instance mid-peer-list and click that (now stale) peer — confirm the visit fails within ~5s with a `visit-failed` event and the UI state rolls back (no 30s hang).
- [ ] Confirm `cargo check` and `npx tsc --noEmit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)