### PR TITLE
revert: CODEOWNERS squash that didn't preserve author

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Auto-request reviews when someone touches platform-specific code.
-# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Linux / WSL2 platform adapter — owned by the original author of PR #81
-src-tauri/src/platform/linux.rs @cuongtranba


### PR DESCRIPTION
Reverting #95 so we can remerge with the `--merge` strategy that preserves @cuongtranba's authorship on the CODEOWNERS commit. The squash strategy overwrote the author with the merger's identity.