### PR TITLE
chore: add CODEOWNERS for Linux/WSL2 platform adapter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Auto-request reviews when someone touches platform-specific code.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Linux / WSL2 platform adapter — owned by the original author of PR #81
+src-tauri/src/platform/linux.rs @cuongtranba


### PR DESCRIPTION
Re-landing #95 after the squash-merge clobbered the author attribution. This time with `--merge` so @cuongtranba's authorship is preserved on the commit as it lands on main.

## What this adds

`.github/CODEOWNERS` with one entry routing reviews on `src-tauri/src/platform/linux.rs` to @cuongtranba — the original author of PR #81 (Linux/WSL2 support).