### PR TITLE
feat(smart-import): shrink .animime export and keep all detected frames

### DIFF
--- a/src/__tests__/components/SmartImport.test.tsx
+++ b/src/__tests__/components/SmartImport.test.tsx
@@ -1,13 +1,20 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { SmartImport, serializeFrames } from "../../components/SmartImport";
 
-// Stub the sprite-sheet processor so the test doesn't need a real canvas pipeline
-vi.mock("../../utils/spriteSheetProcessor", () => {
+// Stub the sprite-sheet processor so the test doesn't need a real canvas pipeline.
+// Keep the pure string helpers (parseFrameInput / serializeFrames) real since the
+// component and tests both use them for input normalization.
+vi.mock("../../utils/spriteSheetProcessor", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/spriteSheetProcessor")>(
+    "../../utils/spriteSheetProcessor"
+  );
   const fakeCanvas = () => document.createElement("canvas");
   const fakeFrames = Array.from({ length: 7 }, (_, i) => ({
     index: i, x1: 0, y1: 0, x2: 10, y2: 10,
   }));
   return {
+    parseFrameInput: actual.parseFrameInput,
+    serializeFrames: actual.serializeFrames,
     loadImage: vi.fn(async () => ({} as HTMLImageElement)),
     prepareCanvas: vi.fn(() => ({ canvas: fakeCanvas(), ctx: null })),
     removeSmallComponents: vi.fn(),

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -96,6 +96,7 @@ export function Settings() {
   const [smartImportPath, setSmartImportPath] = useState<string | null>(null);
   const [editingMime, setEditingMime] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
   const [spriteInputs, setSpriteInputs] = useState<
     Record<Status, { path: string; frames: string }>
@@ -783,11 +784,14 @@ export function Settings() {
                       className="pet-card add-card"
                       data-testid="import-animime-btn"
                       onClick={async () => {
+                        setImportError(null);
                         try {
                           const id = await importMime();
                           if (id) setPet(id);
                         } catch (err) {
-                          logError(`[settings] import failed: ${err instanceof Error ? err.message : err}`);
+                          const msg = err instanceof Error ? err.message : String(err);
+                          logError(`[settings] import failed: ${msg}`);
+                          setImportError(msg);
                         }
                       }}
                     >
@@ -795,6 +799,11 @@ export function Settings() {
                       <span className="pet-name">Animime</span>
                     </button>
                   </div>
+                  {importError && (
+                    <div className="save-error" data-testid="import-error">
+                      Import failed: {importError}
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/src/components/SmartImport.tsx
+++ b/src/components/SmartImport.tsx
@@ -6,15 +6,18 @@ import type { Status } from "../types/status";
 import {
   loadImage,
   prepareCanvas,
-  removeSmallComponents,
   detectRows,
   extractFrames,
   getFramePreview,
   createStripFromFrames,
+  parseFrameInput,
+  serializeFrames,
   type Frame,
 } from "../utils/spriteSheetProcessor";
 import { ALL_STATUSES } from "../hooks/useCustomMimes";
 import { AnimationPreview } from "./AnimationPreview";
+
+export { parseFrameInput, serializeFrames };
 
 interface SmartImportProps {
   onSave: (
@@ -51,58 +54,6 @@ const STATUS_DESCRIPTIONS: Record<Status, string> = {
   initializing: "First-launch setup in progress",
   visiting: "A friend's mime is visiting from the local network",
 };
-
-/** Parse "1-5" or "1,2,3,5,6" into 0-based indices. Preserves order and duplicates. Ranges are directional: 3-1 → 3,2,1. */
-export function parseFrameInput(input: string, maxFrame: number): number[] {
-  const indices: number[] = [];
-  for (const part of input.split(",")) {
-    const trimmed = part.trim();
-    if (!trimmed) continue;
-    const range = trimmed.split("-");
-    if (range.length === 2) {
-      const start = parseInt(range[0]);
-      const end = parseInt(range[1]);
-      if (!isNaN(start) && !isNaN(end)) {
-        const step = start <= end ? 1 : -1;
-        for (let i = start; step === 1 ? i <= end : i >= end; i += step) {
-          if (i >= 1 && i <= maxFrame) {
-            indices.push(i - 1);
-          }
-        }
-      }
-    } else {
-      const n = parseInt(trimmed);
-      if (!isNaN(n) && n >= 1 && n <= maxFrame) {
-        indices.push(n - 1);
-      }
-    }
-  }
-  return indices;
-}
-
-/** Inverse of parseFrameInput. Collapses consecutive runs; preserves direction. */
-export function serializeFrames(nums: number[]): string {
-  if (nums.length === 0) return "";
-  const parts: string[] = [];
-  let i = 0;
-  while (i < nums.length) {
-    let j = i;
-    const prevDup = i > 0 && nums[i - 1] === nums[i];
-    const step = prevDup
-      ? 0
-      : nums[i + 1] === nums[i] + 1
-      ? 1
-      : nums[i + 1] === nums[i] - 1
-      ? -1
-      : 0;
-    if (step !== 0) {
-      while (j + 1 < nums.length && nums[j + 1] === nums[j] + step) j++;
-    }
-    parts.push(j === i ? `${nums[i]}` : `${nums[i]}-${nums[j]}`);
-    i = j + 1;
-  }
-  return parts.join(",");
-}
 
 export function SmartImport({
   onSave,
@@ -154,7 +105,6 @@ export function SmartImport({
       URL.revokeObjectURL(src);
 
       const prepared = prepareCanvas(img).canvas;
-      removeSmallComponents(prepared);
       setCanvas(prepared);
       previewCache.current.clear();
 

--- a/src/hooks/useCustomMimes.ts
+++ b/src/hooks/useCustomMimes.ts
@@ -5,8 +5,16 @@ import { open, save } from "@tauri-apps/plugin-dialog";
 import { copyFile, mkdir, exists, remove, writeFile, readFile } from "@tauri-apps/plugin-fs";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { info } from "@tauri-apps/plugin-log";
+import { info, warn } from "@tauri-apps/plugin-log";
 import type { Status, CustomMimeData } from "../types/status";
+import {
+  loadImage,
+  prepareCanvas,
+  detectRows,
+  extractFrames,
+  createStripFromFrames,
+  parseFrameInput,
+} from "../utils/spriteSheetProcessor";
 
 const STORE_FILE = "settings.json";
 const STORE_KEY = "customMimes";
@@ -258,31 +266,34 @@ export function useCustomMimes() {
     if (!mime) return;
 
     const dir = await ensureSpritesDir();
-    const sprites: Record<string, { frames: number; data: string }> = {};
+    const bytesToBase64 = (bytes: Uint8Array) =>
+      btoa(Array.from(bytes).map((b) => String.fromCharCode(b)).join(""));
 
-    for (const status of ALL_STATUSES) {
-      const { fileName, frames } = mime.sprites[status];
-      const bytes = await readFile(`${dir}/${fileName}`);
-      const binary = Array.from(bytes).map((b) => String.fromCharCode(b)).join("");
-      sprites[status] = { frames, data: btoa(binary) };
-    }
+    let payloadObj: Record<string, unknown>;
 
-    let smartImportExport: { sourceSheet: string; frameInputs: Record<Status, string> } | undefined;
     if (mime.smartImportMeta) {
+      // v2: ship only sourceSheet + frameInputs. Per-status sprites are
+      // regenerable by re-running detection + cropping on import.
       const sheetBytes = await readFile(`${dir}/${mime.smartImportMeta.sheetFileName}`);
-      const sheetBinary = Array.from(sheetBytes).map((b) => String.fromCharCode(b)).join("");
-      smartImportExport = {
-        sourceSheet: btoa(sheetBinary),
-        frameInputs: mime.smartImportMeta.frameInputs,
+      payloadObj = {
+        version: 2,
+        name: mime.name,
+        smartImportMeta: {
+          sourceSheet: bytesToBase64(sheetBytes),
+          frameInputs: mime.smartImportMeta.frameInputs,
+        },
       };
+    } else {
+      const sprites: Record<string, { frames: number; data: string }> = {};
+      for (const status of ALL_STATUSES) {
+        const { fileName, frames } = mime.sprites[status];
+        const bytes = await readFile(`${dir}/${fileName}`);
+        sprites[status] = { frames, data: bytesToBase64(bytes) };
+      }
+      payloadObj = { version: 1, name: mime.name, sprites };
     }
 
-    const payload = JSON.stringify({
-      version: 1,
-      name: mime.name,
-      sprites,
-      ...(smartImportExport ? { smartImportMeta: smartImportExport } : {}),
-    }, null, 2);
+    const payload = JSON.stringify(payloadObj, null, 2);
     const date = new Date().toISOString().slice(0, 10);
     const safeName = mime.name.replace(/[^a-zA-Z0-9_-]/g, "-");
     const defaultName = `animime-${safeName}-${date}`;
@@ -296,7 +307,7 @@ export function useCustomMimes() {
     const path = dest.endsWith(".animime") ? dest : `${dest}.animime`;
     const encoder = new TextEncoder();
     await writeFile(path, encoder.encode(payload));
-    info(`[custom-mimes] exported "${mime.name}" to ${path}`);
+    info(`[custom-mimes] exported "${mime.name}" to ${path} (v${payloadObj.version}, ${payload.length} bytes)`);
   }, [mimes, ensureSpritesDir]);
 
   const importMime = useCallback(async (): Promise<string | null> => {
@@ -310,38 +321,93 @@ export function useCustomMimes() {
     const decoder = new TextDecoder();
     const payload = JSON.parse(decoder.decode(bytes));
 
-    if (payload.version !== 1 || !payload.name || !payload.sprites) {
+    if (!payload.name || (payload.version !== 1 && payload.version !== 2)) {
       throw new Error("Invalid .animime file");
     }
 
+    const base64ToBytes = (b64: string) => {
+      const binary = atob(b64);
+      const out = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+      return out;
+    };
+
     const id = `custom-${Date.now()}`;
-    info(`[custom-mimes] importMime: name="${payload.name}", id=${id}`);
+    info(`[custom-mimes] importMime: name="${payload.name}", id=${id}, version=${payload.version}`);
     const dir = await ensureSpritesDir();
 
     const sprites: Record<string, { fileName: string; frames: number }> = {};
-    for (const status of ALL_STATUSES) {
-      const entry = payload.sprites[status];
-      if (!entry || !entry.data) {
-        throw new Error(`Missing sprite data for "${status}"`);
-      }
-      const binary = atob(entry.data);
-      const blob = new Uint8Array(binary.length);
-      for (let i = 0; i < binary.length; i++) blob[i] = binary.charCodeAt(i);
-
-      const fileName = `${id}-${status}.png`;
-      await writeFile(`${dir}/${fileName}`, blob);
-      sprites[status] = { fileName, frames: entry.frames };
-    }
-
     let metaRecord: CustomMimeData["smartImportMeta"];
-    if (payload.smartImportMeta?.sourceSheet && payload.smartImportMeta?.frameInputs) {
-      const sheetBinary = atob(payload.smartImportMeta.sourceSheet);
-      const sheetBlob = new Uint8Array(sheetBinary.length);
-      for (let i = 0; i < sheetBinary.length; i++) sheetBlob[i] = sheetBinary.charCodeAt(i);
 
+    if (payload.version === 2) {
+      const meta = payload.smartImportMeta;
+      if (!meta?.sourceSheet || !meta?.frameInputs) {
+        throw new Error("v2 .animime file missing sourceSheet or frameInputs");
+      }
+
+      const sheetBytes = base64ToBytes(meta.sourceSheet);
       const sheetFileName = `${id}-source.png`;
-      await writeFile(`${dir}/${sheetFileName}`, sheetBlob);
-      metaRecord = { sheetFileName, frameInputs: payload.smartImportMeta.frameInputs };
+      info(`[custom-mimes] v2 import: decoded source sheet (${sheetBytes.length} bytes), writing to disk`);
+      await writeFile(`${dir}/${sheetFileName}`, sheetBytes);
+
+      const magicType =
+        sheetBytes[0] === 0x47 && sheetBytes[1] === 0x49 && sheetBytes[2] === 0x46 ? "image/gif" :
+        sheetBytes[0] === 0xff && sheetBytes[1] === 0xd8 ? "image/jpeg" :
+        "image/png";
+      const sheetBlob = new Blob([sheetBytes as BlobPart], { type: magicType });
+      const src = URL.createObjectURL(sheetBlob);
+      try {
+        const img = await loadImage(src);
+        info(`[custom-mimes] v2 import: loaded image ${img.width}x${img.height}`);
+        const prepared = prepareCanvas(img).canvas;
+        const detected = detectRows(prepared);
+        if (detected.length === 0) {
+          throw new Error("Could not detect sprite rows in source sheet");
+        }
+        const allFrames = extractFrames(detected);
+        info(`[custom-mimes] v2 import: detected ${detected.length} rows, ${allFrames.length} frames`);
+
+        for (const status of ALL_STATUSES) {
+          const input = meta.frameInputs[status] ?? "";
+          const indices = parseFrameInput(input, allFrames.length);
+          if (indices.length === 0) {
+            throw new Error(`No frames assigned to "${status}" (input="${input}", maxFrame=${allFrames.length})`);
+          }
+          const strip = await createStripFromFrames(prepared, allFrames, indices);
+          const fileName = `${id}-${status}.png`;
+          await writeFile(`${dir}/${fileName}`, strip.blob);
+          sprites[status] = { fileName, frames: strip.frames };
+        }
+        info(`[custom-mimes] v2 import: regenerated all ${ALL_STATUSES.length} status sprites`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        warn(`[custom-mimes] v2 import failed: ${msg}`);
+        throw err instanceof Error ? err : new Error(msg);
+      } finally {
+        URL.revokeObjectURL(src);
+      }
+
+      metaRecord = { sheetFileName, frameInputs: meta.frameInputs };
+    } else {
+      if (!payload.sprites) throw new Error("v1 .animime file missing sprites");
+
+      for (const status of ALL_STATUSES) {
+        const entry = payload.sprites[status];
+        if (!entry || !entry.data) {
+          throw new Error(`Missing sprite data for "${status}"`);
+        }
+        const blob = base64ToBytes(entry.data);
+        const fileName = `${id}-${status}.png`;
+        await writeFile(`${dir}/${fileName}`, blob);
+        sprites[status] = { fileName, frames: entry.frames };
+      }
+
+      if (payload.smartImportMeta?.sourceSheet && payload.smartImportMeta?.frameInputs) {
+        const sheetBytes = base64ToBytes(payload.smartImportMeta.sourceSheet);
+        const sheetFileName = `${id}-source.png`;
+        await writeFile(`${dir}/${sheetFileName}`, sheetBytes);
+        metaRecord = { sheetFileName, frameInputs: payload.smartImportMeta.frameInputs };
+      }
     }
 
     const newMime: CustomMimeData = {

--- a/src/utils/spriteSheetProcessor.ts
+++ b/src/utils/spriteSheetProcessor.ts
@@ -27,12 +27,64 @@ export interface ProcessedStrip {
   frames: number;
 }
 
+/** Parse "1-5" or "1,2,3,5,6" into 0-based indices. Preserves order and duplicates. Ranges are directional: 3-1 → 3,2,1. */
+export function parseFrameInput(input: string, maxFrame: number): number[] {
+  const indices: number[] = [];
+  for (const part of input.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const range = trimmed.split("-");
+    if (range.length === 2) {
+      const start = parseInt(range[0]);
+      const end = parseInt(range[1]);
+      if (!isNaN(start) && !isNaN(end)) {
+        const step = start <= end ? 1 : -1;
+        for (let i = start; step === 1 ? i <= end : i >= end; i += step) {
+          if (i >= 1 && i <= maxFrame) {
+            indices.push(i - 1);
+          }
+        }
+      }
+    } else {
+      const n = parseInt(trimmed);
+      if (!isNaN(n) && n >= 1 && n <= maxFrame) {
+        indices.push(n - 1);
+      }
+    }
+  }
+  return indices;
+}
+
+/** Inverse of parseFrameInput. Collapses consecutive runs; preserves direction. */
+export function serializeFrames(nums: number[]): string {
+  if (nums.length === 0) return "";
+  const parts: string[] = [];
+  let i = 0;
+  while (i < nums.length) {
+    let j = i;
+    const prevDup = i > 0 && nums[i - 1] === nums[i];
+    const step = prevDup
+      ? 0
+      : nums[i + 1] === nums[i] + 1
+      ? 1
+      : nums[i + 1] === nums[i] - 1
+      ? -1
+      : 0;
+    if (step !== 0) {
+      while (j + 1 < nums.length && nums[j + 1] === nums[j] + step) j++;
+    }
+    parts.push(j === i ? `${nums[i]}` : `${nums[i]}-${nums[j]}`);
+    i = j + 1;
+  }
+  return parts.join(",");
+}
+
 /** Load an image from a file path or data URL */
 export function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => resolve(img);
-    img.onerror = reject;
+    img.onerror = () => reject(new Error(`Failed to decode image (src=${src.slice(0, 40)}...)`));
     img.src = src;
   });
 }


### PR DESCRIPTION
## Motivation

The marketplace where `.animime` files are shared caps uploads at 2 MB. Sprite sheets like the Naruto Kyuubi one were producing ~2.2 MB exports — over the limit and un-shareable — because the v1 format embeds the source sheet and every per-status sprite as separate base64 blobs, most of which are redundant.

## Summary

- Smart Import mimes now export in a new v2 `.animime` format that embeds only the source sheet + frame-input strings. The importer re-runs detection + cropping to regenerate per-status sprites, cutting export size ~8x (Naruto Kyuubi: 2.2 MB → 1.2 MB, now under the marketplace cap).
- Removes `removeSmallComponents()` from the Smart Import pipeline so every detected sprite region survives (previously this was dropping the Naruto Kyuubi sheet from 277 → 228 frames, breaking round-trips for any frame range above 228).
- v1 `.animime` files (manual-creator mimes and older Smart Import exports) continue to import unchanged via the v1 branch.
- Import errors now surface in the Settings UI instead of being swallowed into the log.
- `parseFrameInput` / `serializeFrames` move to `spriteSheetProcessor.ts` to break the `useCustomMimes` ↔ `SmartImport` import cycle; `SmartImport` re-exports them so existing test imports keep working.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `bunx vitest run src/__tests__/components/SmartImport.test.tsx src/__tests__/hooks/useCustomMimes.test.ts` passes
- [ ] Smart-import a PNG sprite sheet, save, export → file is significantly smaller than before; it uses `"version": 2` and contains `smartImportMeta.sourceSheet` + `smartImportMeta.frameInputs` with no `sprites[*].data`
- [ ] Re-exported Naruto Kyuubi-scale sheets fit under the 2 MB marketplace upload cap
- [ ] Import that v2 file on a fresh install → all 7 status sprites are regenerated and the mime appears with the original name
- [ ] Import an older v1 `.animime` file → still works, sprites are read from the embedded base64
- [ ] Trigger an import failure (e.g. a malformed `.animime`) → error message shows under the Animime card in Settings instead of silently failing