### PR TITLE
chore: release v0.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.16.6] - 2026-04-20
+
+### Added
+- **Resilient peer discovery** — peer discovery now runs across three parallel channels (mDNS + UDP multicast + UDP unicast `/24` subnet scan), so peers are found on networks where any one channel is blocked. A new `broadcast.rs` module handles the UDP channels on port `1235`; all three channels feed the same `AppState.peers` keyed by `instance_name` so the UI and visit protocol are unchanged. (#98)
+- **`[broadcast]` diagnostic logging** — new log tag with explicit lines for socket bind, multicast join, per-scan summary, `NEW peer` / `refresh peer` / `EXPIRED peer` transitions, and a one-shot `self-loop confirmed` line that proves the local multicast send→recv pipeline is healthy. Makes triaging "peers not finding each other" issues grep-friendly. (#98)
+- **Network-compatibility matrix & troubleshooting guide** in `docs/peer-discovery.md` — covers which channel wins on which network type (home WiFi / managed WiFi with Bonjour Gateway / VLAN) and how to read the log to pinpoint failures. (#98)
+
+### Fixed
+- **Peer discovery on managed WiFi / enterprise networks** — on networks running a Bonjour Gateway that allowlists specific mDNS service types (common in offices and co-working spaces), `_ani-mime._tcp` was silently dropped even between machines on the same subnet. The new UDP unicast subnet scan bypasses multicast filtering entirely by direct-poking every IP in the local `/24` every 30s. (#98)
+
+### Changed
+- New `AppState.broadcast_seen: HashMap<String, u64>` tracks last-heard-from time per peer; the expiry loop removes peers silent for `PEER_EXPIRY_SECS` (30s).
+- `lib.rs` now spawns both `discovery::start_discovery` and `broadcast::start_broadcast` in parallel on startup.
+
 ## [0.16.5] - 2026-04-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.16.5",
+  "version": "0.16.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.16.5"
+version = "0.16.6"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.16.5"
+version = "0.16.6"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1029,7 +1029,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.16.5{devMode && " (Dev Mode)"}
+                  Version 0.16.6{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary

- Bumps version to v0.16.6 across all 4 files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src/components/Settings.tsx`)
- Adds CHANGELOG entry for v0.16.6 covering the p2p discovery work from #98
- Regenerates `Cargo.lock` after the `Cargo.toml` version bump

## Release notes (v0.16.6)

**Added**
- Resilient peer discovery: three parallel channels (mDNS + UDP multicast + UDP unicast `/24` subnet scan)
- `[broadcast]` diagnostic logging with `self-loop confirmed` health check
- Network-compatibility matrix & troubleshooting guide in `docs/peer-discovery.md`

**Fixed**
- Peer discovery on managed WiFi / enterprise networks running Bonjour Gateways

## Test plan

- [ ] CI green (type check, cargo check, tests)
- [ ] After merge: `git tag v0.16.6 && git push origin v0.16.6`
- [ ] Verify CI `create-release` + `build` jobs succeed → DMGs attached to GitHub Release
- [ ] Update Homebrew cask (`Casks/ani-mime.rb`) with new SHA256s

🤖 Generated with [Claude Code](https://claude.com/claude-code)