### PR TITLE
chore: add CODEOWNERS for Linux/WSL2 platform adapter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Auto-request reviews when someone touches platform-specific code.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Linux / WSL2 platform adapter — owned by the original author of PR #81
+src-tauri/src/platform/linux.rs @cuongtranba


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` with an entry pointing Linux/WSL2 platform code to @cuongtranba (original author of PR #81).

## Effect

When a PR touches `src-tauri/src/platform/linux.rs`, GitHub will auto-request review from @cuongtranba so future changes to the Linux/WSLg integration get the right eyes on them.

## Note on auto-review

CODEOWNERS auto-assignment only fires for users with explicit write access to the repo. If @cuongtranba is not yet a collaborator, the entry still documents ownership and credits him on the commit graph — the auto-review request becomes active once he's granted collaborator access.

## Why this particular commit

Adds meaningful infrastructure + retroactively puts @cuongtranba on the contributor graph for the Linux support he built in PR #81. His earlier commits still show in git history but aren't counted by GitHub's graph because they used an email address that isn't linked to his GitHub account — this commit is authored with his verified GitHub email so it attributes correctly.