### PR TITLE
feat(p2p): resilient peer discovery via multicast + unicast scan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ See `docs/ARCHITECTURE.md` for full details. Key data flow:
 ```
 Shell hooks (curl) → HTTP :1234 → Rust state → Tauri event → React UI
 Claude Code ←stdio→ MCP server (Node.js) ←HTTP→ :1234 → Tauri event → React UI
+Peer announces ←UDP :1235 (mDNS + multicast + unicast scan)→ AppState.peers → peers-changed event → UI
 ```
 
 ### Backend (`src-tauri/src/`)
@@ -45,6 +46,8 @@ Claude Code ←stdio→ MCP server (Node.js) ←HTTP→ :1234 → Tauri event �
 | `watchdog.rs` | Background thread: service→idle transition, stale session cleanup |
 | `proc_scan.rs` | Background thread (2s): libproc-based OS scan — auto-discovers shells, fills `pwd`/`tty`/`fg_cmd`, detects `claude` via `KERN_PROCARGS2` argv, drops zombie sessions |
 | `focus.rs` | `focus_terminal_for_pid()` — walks parent chain to find owning terminal app (iTerm/Terminal/VS Code/Cursor/tmux/etc.), activates via `open -a`, optionally targets tab via AppleScript |
+| `discovery.rs` | mDNS peer discovery — registers `_ani-mime._tcp.local.`, browses peers, emits `peers-changed` |
+| `broadcast.rs` | UDP peer discovery on `:1235` — multicast announce (224.0.0.200 every 5s), unicast `/24` scan (every 30s), receive loop, expiry loop. Writes into the same `AppState.peers` as `discovery.rs` keyed by `instance_name` |
 | `helpers.rs` | `now_secs()`, `get_query_param()` |
 | `setup/mod.rs` | First-launch auto-setup orchestrator |
 | `setup/shell.rs` | Shell detection, RC file injection, shell-selection prompt (via `platform::show_dialog`) |
@@ -93,6 +96,7 @@ When multiple terminals are open, the UI shows one winner: `busy > service > idl
 ## Important Details
 
 - HTTP server runs on `127.0.0.1:1234` — this port is hardcoded in shell scripts, Claude hooks, and Rust server
+- Peer discovery runs on UDP `:1235` (multicast group `224.0.0.200` + unicast /24 scan) in addition to mDNS — all three channels feed the same `AppState.peers` HashMap keyed by `instance_name`, so peers discovered by multiple channels appear once
 - pid=0 is reserved for Claude Code hooks (virtual session)
 - Heartbeats only refresh `last_seen` for non-busy sessions (prevents stuck commands from staying alive)
 - `/status` and `/heartbeat` reject with 410 when the pid isn't a live OS process — stops orphaned heartbeat subshells from re-registering dead sessions
@@ -158,6 +162,7 @@ Every interactive or observable UI element must be locatable by automated tests 
 - **New shell**: Add script in `src-tauri/script/`, add `ShellInfo` in `setup/shell.rs`, add to `tauri.conf.json` bundle resources
 - **New terminal app for click-to-focus**: Add an entry to `classify_bundle()` in `proc_scan.rs`, dispatch in `focus.rs` with either an existing strategy (`open -a` + AppleScript tab selection) or a new strategy
 - **New persistent setting**: Follow the `useDockVisible` pattern — hook uses `load("settings.json")` + `listen`/`emit` on a `*-changed` event; add a row in `Settings.tsx`
+- **New peer-discovery channel**: Create a new module in `src-tauri/src/` (or extend `broadcast.rs`). Spawn worker threads from `lib.rs::run()` alongside `start_discovery` / `start_broadcast`. Write peers into the existing `AppState.peers` HashMap keyed by `instance_name` — **do not** maintain a separate peers map. Emit the existing `peers-changed` event when the set mutates. If your channel has freshness/expiry semantics, track them in a dedicated `HashMap<String, u64>` on `AppState` (see `broadcast_seen` for the pattern) and expire under a dedicated loop. Use the `[your-channel]` log tag and include a `self-loop confirmed` style health check where applicable.
 - **Storage**: See `docs/storage.md` for the planned approach (tauri-plugin-store for prefs, SQLite for history)
 
 ## Releasing a New Version

--- a/docs/constants-reference.md
+++ b/docs/constants-reference.md
@@ -12,6 +12,10 @@ All hardcoded values, timeouts, and configurable parameters in the codebase.
 | `SERVICE_DISPLAY_SECS` | 2 | `watchdog.rs` | How long service state shows before auto-transitioning to idle |
 | `IDLE_TO_SLEEP_SECS` | 120 | `watchdog.rs` | Idle duration before entering sleep mode (suppresses emits) |
 | `VISIT_DURATION_SECS` | 15 | `lib.rs` | How long a dog visit lasts |
+| `ANNOUNCE_INTERVAL_SECS` | 5 | `broadcast.rs` | UDP multicast announce cadence |
+| `PEER_EXPIRY_SECS` | 30 | `broadcast.rs` | Remove broadcast peer after this many seconds of silence |
+| `UNICAST_SCAN_INTERVAL_SECS` | 30 | `broadcast.rs` | How often to sweep the local /24 via unicast |
+| `UNICAST_SEND_SPACING_MS` | 10 | `broadcast.rs` | Delay between per-host sends within one scan (keeps peak <100 pps) |
 | Watchdog tick | 2s | `watchdog.rs` | Background thread check interval |
 | Discovery heartbeat | 30s | `discovery.rs` | Peer count check and hint interval |
 | Update check delay | 3s | `updater.rs` | Delay before first background update check |
@@ -20,9 +24,12 @@ All hardcoded values, timeouts, and configurable parameters in the codebase.
 
 | Value | File | Purpose |
 |-------|------|---------|
-| Default port: `1234` | `helpers.rs` | HTTP server port (overridable via `ANI_MIME_PORT` env var) |
+| Default HTTP port: `1234` | `helpers.rs` | HTTP server port (overridable via `ANI_MIME_PORT` env var) |
 | Bind address: `0.0.0.0` | `server.rs` | Listen on all interfaces (for peer visits) |
-| mDNS service: `_ani-mime._tcp.local.` | `discovery.rs` | Service type for peer discovery |
+| mDNS service: `_ani-mime._tcp.local.` | `discovery.rs` | mDNS service type |
+| `MULTICAST_PORT`: `1235` | `broadcast.rs` | UDP port for multicast + unicast announces |
+| `MULTICAST_ADDR`: `224.0.0.200` | `broadcast.rs` | Link-local multicast group (in `224.0.0.0/24` flooded range — same class as AirPlay/mDNS) |
+| `MAGIC`: `"ani-mime/1"` | `broadcast.rs` | Protocol tag in announce payloads; foreign UDP on `:1235` is dropped |
 | curl timeout: `1s` | shell scripts | `--max-time 1` on all curl calls |
 
 ### Limits

--- a/docs/peer-discovery.md
+++ b/docs/peer-discovery.md
@@ -4,20 +4,45 @@ How Ani-Mime instances discover each other on the local network and exchange dog
 
 ## Overview
 
-Multiple Ani-Mime instances on the same LAN can discover each other via mDNS (Bonjour) and send their dogs to visit other screens.
+Multiple Ani-Mime instances on the same LAN discover each other and send their dogs to visit other screens. Discovery runs across **three parallel channels** so that if one is blocked by the network, the others still work.
 
 ```
-Machine A                              Machine B
-┌──────────────┐                      ┌──────────────┐
-│  Ani-Mime    │  mDNS broadcast      │  Ani-Mime    │
-│  discovery   │ ◄──────────────────► │  discovery   │
-│              │                      │              │
-│  HTTP :1234  │  POST /visit         │  HTTP :1234  │
-│              │ ──────────────────►  │              │
-│              │  POST /visit-end     │              │
-│              │ ──────────────────►  │              │
-└──────────────┘                      └──────────────┘
+Machine A                                           Machine B
+┌───────────────────┐                            ┌───────────────────┐
+│   Ani-Mime        │   1. mDNS  (5353)          │   Ani-Mime        │
+│                   │ ◄───────────────────────►  │                   │
+│   discovery.rs    │   2. Multicast (1235)      │   discovery.rs    │
+│   broadcast.rs    │ ◄───────────────────────►  │   broadcast.rs    │
+│                   │   3. Unicast /24 (1235)    │                   │
+│                   │ ◄───────────────────────►  │                   │
+│                   │                            │                   │
+│   HTTP :1234      │   POST /visit              │   HTTP :1234      │
+│                   │ ─────────────────────────► │                   │
+│                   │   POST /visit-end          │                   │
+│                   │ ─────────────────────────► │                   │
+└───────────────────┘                            └───────────────────┘
 ```
+
+All three channels write into the same `AppState.peers` HashMap keyed by `instance_name`, so a peer found via multiple channels appears once in the UI.
+
+### Channel summary
+
+| # | Channel | Source | Cadence | Target | When it wins |
+|---|---------|--------|---------|--------|--------------|
+| 1 | **mDNS** | `discovery.rs` | TTL-driven | `_ani-mime._tcp.local.` via `224.0.0.251` | Home / small office networks |
+| 2 | **Multicast announce** | `broadcast.rs::announce_loop` | every 5s | `224.0.0.200:1235` | Networks that allow arbitrary link-local multicast |
+| 3 | **Unicast subnet scan** | `broadcast.rs::unicast_scan_loop` | every 30s | every host in local `/24` at `:1235` | Networks that block all multicast but allow unicast (managed WiFi / Bonjour Gateways) |
+
+### Network compatibility matrix
+
+| Network type | mDNS | Multicast 224.0.0.200 | Unicast /24 scan |
+|--------------|:----:|:---------------------:|:----------------:|
+| Home WiFi / small office | ✅ | ✅ | ✅ |
+| Managed WiFi w/ Bonjour Gateway | ⚠️ partial | ❌ | ✅ |
+| WiFi with full client isolation | ❌ | ❌ | ❌ |
+| Guest WiFi / different VLAN | ❌ | ❌ | ❌ *(different subnet)* |
+
+If unicast scan doesn't work either, the only path forward is a signaling server outside the LAN — not currently implemented.
 
 ## mDNS Discovery
 
@@ -56,6 +81,64 @@ When a peer disappears (`ServiceRemoved` event):
 ### No-Peers Hint
 
 A background thread checks every 30 seconds. If no peers are found after the first check, emits `discovery-hint: "no_peers"` once (shown as speech bubble).
+
+## UDP Announce Protocol (`broadcast.rs`)
+
+The broadcast module runs independently from mDNS and provides two channels: multicast announce (fast, when it works) and unicast subnet scan (slow but network-proof).
+
+### Packet format
+
+Every announce — multicast or unicast — carries the same JSON payload:
+
+```json
+{
+  "magic": "ani-mime/1",
+  "instance_name": "Alice-12345",
+  "nickname": "Alice",
+  "pet": "rottweiler",
+  "ip": "192.168.20.42",
+  "port": 1234
+}
+```
+
+- `magic` — protocol tag. Foreign traffic on `:1235` that doesn't match is silently dropped.
+- `instance_name` — `{nickname}-{pid}`. Unique per running process. Used as the HashMap key for dedup across channels.
+- `ip` / `port` — where the sender's HTTP visit endpoint is reachable.
+
+Payload is JSON-encoded plaintext and kept under ~200 bytes to stay well inside one UDP datagram.
+
+### Threads
+
+`broadcast.rs::start_broadcast` spawns four threads:
+
+| Thread | Purpose |
+|--------|---------|
+| `announce_loop` | Every `ANNOUNCE_INTERVAL_SECS` (5s), sends the payload to `224.0.0.200:1235` multicast. |
+| `unicast_scan_loop` | Every `UNICAST_SCAN_INTERVAL_SECS` (30s), sends the payload to every IP `.1`–`.254` in the local `/24` at `:1235`. Spaced at `UNICAST_SEND_SPACING_MS` (10ms) between sends to stay under ~100 pps. |
+| `listen_loop` | Binds `0.0.0.0:1235`, joins multicast group `224.0.0.200`. Receives both multicast (via group join) and unicast (by virtue of the bind) on the same socket. Calls `handle_announce` for each valid packet. |
+| `expiry_loop` | Every 5s, removes peers from `AppState.peers` whose `AppState.broadcast_seen` entry is older than `PEER_EXPIRY_SECS` (30s). Emits `peers-changed`. |
+
+### Peer upsert
+
+`handle_announce` for any received announce:
+1. Verifies `magic == "ani-mime/1"`.
+2. Filters out our own instance (one-shot `self-loop confirmed` log the first time — used as a health check for local multicast).
+3. Inserts/updates `AppState.peers[instance_name]` with fresh `PeerInfo`.
+4. Updates `AppState.broadcast_seen[instance_name]` with the current timestamp.
+5. If this is a new peer, logs `NEW peer:` and emits `peers-changed`.
+6. If already known, only logs `refresh peer:` at most once per minute per peer to avoid log spam.
+
+### Multicast vs Unicast receive
+
+The listen socket is bound to `0.0.0.0:1235`. It receives:
+- **Multicast** packets sent to `224.0.0.200:1235` — because we joined the group via `join_multicast_v4` on the detected local IPv4 interface.
+- **Unicast** packets sent to `<our-ip>:1235` — because our bind accepts unicast on that port by default.
+
+Both go through the same `handle_announce` code path — the sender's channel is invisible to the receiver. The `from` address in the log is the sender's IP, not `224.0.0.200`, in both cases.
+
+### Subnet derivation
+
+`unicast_scan_loop` derives the scan range from our detected local IPv4 by taking the first three octets (a `/24` assumption). This covers the vast majority of home and office networks (`192.168.*.*`, `10.0.*.*`). Networks using `/16` or non-standard masks will only have the first 256 hosts scanned — a known limitation, acceptable for current usage.
 
 ## Visit Protocol
 
@@ -145,31 +228,62 @@ Additionally, `src-tauri/Info.plist` declares:
 
 ### Peers not finding each other
 
-1. **Both machines must be on the same WiFi/LAN subnet** — mDNS doesn't cross subnets
-2. **macOS Local Network permission** — on first launch, macOS asks to allow local network access. If denied, go to **System Settings > Privacy & Security > Local Network** and enable ani-mime
-3. **Verify registration** — run in Terminal: `dns-sd -B _ani-mime._tcp local.` — you should see your instance name within seconds
-4. **Check debug endpoint** — run `curl http://127.0.0.1:1234/debug` to see registered IP and discovered peers
-5. **Entitlements missing** — if shared via DMG without the post-build sign step, mDNS silently fails. Re-build with `bun run tauri build && bash src-tauri/script/post-build-sign.sh`
-6. **Quarantine attribute** — apps transferred between Macs get quarantined. Run `xattr -cr /Applications/ani-mime.app` on the receiving machine
+Walk through these in order — each rules out a layer:
 
-### Verify mDNS is working
+1. **Both machines must be on the same WiFi/LAN subnet** — none of our channels cross subnets.
+2. **macOS Local Network permission** — on first launch, macOS asks to allow local network access. If denied, go to **System Settings > Privacy & Security > Local Network** and enable ani-mime.
+3. **Check `/debug` endpoint** — `curl http://127.0.0.1:1234/debug` should show your `instance_name`, `registered_addrs`, and the current peers list.
+4. **Read the log**, filter for `[broadcast]` and `[discovery]`:
+   ```bash
+   grep -E '\[broadcast\]|\[discovery\]' ~/Library/Logs/com.vietnguyenwsilentium.ani-mime/ani-mime.log | tail -40
+   ```
+   Key lines to look for:
+   - `[broadcast] listen socket bound on 0.0.0.0:1235, joined multicast group 224.0.0.200` — socket OK
+   - `[broadcast] self-loop confirmed` — local multicast end-to-end OK
+   - `[broadcast] unicast scan #N done: ... sent_ok=253` — unicast scan completed
+   - `[broadcast] NEW peer: ...` — 🎉 a peer was found
+5. **Verify mDNS registration** — `dns-sd -B _ani-mime._tcp local.` should show your instance.
+6. **Verify unicast works between machines** — `curl --max-time 3 http://<peer-ip>:1234/debug` from your machine should return the peer's state. If this fails, your network has client-to-client isolation and none of our channels will work.
+7. **Entitlements missing** — if shared via DMG without the post-build sign step, mDNS silently fails. Re-build with `bun run tauri build && bash src-tauri/script/post-build-sign.sh`
+8. **Quarantine attribute** — apps transferred between Macs get quarantined. Run `xattr -cr /Applications/ani-mime.app` on the receiving machine.
+
+### Interpreting broadcast logs
+
+| Log pattern | Meaning |
+|-------------|---------|
+| `FAILED to bind/join multicast ...` | Port conflict, permission denied, or interface has no IPv4. Socket never came up. |
+| `self-loop confirmed` present, no `NEW peer` on either side | Network blocks multicast between clients but local pipeline works. Unicast scan should still find the peer within 30s. |
+| `self-loop confirmed` absent after 30s | Local multicast is broken — usually interface-level issue. Unicast scan is your only remaining channel. |
+| `unicast scan #N done: ... send_err=X` with large X | Most sends are hitting EHOSTUNREACH — could mean ARP is failing, or the subnet is sparsely populated (harmless). |
+
+### Verify each channel independently
 
 ```bash
-# See all ani-mime instances on the network
+# 1. mDNS — see all ani-mime instances via Bonjour
 dns-sd -B _ani-mime._tcp local.
 
-# See details of a specific instance
-dns-sd -L "InstanceName" "_ani-mime._tcp" "local."
+# 2. Multicast — listen on the broadcast group
+# (kill with Ctrl+C; use tcpdump if available)
+sudo tcpdump -i any -n 'host 224.0.0.200 and port 1235'
 
-# Test with a fake peer (appears in context menu)
-dns-sd -R "TestBuddy-9999" "_ani-mime._tcp" "local." 1235 nickname=Buddy pet=dalmatian
+# 3. Unicast — direct debug request to a peer
+curl --max-time 3 http://192.168.20.29:1234/debug
+```
+
+### Test with a fake peer
+
+```bash
+# Make a fake mDNS peer appear in your context menu
+dns-sd -R "TestBuddy-9999" "_ani-mime._tcp" "local." 1234 nickname=Buddy pet=dalmatian
 ```
 
 ## Limitations
 
-- **LAN only** — mDNS doesn't cross subnet boundaries (no WAN discovery)
-- **No authentication** — any Ani-Mime instance on the network can visit
-- **No rejection** — visits are automatically accepted
-- **No encryption** — HTTP traffic is plaintext
-- **Single visit** — can only visit one peer at a time
-- **Fixed duration** — visits last exactly 15 seconds, not configurable by user
+- **LAN only** — no channel crosses subnet boundaries or reaches over WAN.
+- **`/24` assumption in unicast scan** — only the first 256 hosts of larger subnets are reached.
+- **Multicast-hostile networks degrade to 30s discovery** — the unicast scan cadence is the floor.
+- **No authentication** — any Ani-Mime instance on the network can visit; any announce that matches the magic string is trusted.
+- **No rejection** — visits are automatically accepted.
+- **No encryption** — HTTP traffic and UDP announces are plaintext.
+- **Single visit** — can only visit one peer at a time.
+- **Fixed visit duration** — 15 seconds, not configurable by user.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -104,6 +104,7 @@ src-tauri/
 │   ├── proc_scan.rs           # Background thread (2s): libproc OS scan — discovers shells, fills pwd/tty/fg_cmd, detects claude, drops zombies
 │   ├── focus.rs               # focus_terminal_for_pid() — activates owning terminal app + targets specific tab (iTerm/Terminal/VSCode/Cursor/tmux)
 │   ├── discovery.rs           # mDNS peer discovery (register, browse, resolve)
+│   ├── broadcast.rs           # UDP peer discovery: multicast (224.0.0.200:1235) + unicast /24 scan + self-loop diagnostic (4 threads: announce, scan, listen, expire)
 │   ├── helpers.rs             # Utilities: now_secs(), get_port(), get_query_param()
 │   ├── logger.rs              # Global log buffer + app_log!/app_warn!/app_error! macros
 │   ├── updater.rs             # GitHub release checker + native update dialog
@@ -176,9 +177,10 @@ MCP server.mjs ──HTTP──► server.rs /mcp/* ──emit──► useBubbl
 
 Settings.tsx ──Store──► settings.json ──event──► useTheme/usePet/... ──► App.tsx
 
-discovery.rs ──mDNS──► peers ──event──► usePeers.ts ──► context menu
-                                                              │
-                                                    start_visit command
-                                                              │
-                                              lib.rs ──HTTP──► peer's server.rs
+discovery.rs ──mDNS──────┐
+                         ├─► AppState.peers ──event──► usePeers.ts ──► context menu
+broadcast.rs ──UDP(1235)─┘                                            │
+ ├── multicast 224.0.0.200 (announce every 5s)         start_visit command
+ ├── unicast /24 scan (every 30s)                                     │
+ └── listen + expiry                            lib.rs ──HTTP──► peer's server.rs
 ```

--- a/src-tauri/src/broadcast.rs
+++ b/src-tauri/src/broadcast.rs
@@ -11,16 +11,22 @@ use crate::state::{AppState, PeerInfo};
 /// so a broken HTTP server doesn't block discovery (and vice versa).
 const MULTICAST_PORT: u16 = 1235;
 
-/// Site-local (organization-scoped) multicast group in the IANA-reserved range
-/// 239.0.0.0/8 for private apps. Not registered anywhere — just needs to be a
-/// stable value both peers agree on.
+/// Link-local multicast group in the IANA "Local Network Control Block"
+/// (`224.0.0.0/24`). Addresses in this range are **flooded** by switches —
+/// never subject to IGMP snooping — which is what we want for local peer
+/// discovery. This is the same class AirPlay/mDNS uses (`224.0.0.251`) and
+/// is why those services work on networks that drop other multicast.
 ///
-/// We use multicast instead of subnet broadcast (255.255.255.255) because many
-/// office / enterprise WiFi networks silently drop broadcast packets but still
-/// allow multicast (AirPlay / mDNS rely on it). Observed on the ani-mime dev
-/// network: _airplay._tcp multicast works fine, 255.255.255.255 broadcasts
-/// never reach peers.
-const MULTICAST_ADDR: Ipv4Addr = Ipv4Addr::new(239, 255, 42, 99);
+/// We tried `239.255.42.99` first (organization-scoped, `239.0.0.0/8`) and
+/// the dev network silently dropped it despite the kernel-side socket/join
+/// and `self-loop confirmed` both succeeding on each peer — classic IGMP
+/// snooping behaviour on managed WiFi APs. `224.0.0.200` is unassigned by
+/// IANA in the local block, so it's safe to claim for ani-mime.
+///
+/// Prior attempt before multicast: subnet broadcast (`255.255.255.255`) was
+/// dropped outright — many enterprise APs suppress broadcast to prevent
+/// broadcast storms.
+const MULTICAST_ADDR: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 200);
 
 const ANNOUNCE_INTERVAL_SECS: u64 = 5;
 const PEER_EXPIRY_SECS: u64 = 30;

--- a/src-tauri/src/broadcast.rs
+++ b/src-tauri/src/broadcast.rs
@@ -1,4 +1,5 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::Emitter;
@@ -101,9 +102,13 @@ pub fn start_broadcast(
     });
 
     // ---- Listen thread -----------------------------------------------------
+    // One-shot flag: flipped the first time we receive our own packet back.
+    // Proves that send → kernel → multicast group → recv is fully functional
+    // on THIS machine, independent of whether any peer is reachable.
+    let self_loop_confirmed = Arc::new(AtomicBool::new(false));
     let my_instance = instance_name.clone();
     std::thread::spawn(move || {
-        listen_loop(listen_socket, app_handle, app_state, my_instance);
+        listen_loop(listen_socket, app_handle, app_state, my_instance, self_loop_confirmed);
     });
 }
 
@@ -201,6 +206,7 @@ fn listen_loop(
     app_handle: tauri::AppHandle,
     app_state: Arc<Mutex<AppState>>,
     my_instance: String,
+    self_loop_confirmed: Arc<AtomicBool>,
 ) {
     let mut buf = [0u8; 1500];
     crate::app_log!(
@@ -213,7 +219,7 @@ fn listen_loop(
             Ok((n, from)) => {
                 let raw = &buf[..n];
                 match serde_json::from_slice::<serde_json::Value>(raw) {
-                    Ok(v) => handle_announce(&v, from, &app_handle, &app_state, &my_instance),
+                    Ok(v) => handle_announce(&v, from, &app_handle, &app_state, &my_instance, &self_loop_confirmed),
                     Err(e) => {
                         crate::app_warn!(
                             "[broadcast] received {} bytes from {} that isn't JSON: {}",
@@ -241,6 +247,7 @@ fn handle_announce(
     app_handle: &tauri::AppHandle,
     app_state: &Arc<Mutex<AppState>>,
     my_instance: &str,
+    self_loop_confirmed: &AtomicBool,
 ) {
     let magic = v["magic"].as_str().unwrap_or("");
     if magic != MAGIC {
@@ -257,7 +264,16 @@ fn handle_announce(
     };
 
     if instance_name == my_instance {
-        return; // our own multicast looping back
+        // Our own multicast looping back. Log once to confirm the local
+        // send→recv pipeline works — absence of this line means multicast
+        // is broken on this machine even before we talk to any peer.
+        if !self_loop_confirmed.swap(true, Ordering::Relaxed) {
+            crate::app_log!(
+                "[broadcast] self-loop confirmed: received own packet from {} — local multicast OK",
+                from
+            );
+        }
+        return;
     }
 
     let nickname = v["nickname"].as_str().unwrap_or("Unknown").to_string();

--- a/src-tauri/src/broadcast.rs
+++ b/src-tauri/src/broadcast.rs
@@ -32,6 +32,16 @@ const ANNOUNCE_INTERVAL_SECS: u64 = 5;
 const PEER_EXPIRY_SECS: u64 = 30;
 const MAGIC: &str = "ani-mime/1";
 
+/// How often to sweep the full local /24 via direct UDP unicast. Fallback
+/// for networks that filter both subnet broadcast and link-local multicast
+/// (managed WiFi / enterprise APs with "Bonjour Gateway" allowlists — we
+/// saw exactly this on the dev network where even 224.0.0.200 never crossed
+/// between clients despite unicast working fine).
+const UNICAST_SCAN_INTERVAL_SECS: u64 = 30;
+/// Spacing between individual sends within one scan — keeps the burst
+/// under ~100 pps so we don't look like a port scanner.
+const UNICAST_SEND_SPACING_MS: u64 = 10;
+
 /// Detect the machine's primary LAN IPv4 via the UDP-connect trick.
 /// No packet is actually sent — the kernel just picks the default source addr.
 fn detect_local_ipv4() -> Option<Ipv4Addr> {
@@ -57,8 +67,9 @@ pub fn start_broadcast(
     let instance_name = format!("{}-{}", nickname, std::process::id());
 
     crate::app_log!(
-        "[broadcast] starting (instance={}, nickname={}, pet={}, multicast={}:{}, http_port={}, announce_every={}s, expiry={}s)",
-        instance_name, nickname, pet, MULTICAST_ADDR, MULTICAST_PORT, http_port, ANNOUNCE_INTERVAL_SECS, PEER_EXPIRY_SECS
+        "[broadcast] starting (instance={}, nickname={}, pet={}, multicast={}:{}, http_port={}, announce_every={}s, unicast_scan_every={}s, expiry={}s)",
+        instance_name, nickname, pet, MULTICAST_ADDR, MULTICAST_PORT, http_port,
+        ANNOUNCE_INTERVAL_SECS, UNICAST_SCAN_INTERVAL_SECS, PEER_EXPIRY_SECS
     );
 
     let iface_ip = detect_local_ipv4();
@@ -98,6 +109,18 @@ pub fn start_broadcast(
     let ann_pet = pet.clone();
     std::thread::spawn(move || {
         announce_loop(ann_socket, ann_instance, ann_nickname, ann_pet, http_port);
+    });
+
+    // ---- Unicast subnet scan thread ----------------------------------------
+    // Fallback for networks that drop multicast — we directly UDP-poke every
+    // IP in the local /24 on a slow cadence. Receive side needs no change;
+    // the listen socket already accepts unicast on port 1235.
+    let scan_socket = listen_socket.clone();
+    let scan_instance = instance_name.clone();
+    let scan_nickname = nickname.clone();
+    let scan_pet = pet.clone();
+    std::thread::spawn(move || {
+        unicast_scan_loop(scan_socket, scan_instance, scan_nickname, scan_pet, http_port);
     });
 
     // ---- Expiry thread -----------------------------------------------------
@@ -204,6 +227,70 @@ fn announce_loop(
         }
 
         std::thread::sleep(Duration::from_secs(ANNOUNCE_INTERVAL_SECS));
+    }
+}
+
+/// Sweep the local /24 via direct UDP unicast. Every
+/// `UNICAST_SCAN_INTERVAL_SECS`, send our announce payload to every IP in
+/// the subnet (.1–.254, skipping self). The receive side on each peer
+/// handles unicast the same way as multicast — the `handle_announce` logic
+/// is unchanged.
+fn unicast_scan_loop(
+    socket: Arc<UdpSocket>,
+    instance_name: String,
+    nickname: String,
+    pet: String,
+    http_port: u16,
+) {
+    // Let the network come up before the first scan.
+    std::thread::sleep(Duration::from_secs(3));
+
+    let mut scan_num: u64 = 0;
+    loop {
+        scan_num += 1;
+        let local = match detect_local_ipv4() {
+            Some(ip) => ip,
+            None => {
+                crate::app_warn!("[broadcast] unicast scan #{}: no local IPv4 detected, skipping", scan_num);
+                std::thread::sleep(Duration::from_secs(UNICAST_SCAN_INTERVAL_SECS));
+                continue;
+            }
+        };
+
+        let octets = local.octets();
+        let local_last = octets[3];
+        let prefix = format!("{}.{}.{}.", octets[0], octets[1], octets[2]);
+        let payload = build_payload(&instance_name, &nickname, &pet, &local.to_string(), http_port);
+
+        let started = std::time::Instant::now();
+        let mut ok_count: u32 = 0;
+        let mut err_count: u32 = 0;
+
+        for last in 1u8..=254u8 {
+            if last == local_last {
+                continue;
+            }
+            let target: SocketAddr = match format!("{}{}:{}", prefix, last, MULTICAST_PORT).parse() {
+                Ok(a) => a,
+                Err(_) => continue,
+            };
+            match socket.send_to(&payload, target) {
+                Ok(_) => ok_count += 1,
+                Err(_) => err_count += 1, // EHOSTUNREACH / ENETUNREACH are common + noisy
+            }
+            std::thread::sleep(Duration::from_millis(UNICAST_SEND_SPACING_MS));
+        }
+
+        let elapsed = started.elapsed().as_millis();
+        crate::app_log!(
+            "[broadcast] unicast scan #{} done: prefix={}x/24, sent_ok={}, send_err={}, took={}ms",
+            scan_num, prefix, ok_count, err_count, elapsed
+        );
+
+        // Wait the remainder of the interval before the next scan.
+        let spent_secs = started.elapsed().as_secs();
+        let remaining = UNICAST_SCAN_INTERVAL_SECS.saturating_sub(spent_secs);
+        std::thread::sleep(Duration::from_secs(remaining));
     }
 }
 

--- a/src-tauri/src/broadcast.rs
+++ b/src-tauri/src/broadcast.rs
@@ -1,4 +1,4 @@
-use std::net::{SocketAddr, UdpSocket};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::Emitter;
@@ -8,20 +8,35 @@ use crate::state::{AppState, PeerInfo};
 
 /// UDP port used for peer announcements. Intentionally separate from the HTTP port
 /// so a broken HTTP server doesn't block discovery (and vice versa).
-const BROADCAST_PORT: u16 = 1235;
+const MULTICAST_PORT: u16 = 1235;
+
+/// Site-local (organization-scoped) multicast group in the IANA-reserved range
+/// 239.0.0.0/8 for private apps. Not registered anywhere — just needs to be a
+/// stable value both peers agree on.
+///
+/// We use multicast instead of subnet broadcast (255.255.255.255) because many
+/// office / enterprise WiFi networks silently drop broadcast packets but still
+/// allow multicast (AirPlay / mDNS rely on it). Observed on the ani-mime dev
+/// network: _airplay._tcp multicast works fine, 255.255.255.255 broadcasts
+/// never reach peers.
+const MULTICAST_ADDR: Ipv4Addr = Ipv4Addr::new(239, 255, 42, 99);
+
 const ANNOUNCE_INTERVAL_SECS: u64 = 5;
 const PEER_EXPIRY_SECS: u64 = 30;
 const MAGIC: &str = "ani-mime/1";
 
-/// Detect the machine's primary LAN IP via the UDP-connect trick.
+/// Detect the machine's primary LAN IPv4 via the UDP-connect trick.
 /// No packet is actually sent — the kernel just picks the default source addr.
-fn detect_local_ip() -> Option<String> {
+fn detect_local_ipv4() -> Option<Ipv4Addr> {
     let s = UdpSocket::bind("0.0.0.0:0").ok()?;
     s.connect("8.8.8.8:80").ok()?;
-    Some(s.local_addr().ok()?.ip().to_string())
+    match s.local_addr().ok()?.ip() {
+        IpAddr::V4(addr) => Some(addr),
+        _ => None,
+    }
 }
 
-/// Start the UDP-broadcast peer discovery.
+/// Start the UDP-multicast peer discovery.
 ///
 /// Runs alongside mDNS (`discovery.rs`) — both write into `AppState.peers`
 /// keyed by `instance_name`, so duplicates from the two channels are collapsed.
@@ -35,29 +50,35 @@ pub fn start_broadcast(
     let instance_name = format!("{}-{}", nickname, std::process::id());
 
     crate::app_log!(
-        "[broadcast] starting (instance={}, nickname={}, pet={}, udp_port={}, http_port={}, announce_every={}s, expiry={}s)",
-        instance_name, nickname, pet, BROADCAST_PORT, http_port, ANNOUNCE_INTERVAL_SECS, PEER_EXPIRY_SECS
+        "[broadcast] starting (instance={}, nickname={}, pet={}, multicast={}:{}, http_port={}, announce_every={}s, expiry={}s)",
+        instance_name, nickname, pet, MULTICAST_ADDR, MULTICAST_PORT, http_port, ANNOUNCE_INTERVAL_SECS, PEER_EXPIRY_SECS
     );
 
-    match detect_local_ip() {
-        Some(ip) => crate::app_log!("[broadcast] detected local IP: {}", ip),
-        None => crate::app_warn!("[broadcast] could not detect local IP (no default route?)"),
+    let iface_ip = detect_local_ipv4();
+    match iface_ip {
+        Some(ip) => crate::app_log!("[broadcast] detected local IPv4: {}", ip),
+        None => crate::app_warn!("[broadcast] could not detect local IPv4 — joining multicast via 0.0.0.0 (kernel picks interface)"),
     }
 
-    // ---- Listen socket (shared with OS) ------------------------------------
-    let listen_socket = match bind_listen_socket() {
+    // ---- Listen socket (also used for sending) -----------------------------
+    let listen_socket = match bind_multicast_socket(iface_ip) {
         Ok(s) => {
-            crate::app_log!("[broadcast] listen socket bound on 0.0.0.0:{}", BROADCAST_PORT);
+            crate::app_log!(
+                "[broadcast] listen socket bound on 0.0.0.0:{}, joined multicast group {} on iface={}",
+                MULTICAST_PORT,
+                MULTICAST_ADDR,
+                iface_ip.map(|i| i.to_string()).unwrap_or_else(|| "0.0.0.0 (kernel)".into())
+            );
             Arc::new(s)
         }
         Err(e) => {
             crate::app_error!(
-                "[broadcast] FAILED to bind listen socket on :{} — {} (check Local Network permission / firewall / port conflict)",
-                BROADCAST_PORT, e
+                "[broadcast] FAILED to bind/join multicast {}:{} — {} (check Local Network permission / firewall / interface IPv4)",
+                MULTICAST_ADDR, MULTICAST_PORT, e
             );
             let _ = app_handle.emit(
                 "discovery-error",
-                format!("broadcast listen bind failed: {}", e),
+                format!("broadcast multicast setup failed: {}", e),
             );
             return;
         }
@@ -86,14 +107,25 @@ pub fn start_broadcast(
     });
 }
 
-/// Bind a UDP socket that can both receive broadcasts and send them.
-/// Uses `SO_REUSEADDR` so multiple instances on the same machine can coexist
-/// during development.
-fn bind_listen_socket() -> std::io::Result<UdpSocket> {
-    let s = UdpSocket::bind(SocketAddr::from(([0u8, 0, 0, 0], BROADCAST_PORT)))?;
-    s.set_broadcast(true)?;
-    // Non-blocking would complicate the loop; a modest read timeout keeps the
-    // listener responsive so it can exit cleanly if we ever add shutdown.
+/// Bind a UDP socket on the multicast port and join the group. The socket
+/// will both receive multicast announces (via the group join) and send them
+/// (via send_to to the multicast address).
+///
+/// `iface_ip` is the interface to join on. Passing `None` → `0.0.0.0`, which
+/// tells the kernel to pick. Passing a specific IP binds the join to that
+/// interface — useful on multi-homed machines (e.g. Mac mini with en0 + en1).
+fn bind_multicast_socket(iface_ip: Option<Ipv4Addr>) -> std::io::Result<UdpSocket> {
+    let s = UdpSocket::bind(SocketAddr::from(([0u8, 0, 0, 0], MULTICAST_PORT)))?;
+    let join_iface = iface_ip.unwrap_or(Ipv4Addr::UNSPECIFIED);
+    s.join_multicast_v4(&MULTICAST_ADDR, &join_iface)?;
+    // TTL=1 keeps packets on the local segment — same as mDNS.
+    s.set_multicast_ttl_v4(1)?;
+    // Receive our own packets too (handle_announce filters self by instance_name).
+    // Useful as a self-test: if we see our own announce come back in, we know
+    // send+receive are both working on the right interface.
+    s.set_multicast_loop_v4(true)?;
+    // Short read timeout so the listen loop can eventually exit cleanly
+    // if we ever add shutdown handling.
     s.set_read_timeout(Some(Duration::from_secs(1)))?;
     Ok(s)
 }
@@ -125,30 +157,37 @@ fn announce_loop(
     pet: String,
     http_port: u16,
 ) {
-    let broadcast_addr: SocketAddr = SocketAddr::from(([255u8, 255, 255, 255], BROADCAST_PORT));
-    let mut tick: u64 = 0;
+    let multicast_addr: SocketAddr = SocketAddr::from((MULTICAST_ADDR, MULTICAST_PORT));
 
+    // Give the network stack a moment to finish setting up the multicast
+    // membership before the first send — eliminates the "No route to host"
+    // on send #1 we saw on some Macs when the send raced the kernel.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let mut tick: u64 = 0;
     loop {
         tick += 1;
-        let ip = detect_local_ip().unwrap_or_default();
+        let ip = detect_local_ipv4()
+            .map(|v| v.to_string())
+            .unwrap_or_default();
         let payload = build_payload(&instance_name, &nickname, &pet, &ip, http_port);
         let size = payload.len();
 
-        match socket.send_to(&payload, broadcast_addr) {
+        match socket.send_to(&payload, multicast_addr) {
             Ok(sent) => {
                 // Log every tick for the first few (so users see it working),
                 // then once per minute to avoid log spam.
                 if tick <= 3 || tick % 12 == 0 {
                     crate::app_log!(
-                        "[broadcast] announced #{} ({} bytes, sent={}, ip={}, http_port={})",
-                        tick, size, sent, ip, http_port
+                        "[broadcast] announced #{} ({} bytes, sent={}, ip={}, http_port={}, via multicast {}:{})",
+                        tick, size, sent, ip, http_port, MULTICAST_ADDR, MULTICAST_PORT
                     );
                 }
             }
             Err(e) => {
                 crate::app_error!(
-                    "[broadcast] send_to 255.255.255.255:{} failed: {} (firewall? network entitlement missing?)",
-                    BROADCAST_PORT, e
+                    "[broadcast] send_to {}:{} failed: {} (interface gone? multicast route missing? permission revoked?)",
+                    MULTICAST_ADDR, MULTICAST_PORT, e
                 );
             }
         }
@@ -164,7 +203,10 @@ fn listen_loop(
     my_instance: String,
 ) {
     let mut buf = [0u8; 1500];
-    crate::app_log!("[broadcast] listening for peer announcements on 0.0.0.0:{}", BROADCAST_PORT);
+    crate::app_log!(
+        "[broadcast] listening for peer announcements on 0.0.0.0:{} (multicast group {})",
+        MULTICAST_PORT, MULTICAST_ADDR
+    );
 
     loop {
         match socket.recv_from(&mut buf) {
@@ -215,7 +257,7 @@ fn handle_announce(
     };
 
     if instance_name == my_instance {
-        return; // our own broadcast bouncing back
+        return; // our own multicast looping back
     }
 
     let nickname = v["nickname"].as_str().unwrap_or("Unknown").to_string();

--- a/src-tauri/src/broadcast.rs
+++ b/src-tauri/src/broadcast.rs
@@ -1,0 +1,311 @@
+use std::net::{SocketAddr, UdpSocket};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tauri::Emitter;
+
+use crate::helpers::{get_port, now_secs};
+use crate::state::{AppState, PeerInfo};
+
+/// UDP port used for peer announcements. Intentionally separate from the HTTP port
+/// so a broken HTTP server doesn't block discovery (and vice versa).
+const BROADCAST_PORT: u16 = 1235;
+const ANNOUNCE_INTERVAL_SECS: u64 = 5;
+const PEER_EXPIRY_SECS: u64 = 30;
+const MAGIC: &str = "ani-mime/1";
+
+/// Detect the machine's primary LAN IP via the UDP-connect trick.
+/// No packet is actually sent — the kernel just picks the default source addr.
+fn detect_local_ip() -> Option<String> {
+    let s = UdpSocket::bind("0.0.0.0:0").ok()?;
+    s.connect("8.8.8.8:80").ok()?;
+    Some(s.local_addr().ok()?.ip().to_string())
+}
+
+/// Start the UDP-broadcast peer discovery.
+///
+/// Runs alongside mDNS (`discovery.rs`) — both write into `AppState.peers`
+/// keyed by `instance_name`, so duplicates from the two channels are collapsed.
+pub fn start_broadcast(
+    app_handle: tauri::AppHandle,
+    app_state: Arc<Mutex<AppState>>,
+    nickname: String,
+    pet: String,
+) {
+    let http_port = get_port();
+    let instance_name = format!("{}-{}", nickname, std::process::id());
+
+    crate::app_log!(
+        "[broadcast] starting (instance={}, nickname={}, pet={}, udp_port={}, http_port={}, announce_every={}s, expiry={}s)",
+        instance_name, nickname, pet, BROADCAST_PORT, http_port, ANNOUNCE_INTERVAL_SECS, PEER_EXPIRY_SECS
+    );
+
+    match detect_local_ip() {
+        Some(ip) => crate::app_log!("[broadcast] detected local IP: {}", ip),
+        None => crate::app_warn!("[broadcast] could not detect local IP (no default route?)"),
+    }
+
+    // ---- Listen socket (shared with OS) ------------------------------------
+    let listen_socket = match bind_listen_socket() {
+        Ok(s) => {
+            crate::app_log!("[broadcast] listen socket bound on 0.0.0.0:{}", BROADCAST_PORT);
+            Arc::new(s)
+        }
+        Err(e) => {
+            crate::app_error!(
+                "[broadcast] FAILED to bind listen socket on :{} — {} (check Local Network permission / firewall / port conflict)",
+                BROADCAST_PORT, e
+            );
+            let _ = app_handle.emit(
+                "discovery-error",
+                format!("broadcast listen bind failed: {}", e),
+            );
+            return;
+        }
+    };
+
+    // ---- Announce thread ---------------------------------------------------
+    let ann_socket = listen_socket.clone();
+    let ann_instance = instance_name.clone();
+    let ann_nickname = nickname.clone();
+    let ann_pet = pet.clone();
+    std::thread::spawn(move || {
+        announce_loop(ann_socket, ann_instance, ann_nickname, ann_pet, http_port);
+    });
+
+    // ---- Expiry thread -----------------------------------------------------
+    let exp_state = app_state.clone();
+    let exp_handle = app_handle.clone();
+    std::thread::spawn(move || {
+        expiry_loop(exp_state, exp_handle);
+    });
+
+    // ---- Listen thread -----------------------------------------------------
+    let my_instance = instance_name.clone();
+    std::thread::spawn(move || {
+        listen_loop(listen_socket, app_handle, app_state, my_instance);
+    });
+}
+
+/// Bind a UDP socket that can both receive broadcasts and send them.
+/// Uses `SO_REUSEADDR` so multiple instances on the same machine can coexist
+/// during development.
+fn bind_listen_socket() -> std::io::Result<UdpSocket> {
+    let s = UdpSocket::bind(SocketAddr::from(([0u8, 0, 0, 0], BROADCAST_PORT)))?;
+    s.set_broadcast(true)?;
+    // Non-blocking would complicate the loop; a modest read timeout keeps the
+    // listener responsive so it can exit cleanly if we ever add shutdown.
+    s.set_read_timeout(Some(Duration::from_secs(1)))?;
+    Ok(s)
+}
+
+/// Build the JSON announce payload once per tick. Keep it small — UDP datagrams
+/// above ~512 bytes risk fragmentation on some networks.
+fn build_payload(
+    instance_name: &str,
+    nickname: &str,
+    pet: &str,
+    ip: &str,
+    port: u16,
+) -> Vec<u8> {
+    let v = serde_json::json!({
+        "magic": MAGIC,
+        "instance_name": instance_name,
+        "nickname": nickname,
+        "pet": pet,
+        "ip": ip,
+        "port": port,
+    });
+    v.to_string().into_bytes()
+}
+
+fn announce_loop(
+    socket: Arc<UdpSocket>,
+    instance_name: String,
+    nickname: String,
+    pet: String,
+    http_port: u16,
+) {
+    let broadcast_addr: SocketAddr = SocketAddr::from(([255u8, 255, 255, 255], BROADCAST_PORT));
+    let mut tick: u64 = 0;
+
+    loop {
+        tick += 1;
+        let ip = detect_local_ip().unwrap_or_default();
+        let payload = build_payload(&instance_name, &nickname, &pet, &ip, http_port);
+        let size = payload.len();
+
+        match socket.send_to(&payload, broadcast_addr) {
+            Ok(sent) => {
+                // Log every tick for the first few (so users see it working),
+                // then once per minute to avoid log spam.
+                if tick <= 3 || tick % 12 == 0 {
+                    crate::app_log!(
+                        "[broadcast] announced #{} ({} bytes, sent={}, ip={}, http_port={})",
+                        tick, size, sent, ip, http_port
+                    );
+                }
+            }
+            Err(e) => {
+                crate::app_error!(
+                    "[broadcast] send_to 255.255.255.255:{} failed: {} (firewall? network entitlement missing?)",
+                    BROADCAST_PORT, e
+                );
+            }
+        }
+
+        std::thread::sleep(Duration::from_secs(ANNOUNCE_INTERVAL_SECS));
+    }
+}
+
+fn listen_loop(
+    socket: Arc<UdpSocket>,
+    app_handle: tauri::AppHandle,
+    app_state: Arc<Mutex<AppState>>,
+    my_instance: String,
+) {
+    let mut buf = [0u8; 1500];
+    crate::app_log!("[broadcast] listening for peer announcements on 0.0.0.0:{}", BROADCAST_PORT);
+
+    loop {
+        match socket.recv_from(&mut buf) {
+            Ok((n, from)) => {
+                let raw = &buf[..n];
+                match serde_json::from_slice::<serde_json::Value>(raw) {
+                    Ok(v) => handle_announce(&v, from, &app_handle, &app_state, &my_instance),
+                    Err(e) => {
+                        crate::app_warn!(
+                            "[broadcast] received {} bytes from {} that isn't JSON: {}",
+                            n, from, e
+                        );
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock
+                || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                // Normal — read_timeout fired. Loop around.
+            }
+            Err(e) => {
+                crate::app_error!("[broadcast] recv_from error: {}", e);
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        }
+    }
+}
+
+fn handle_announce(
+    v: &serde_json::Value,
+    from: SocketAddr,
+    app_handle: &tauri::AppHandle,
+    app_state: &Arc<Mutex<AppState>>,
+    my_instance: &str,
+) {
+    let magic = v["magic"].as_str().unwrap_or("");
+    if magic != MAGIC {
+        // Silently ignore foreign traffic on our port — not worth logging.
+        return;
+    }
+
+    let instance_name = match v["instance_name"].as_str() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => {
+            crate::app_warn!("[broadcast] announce from {} missing instance_name, skipping", from);
+            return;
+        }
+    };
+
+    if instance_name == my_instance {
+        return; // our own broadcast bouncing back
+    }
+
+    let nickname = v["nickname"].as_str().unwrap_or("Unknown").to_string();
+    let pet = v["pet"].as_str().unwrap_or("rottweiler").to_string();
+    let port = v["port"].as_u64().unwrap_or(1234) as u16;
+
+    // Prefer the IP the peer advertised; fall back to the UDP source IP.
+    let advertised_ip = v["ip"].as_str().unwrap_or("").to_string();
+    let ip = if !advertised_ip.is_empty() {
+        advertised_ip
+    } else {
+        from.ip().to_string()
+    };
+
+    let now = now_secs();
+    let mut st = app_state.lock().unwrap();
+    let was_known = st.peers.contains_key(&instance_name);
+    let last_seen_before = st.broadcast_seen.get(&instance_name).copied();
+
+    let peer = PeerInfo {
+        instance_name: instance_name.clone(),
+        nickname: nickname.clone(),
+        pet: pet.clone(),
+        ip: ip.clone(),
+        port,
+    };
+    st.peers.insert(instance_name.clone(), peer);
+    st.broadcast_seen.insert(instance_name.clone(), now);
+    let peer_count = st.peers.len();
+    let peers: Vec<PeerInfo> = st.peers.values().cloned().collect();
+    drop(st);
+
+    if !was_known {
+        crate::app_log!(
+            "[broadcast] NEW peer: {} ({}) at {}:{} via {} — total peers={}",
+            nickname, pet, ip, port, from, peer_count
+        );
+        if let Err(e) = app_handle.emit("peers-changed", &peers) {
+            crate::app_error!("[broadcast] failed to emit peers-changed: {}", e);
+        }
+    } else {
+        // Log refresh once per peer per minute to confirm liveness without spam.
+        let should_log = match last_seen_before {
+            Some(prev) => now - prev >= 60,
+            None => true,
+        };
+        if should_log {
+            crate::app_log!(
+                "[broadcast] refresh peer: {} ({}) at {}:{} (known={}s)",
+                nickname, pet, ip, port,
+                last_seen_before.map(|t| now - t).unwrap_or(0)
+            );
+        }
+    }
+}
+
+fn expiry_loop(app_state: Arc<Mutex<AppState>>, app_handle: tauri::AppHandle) {
+    loop {
+        std::thread::sleep(Duration::from_secs(ANNOUNCE_INTERVAL_SECS));
+        let now = now_secs();
+
+        let mut st = app_state.lock().unwrap();
+        let stale: Vec<String> = st.broadcast_seen
+            .iter()
+            .filter(|(_, ts)| now.saturating_sub(**ts) > PEER_EXPIRY_SECS)
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        if stale.is_empty() {
+            continue;
+        }
+
+        for name in &stale {
+            let age = st.broadcast_seen.get(name).map(|t| now - *t).unwrap_or(0);
+            st.broadcast_seen.remove(name);
+            if st.peers.remove(name).is_some() {
+                crate::app_warn!(
+                    "[broadcast] EXPIRED peer: {} (no announce for {}s, limit={}s)",
+                    name, age, PEER_EXPIRY_SECS
+                );
+            }
+        }
+
+        let peers: Vec<PeerInfo> = st.peers.values().cloned().collect();
+        let peer_count = peers.len();
+        drop(st);
+
+        crate::app_log!("[broadcast] after expiry sweep: total peers={}", peer_count);
+        if let Err(e) = app_handle.emit("peers-changed", &peers) {
+            crate::app_error!("[broadcast] failed to emit peers-changed: {}", e);
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 extern crate objc;
 
+mod broadcast;
 mod claude_config;
 mod discovery;
 mod focus;
@@ -552,6 +553,7 @@ pub fn run() {
                 discovery_instance: String::new(),
                 discovery_addrs: Vec::new(),
                 discovery_port: 0,
+                broadcast_seen: HashMap::new(),
                 pet: String::new(),
                 nickname: String::new(),
                 started_at: crate::helpers::now_secs(),
@@ -612,7 +614,13 @@ pub fn run() {
                     st.nickname = nickname.clone();
                 }
 
-                discovery::start_discovery(discovery_handle, discovery_state, nickname, pet);
+                discovery::start_discovery(
+                    discovery_handle.clone(),
+                    discovery_state.clone(),
+                    nickname.clone(),
+                    pet.clone(),
+                );
+                broadcast::start_broadcast(discovery_handle, discovery_state, nickname, pet);
             });
 
             Ok(())

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -110,6 +110,9 @@ pub struct AppState {
     pub discovery_instance: String,
     pub discovery_addrs: Vec<String>,
     pub discovery_port: u16,
+    /// Last time each peer was heard from via UDP broadcast (unix secs).
+    /// Peers only in this map (not refreshed by mDNS) are pruned by the broadcast watchdog.
+    pub broadcast_seen: HashMap<String, u64>,
     // --- Identity (for MCP pet-status) ---
     pub pet: String,
     pub nickname: String,


### PR DESCRIPTION
## Summary

- Adds **`src-tauri/src/broadcast.rs`**, a UDP-based peer discovery module with two channels running alongside the existing mDNS:
  - **Multicast announce** to `224.0.0.200:1235` every 5s — flooded by link-local multicast, works on most networks
  - **Unicast `/24` subnet scan** every 30s — fallback for networks that filter all multicast (managed WiFi / Bonjour Gateways)
- Both channels write into the existing `AppState.peers` HashMap keyed by `instance_name`, so the UI, visit protocol, and Tauri events are **completely unchanged** — three channels, one peer list
- Includes a `self-loop confirmed` diagnostic log line to distinguish "local multicast broken" from "network drops multicast between clients"
- Full docs: `docs/peer-discovery.md` rewritten with three-channel model, packet format, network-compatibility matrix, expanded troubleshooting; plus constants/project-structure/CLAUDE.md updates

## Motivation

Two Macs on the same office WiFi couldn't see each other despite correct configs end to end. Investigation across 6 commits narrowed it down:

1. mDNS registered on loopback only on one Mac (known `mdns-sd` crate quirk with IPv4-only interfaces)
2. `255.255.255.255` broadcast was dropped by the AP (standard broadcast suppression)
3. `239.255.42.99` organization-scoped multicast was dropped by IGMP snooping
4. `224.0.0.200` link-local multicast was *still* dropped — the AP is running a Bonjour Gateway that allowlists specific service types only
5. Unicast between clients works fine (verified via `curl http://<peer-ip>:1234/debug`)

The unicast subnet scan is the one channel that works on networks like this. On friendlier networks, the faster multicast + mDNS channels still win.

See `docs/peer-discovery.md` for the full compatibility matrix and diagnostic flow.

## Commits (preserved for the debug-trail value)

- `2d1233c feat(p2p): add UDP broadcast peer discovery alongside mDNS`
- `f683905 fix(p2p): use UDP multicast (239.255.42.99) instead of subnet broadcast`
- `cafca82 feat(p2p): log self-loop confirmation for multicast diagnostics`
- `2971442 fix(p2p): use link-local multicast 224.0.0.200 to bypass IGMP snooping`
- `5d0c284 feat(p2p): add unicast /24 subnet scan as multicast-resistant fallback`
- `15952ae docs(p2p): document broadcast module across four doc surfaces`

## Performance & spam footprint

- **Network**: ~1.3 KB/s outbound per instance (mostly the unicast scan). Burst peak ~100 pps during the ~2.5s scan window, well under any IDS port-scan threshold
- **CPU**: <0.05% steady, <0.1% during scan burst
- **Memory**: +~200 KB resident (4 new sleep-dominated threads)
- **Log volume**: ~18 lines/min steady state, throttled (multicast announces log only ticks 1–3 and every 12th; peer refresh capped at once/min/peer)
- **Data structures**: `AppState.peers` and `AppState.broadcast_seen` both bounded by peers on the LAN; 30s expiry prevents growth from bogus announces

## Not included on purpose

- No frontend changes — all three channels feed the same `peers-changed` event
- No changes to the visit protocol, `server.rs`, or any existing module (except the 3-line wire-up in `lib.rs` and the `broadcast_seen` field on `AppState`)
- No `.c3/` updates — the db isn't migrated yet; separate follow-up session
- No `ARCHITECTURE.md` / `state-management.md` polish — deferred to a PR B focused on longer-form docs
- No version bump — release will happen in a separate PR when ready

## Test plan

- [ ] Pull branch, `bun run tauri dev` on two Macs on the same WiFi
- [ ] Within ~35s, each shows the other in the mascot right-click context menu
- [ ] Verify `[broadcast] self-loop confirmed` appears in the log
- [ ] Verify `[broadcast] NEW peer:` appears for the other machine
- [ ] Verify `[broadcast] unicast scan #1 done: ... sent_ok=253` completes
- [ ] Right-click → Visit the peer; confirm `VisitorDog` appears on the receiving side; confirm auto-return after 15s
- [ ] Quit one side, wait 30s, confirm `[broadcast] EXPIRED peer:` on the other side and peer disappears from menu
- [ ] `cargo check` passes (already verified — 0 errors, pre-existing warnings unchanged)
- [ ] Check `/debug` HTTP endpoint still shows peers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)