### PR TITLE
chore: release v0.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.16.5] - 2026-04-20
+
+### Added
+- **Linux / WSL2 support** — Ani-Mime now runs on Linux and WSL2 via a cross-platform backend facade. Native Linux uses GTK `set_keep_above`; WSLg uses a `SetWindowPos(HWND_TOPMOST)` PowerShell shim, re-asserted on every focus-lost event so the pet stays on top after clicking into other maximized Windows apps. Dialogs use `zenity`, file/URL open uses `xdg-open`. macOS is unchanged. (#81, @cuongtranba)
+- **Linux release artifacts in CI** — tag pushes now build and publish `.deb`, `.rpm`, and `.AppImage` for both `x86_64` and `aarch64` alongside the existing macOS DMGs. A release now ships 8 artifacts (2 DMGs + 6 Linux bundles). (#93)
+- **Claude Code Management UI screenshot** — new `docs/assets/settings-claude-code.png` added to the README Screenshots table with a dedicated Features bullet describing the Settings → Claude Code tab. (#93)
+
+### Fixed
+- **Updater auto-install compile break** — the auto-install branch called `update_now(&app_handle)` with one argument while the function requires `(app_handle, release_url)`. This was a hard `E0061` compile error on Linux and a silent hole on macOS where auto-install never reached the upgrade flow. `release_url` is now computed once per run and passed to both the auto-install path and `show_update_dialog`. (#93)
+- **macOS full-screen Spaces** — pet now floats over full-screen apps on every Space (`setCollectionBehavior` switched from `fullScreenNone` to `fullScreenAuxiliary`). (#81)
+- **Peer discovery & visit flow** — hardened to match snor-oh parity; visitors now render reliably with a fallback sprite for unknown pet types. (#92)
+- **Claude Code settings — MCP Servers** — "Global" and per-project sub-headers no longer hug the card's left edge; horizontal padding bumped from `0` to `12px` so they align with the server rows below. (#93)
+- **Claude Code settings — Commands** — the expanded `/command` body (shown after tapping View) now sits inside the card with `12px` left/right margin instead of stretching flush edge-to-edge. (#93)
+- **Claude Code settings — Plugins** — plugin rows now match the 2-line rhythm used by MCP, Commands, and Hooks: name + version badge on line 1, marketplace on line 2. The enable/disable toggle keeps its full size on narrow windows (`.toggle-switch` gets `flex-shrink: 0`). The plugin skills expand toggle ("N skills") is temporarily hidden pending UX work. (#93)
+
+### Changed
+- `.claude-item-info` now wraps so any row can drop an ellipsized preview onto a second line via `.claude-cmd-preview { flex-basis: 100%; }`. Unifies the layout across Commands, MCP Servers, Plugins, and Hooks rows. (#93)
+
 ## [0.16.4] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 </p>
 
 <p align="center">
-  <strong>A floating pixel mascot that mirrors your terminal & Claude Code activity on macOS.</strong>
+  <strong>A floating pixel mascot that mirrors your terminal & Claude Code activity on macOS and Linux.</strong>
 </p>
 
 <p align="center">
   <a href="https://github.com/vietnguyenhoangw/ani-mime/releases"><img src="https://img.shields.io/github/v/release/vietnguyenhoangw/ani-mime?style=for-the-badge&color=8b5cf6" alt="Version"></a>
   <a href="https://github.com/vietnguyenhoangw/ani-mime/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-vietnguyenhoangw-8b5cf6?style=for-the-badge" alt="License"></a>
-  <img src="https://img.shields.io/badge/Platform-macOS-000000?style=for-the-badge&logo=apple" alt="Platform">
+  <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20WSL2-000000?style=for-the-badge&logo=apple" alt="Platform">
 </p>
 
 <p align="center">
@@ -175,7 +175,7 @@ Without these permissions, the click still brings the app to the front via `open
 
 ## Install
 
-### Homebrew (recommended)
+### macOS — Homebrew (recommended)
 
 ```bash
 brew tap vietnguyenhoangw/ani-mime
@@ -190,6 +190,31 @@ Open a new terminal tab and the mascot starts reacting.
 
 The MCP server is also auto-configured so Claude Code can interact with your pet directly (see [MCP Server](#mcp-server) below).
 
+### Linux — `.deb`, `.rpm`, or `.AppImage`
+
+Download the bundle for your distro and arch from the [Releases page](https://github.com/vietnguyenhoangw/ani-mime/releases/latest):
+
+```bash
+# Debian / Ubuntu
+sudo apt install ./ani-mime_X.Y.Z_amd64.deb      # or _arm64.deb on ARM
+
+# Fedora / RHEL / openSUSE
+sudo rpm -i ani-mime-X.Y.Z-1.x86_64.rpm          # or .aarch64.rpm
+
+# AppImage (any distro)
+chmod +x ani-mime_X.Y.Z_amd64.AppImage && ./ani-mime_X.Y.Z_amd64.AppImage
+```
+
+Runtime deps (installed automatically by `apt`/`rpm`; required manually for AppImage):
+
+```bash
+sudo apt install libwebkit2gtk-4.1-0 libayatana-appindicator3-1 zenity xdg-utils
+```
+
+### WSL2
+
+Install the Linux `.deb` inside your WSL2 distro. Always-on-top works via a WSLg-specific `SetWindowPos(HWND_TOPMOST)` shim — no extra setup required.
+
 ### Manual (from source)
 
 ```bash
@@ -199,7 +224,15 @@ bun install
 bun tauri dev
 ```
 
-Then source the zsh script:
+On Linux you also need the build deps:
+
+```bash
+sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+  librsvg2-dev libxdo-dev libglib2.0-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev \
+  xdg-utils pkg-config build-essential zenity
+```
+
+Then source the shell script for your shell (`terminal-mirror.zsh`, `.bash`, or `.fish`):
 
 ```bash
 echo 'source "/path/to/ani-mime/src-tauri/script/terminal-mirror.zsh"' >> ~/.zshrc
@@ -210,9 +243,28 @@ source ~/.zshrc
 
 ## Requirements
 
-- **macOS** (Intel or Apple Silicon)
-- **zsh** (default shell on macOS)
+- **macOS** (Intel or Apple Silicon) — full feature set
+- **Linux** (x86_64 or aarch64) — runs with shell hooks; some click-to-focus integrations are macOS-only
+- **WSL2 / WSLg** — runs as a Linux build with a WSLg-aware always-on-top shim
+- **Shell** — zsh / bash / fish (hooks provided for each)
 - **Claude Code** (optional) — for Claude activity tracking
+
+### Platform feature matrix
+
+| Feature                              | macOS | Linux | WSL2 |
+| ------------------------------------ | :---: | :---: | :--: |
+| Mascot + speech bubbles              |  ✅   |  ✅   |  ✅  |
+| Shell hook tracking (zsh/bash/fish)  |  ✅   |  ✅   |  ✅  |
+| Claude Code hooks + MCP server       |  ✅   |  ✅   |  ✅  |
+| Always-on-top over full-screen apps  |  ✅   |  ✅   |  ✅  |
+| Peer discovery (mDNS / Bonjour)      |  ✅   |  ✅   |  ⚠️  |
+| Session list dropdown                |  ✅   |  ✅   |  ✅  |
+| Click-to-focus terminal tabs         |  ✅   |  ❌   |  ❌  |
+| Auto shell discovery (libproc scan)  |  ✅   |  ❌   |  ❌  |
+| Homebrew cask install                |  ✅   |  —    |  —   |
+| Auto-install update via `brew`       |  ✅   |  —    |  —   |
+
+Linux and WSL2 fall back to the shell-hook based path for terminal tracking — you get the full mascot + Claude Code + MCP experience, just without the macOS-only auto-discovery and tab-precise focus.
 
 ## Tech Stack
 
@@ -298,6 +350,8 @@ Claude Code calls MCP tools during conversations. The MCP server translates them
 
 ## Building for Release
 
+### macOS (DMG)
+
 ```bash
 # Build the Tauri app
 bun run tauri build
@@ -316,6 +370,27 @@ If the recipient sees "app is damaged", they need to remove the quarantine attri
 ```bash
 xattr -cr /Applications/ani-mime.app
 ```
+
+### Linux (`.deb`, `.rpm`, `.AppImage`)
+
+```bash
+bun run tauri build
+```
+
+Produces all three bundle formats under `src-tauri/target/release/bundle/{deb,rpm,appimage}/`. No post-build signing step required on Linux.
+
+### CI release pipeline
+
+Tag pushes (`v*`) trigger `.github/workflows/release.yml`, which runs a 4-job matrix:
+
+| Job | Runner | Target | Artifact |
+| --- | ------ | ------ | -------- |
+| macOS aarch64 | `macos-latest` | `aarch64-apple-darwin` | `.dmg` |
+| macOS x86_64  | `macos-latest` | `x86_64-apple-darwin`  | `.dmg` |
+| Linux aarch64 | `ubuntu-22.04-arm` | `aarch64-unknown-linux-gnu` | `.deb` + `.rpm` + `.AppImage` |
+| Linux x86_64  | `ubuntu-22.04` | `x86_64-unknown-linux-gnu`  | `.deb` + `.rpm` + `.AppImage` |
+
+Each release publishes 8 artifacts total.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/vietnguyenhoangw/ani-mime/releases"><img src="https://img.shields.io/github/v/release/vietnguyenhoangw/ani-mime?style=for-the-badge&color=8b5cf6" alt="Version"></a>
   <a href="https://github.com/vietnguyenhoangw/ani-mime/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-vietnguyenhoangw-8b5cf6?style=for-the-badge" alt="License"></a>
-  <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20WSL2-000000?style=for-the-badge&logo=apple" alt="Platform">
+  <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20WSL2-f97316?style=for-the-badge&logo=apple" alt="Platform">
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.16.4",
+  "version": "0.16.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.16.4"
+version = "0.16.5"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1029,7 +1029,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.16.4{devMode && " (Dev Mode)"}
+                  Version 0.16.5{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary

Release v0.16.5 — version bumps, CHANGELOG entry.

## Version bumps (4 files per release checklist)

- `package.json` — `0.16.4 → 0.16.5`
- `src-tauri/Cargo.toml` — `0.16.4 → 0.16.5` (+ `Cargo.lock` regenerated via `cargo check`)
- `src-tauri/tauri.conf.json` — `0.16.4 → 0.16.5`
- `src/components/Settings.tsx` — About section "Version 0.16.4 → 0.16.5"

## CHANGELOG highlights

**Added**
- Linux / WSL2 support via cross-platform backend facade (#81)
- CI now publishes `.deb`, `.rpm`, `.AppImage` for `x86_64` and `aarch64` in addition to macOS DMGs (#93)
- Claude Code Management UI screenshot added to README Screenshots table (#93)

**Fixed**
- Updater auto-install `E0061` compile break on Linux / silent hole on macOS (#93)
- macOS full-screen Spaces — pet floats over full-screen apps on every Space (#81)
- Peer discovery & visit flow hardened (#92)
- Claude Code settings — MCP sub-headers, command preview, plugin row all aligned at 12px with a consistent 2-line layout (#93)

**Changed**
- `.claude-item-info` wraps + `.claude-cmd-preview` pins to `flex-basis: 100%` — unifies row layout across Commands, MCP Servers, Plugins, and Hooks (#93)

## Release artifacts on tag push

With the CI update in #93, pushing `v0.16.5` will produce **8 artifacts**:

| Platform | Arch | Files |
|---|---|---|
| macOS | aarch64 | `.dmg` |
| macOS | x86_64 | `.dmg` |
| Linux | aarch64 | `.deb` + `.rpm` + `.AppImage` |
| Linux | x86_64 | `.deb` + `.rpm` + `.AppImage` |

## After merge

1. Tag on main: `git tag v0.16.5 && git push origin v0.16.5`
2. CI runs — 4 matrix jobs, ~10–15 min total
3. Update Homebrew cask in `vietnguyenhoangw/homebrew-ani-mime`:
   - `gh release download v0.16.5 --pattern "*.dmg"`
   - `shasum -a 256 *.dmg`
   - Update `Casks/ani-mime.rb` with new version + SHA256s