### PR TITLE
feat(ui): peer-list popover window, unified action bar, visitor greetings

### DIFF
--- a/docs/constants-reference.md
+++ b/docs/constants-reference.md
@@ -11,7 +11,7 @@ All hardcoded values, timeouts, and configurable parameters in the codebase.
 | `HEARTBEAT_TIMEOUT_SECS` | 40 | `watchdog.rs` | Remove session if no heartbeat for this long |
 | `SERVICE_DISPLAY_SECS` | 2 | `watchdog.rs` | How long service state shows before auto-transitioning to idle |
 | `IDLE_TO_SLEEP_SECS` | 120 | `watchdog.rs` | Idle duration before entering sleep mode (suppresses emits) |
-| `VISIT_DURATION_SECS` | 15 | `lib.rs` | How long a dog visit lasts |
+| `VISIT_DURATION_SECS` | 8 | `lib.rs` | How long a dog visit lasts |
 | `ANNOUNCE_INTERVAL_SECS` | 5 | `broadcast.rs` | UDP multicast announce cadence |
 | `PEER_EXPIRY_SECS` | 30 | `broadcast.rs` | Remove broadcast peer after this many seconds of silence |
 | `UNICAST_SCAN_INTERVAL_SECS` | 30 | `broadcast.rs` | How often to sweep the local /24 via unicast |

--- a/docs/peer-discovery.md
+++ b/docs/peer-discovery.md
@@ -154,7 +154,7 @@ Both go through the same `handle_announce` code path — the sender's channel is
      { "instance_name": "Alice-12345", "pet": "rottweiler", "nickname": "Alice", "duration_secs": 15 }
      ```
    - Emits `dog-away: true` (hides local mascot)
-   - Spawns thread: sleeps for `VISIT_DURATION_SECS` (15s)
+   - Spawns thread: sleeps for `VISIT_DURATION_SECS` (8s)
 
 ### Receiving a Visit
 
@@ -286,4 +286,4 @@ dns-sd -R "TestBuddy-9999" "_ani-mime._tcp" "local." 1234 nickname=Buddy pet=dal
 - **No rejection** — visits are automatically accepted.
 - **No encryption** — HTTP traffic and UDP announces are plaintext.
 - **Single visit** — can only visit one peer at a time.
-- **Fixed visit duration** — 15 seconds, not configurable by user.
+- **Fixed visit duration** — 8 seconds, not configurable by user.

--- a/peer-list.html
+++ b/peer-list.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mime Around You</title>
+    <style>html, body, #root { margin: 0; padding: 0; overflow: hidden; height: 100%; background: transparent; }</style>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/peer-list-main.tsx"></script>
+  </body>
+</html>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main", "settings"],
+  "windows": ["main", "settings", "superpower", "peer-list"],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
@@ -12,6 +12,12 @@
     "core:window:allow-outer-position",
     "core:window:allow-outer-size",
     "core:window:allow-scale-factor",
+    "core:window:allow-show",
+    "core:window:allow-hide",
+    "core:window:allow-set-focus",
+    "core:window:allow-is-visible",
+    "core:webview:allow-webview-show",
+    "core:webview:allow-webview-hide",
     "core:event:default",
     "opener:default",
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,7 +24,7 @@ use tauri::tray::TrayIconBuilder;
 
 use crate::state::{AppState, SessionInfo};
 
-const VISIT_DURATION_SECS: u64 = 15;
+const VISIT_DURATION_SECS: u64 = 8;
 
 #[tauri::command]
 fn get_logs() -> Vec<logger::LogEntry> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,14 @@ use tauri::tray::TrayIconBuilder;
 use crate::state::{AppState, SessionInfo};
 
 const VISIT_DURATION_SECS: u64 = 8;
+/// Visit duration when the sender attached a message. Currently equal
+/// to the plain visit duration; kept as a separate constant so we can
+/// extend (or shrink) message visits later without affecting plain ones.
+const MESSAGE_VISIT_DURATION_SECS: u64 = 8;
+/// Max characters accepted for a chat message. Messages longer than this
+/// are truncated server-side as a defensive bound; the frontend enforces
+/// the same limit at input time.
+const MESSAGE_MAX_LEN: usize = 100;
 
 #[tauri::command]
 fn get_logs() -> Vec<logger::LogEntry> {
@@ -255,10 +263,29 @@ fn start_visit(
     peer_id: String,
     nickname: String,
     pet: String,
+    message: Option<String>,
     state: tauri::State<'_, Arc<Mutex<AppState>>>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    crate::app_log!("[visit] starting visit to peer={} as {} ({})", peer_id, nickname, pet);
+    // Normalize + enforce message length server-side (frontend caps at
+    // MESSAGE_MAX_LEN already; this is a defensive bound for other
+    // callers / bad actors).
+    let message = message
+        .map(|m| m.trim().to_string())
+        .filter(|m| !m.is_empty())
+        .map(|m| m.chars().take(MESSAGE_MAX_LEN).collect::<String>());
+
+    let duration_secs = if message.is_some() {
+        MESSAGE_VISIT_DURATION_SECS
+    } else {
+        VISIT_DURATION_SECS
+    };
+
+    crate::app_log!(
+        "[visit] starting visit to peer={} as {} ({}){}",
+        peer_id, nickname, pet,
+        message.as_deref().map(|m| format!(" with message: {:?}", m)).unwrap_or_default()
+    );
 
     let (ip, port, my_instance) = {
         let mut st = state.lock().unwrap();
@@ -298,17 +325,21 @@ fn start_visit(
     let app_clone = app.clone();
     let nickname_clone = nickname.clone();
     let pet_clone = pet.clone();
+    let message_clone = message.clone();
     std::thread::spawn(move || {
         let base = crate::helpers::format_http_host(&ip, port);
         let url = format!("{}/visit", base);
         crate::app_log!("[visit] sending POST {}", url);
 
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "instance_name": my_instance,
             "pet": pet_clone,
             "nickname": nickname_clone,
-            "duration_secs": VISIT_DURATION_SECS,
+            "duration_secs": duration_secs,
         });
+        if let Some(m) = &message_clone {
+            body["message"] = serde_json::Value::String(m.clone());
+        }
 
         let agent = visit_agent();
         if let Err(e) = agent.post(&url).send_json(&body) {
@@ -328,8 +359,8 @@ fn start_visit(
             return;
         }
 
-        crate::app_log!("[visit] visit request accepted by peer, returning in {}s", VISIT_DURATION_SECS);
-        std::thread::sleep(std::time::Duration::from_secs(VISIT_DURATION_SECS));
+        crate::app_log!("[visit] visit request accepted by peer, returning in {}s", duration_secs);
+        std::thread::sleep(std::time::Duration::from_secs(duration_secs));
 
         // Send visit-end to peer — use instance_name as stable identifier
         let my_instance_clone = {

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -232,8 +232,16 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
                         let pet = payload["pet"].as_str().unwrap_or("rottweiler").to_string();
                         let nickname = payload["nickname"].as_str().unwrap_or("Unknown").to_string();
                         let duration_secs = payload["duration_secs"].as_u64().unwrap_or(15);
+                        let message = payload["message"]
+                            .as_str()
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty());
 
-                        crate::app_log!("[visit] {} ({}) [{}] arrived for {}s", nickname, pet, instance_name, duration_secs);
+                        crate::app_log!(
+                            "[visit] {} ({}) [{}] arrived for {}s{}",
+                            nickname, pet, instance_name, duration_secs,
+                            message.as_deref().map(|m| format!(" — msg: {:?}", m)).unwrap_or_default()
+                        );
 
                         let mut st = app_state.lock().unwrap();
                         st.visitors.push(crate::state::VisitingDog {
@@ -242,18 +250,23 @@ pub fn start_http_server(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppS
                             nickname: nickname.clone(),
                             arrived_at: now,
                             duration_secs,
+                            message: message.clone(),
                         });
                         let visitor_count = st.visitors.len();
                         drop(st);
 
                         crate::app_log!("[visit] total visitors: {}", visitor_count);
 
-                        if let Err(e) = app_handle.emit("visitor-arrived", serde_json::json!({
+                        let mut event_payload = serde_json::json!({
                             "instance_name": instance_name,
                             "pet": pet,
                             "nickname": nickname,
                             "duration_secs": duration_secs,
-                        })) {
+                        });
+                        if let Some(m) = &message {
+                            event_payload["message"] = serde_json::Value::String(m.clone());
+                        }
+                        if let Err(e) = app_handle.emit("visitor-arrived", event_payload) {
                             crate::app_error!("[visit] failed to emit visitor-arrived: {}", e);
                         }
                     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -26,6 +26,11 @@ pub struct VisitingDog {
     pub nickname: String,
     pub arrived_at: u64,
     pub duration_secs: u64,
+    /// Optional one-line message from the sender. When present, the
+    /// frontend renders it as a persistent speech bubble for the full
+    /// visit duration instead of showing a random greeting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 /// Per-shell session state.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,6 +49,21 @@
         "decorations": true,
         "transparent": false,
         "center": true
+      },
+      {
+        "label": "peer-list",
+        "title": "Mime Around You",
+        "url": "peer-list.html",
+        "width": 280,
+        "height": 260,
+        "resizable": false,
+        "visible": false,
+        "decorations": false,
+        "transparent": true,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "focus": true,
+        "shadow": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,7 @@ function App() {
               key={v.instance_name || v.nickname || `${i}`}
               pet={v.pet}
               nickname={v.nickname}
+              message={v.message}
               index={i}
             />
           ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,72 +10,48 @@ import { useDrag } from "./hooks/useDrag";
 import { useTheme } from "./hooks/useTheme";
 import { useBubble } from "./hooks/useBubble";
 import { useVisitors } from "./hooks/useVisitors";
-import { usePeers } from "./hooks/usePeers";
-import { useNickname } from "./hooks/useNickname";
-import { usePet } from "./hooks/usePet";
 import { useScale } from "./hooks/useScale";
 import { useDevMode } from "./hooks/useDevMode";
 import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
-import { useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import { Menu, MenuItem } from "@tauri-apps/api/menu";
+import { useEffect, useRef, useState } from "react";
+import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 import "./styles/theme.css";
 import "./styles/app.css";
+
+// Extra height to add to the widget window while the fixed-positioned
+// session-list dropdown is open. Gives the dropdown room to render
+// without being clipped (the dropdown itself is position: fixed so it
+// doesn't inflate the container, which means useWindowAutoSize would
+// otherwise leave the window at its compact size). 300 = dropdown
+// max-height (280px) + top gap (6) + shadow buffer (~14).
+const SESSION_DROPDOWN_EXTRA_HEIGHT = 300;
+const SESSION_DROPDOWN_MIN_WIDTH = 320;
 
 function App() {
   const { status, scenario } = useStatus();
   const { dragging, onMouseDown } = useDrag();
   const { visible, message, dismiss } = useBubble();
   const visitors = useVisitors();
-  const peers = usePeers();
-  const { nickname } = useNickname();
-  const { pet } = usePet();
   const { scale } = useScale();
   const devMode = useDevMode();
   const containerRef = useRef<HTMLDivElement>(null);
   const [effectActive, setEffectActive] = useState(false);
+  const [sessionOpen, setSessionOpen] = useState(false);
   useTheme();
-  useWindowAutoSize(containerRef, effectActive);
+  // Pause auto-size while the session dropdown is open — we manually
+  // grow the window so the absolute-positioned dropdown has room.
+  useWindowAutoSize(containerRef, effectActive || sessionOpen);
 
-  const onContextMenu = async (e: React.MouseEvent) => {
-    e.preventDefault();
-
-    if (status === "visiting") return;
-
-    const items: MenuItem[] = [];
-
-    if (peers.length === 0) {
-      const item = await MenuItem.new({
-        id: "no-peers",
-        text: "No peers nearby \u2014 check Local Network permission",
-        enabled: false,
-      });
-      items.push(item);
-    } else {
-      for (const peer of peers) {
-        const peerId = peer.instance_name;
-        const item = await MenuItem.new({
-          id: peerId,
-          text: `Visit ${peer.nickname} (${peer.pet})`,
-          action: async () => {
-            try {
-              await invoke("start_visit", {
-                peerId,
-                nickname,
-                pet,
-              });
-            } catch (err) {
-              console.error("Visit failed:", err);
-            }
-          },
-        });
-        items.push(item);
-      }
-    }
-
-    const menu = await Menu.new({ items });
-    await menu.popup();
-  };
+  useEffect(() => {
+    if (!sessionOpen) return;
+    const el = containerRef.current;
+    if (!el) return;
+    const width = Math.max(el.offsetWidth, SESSION_DROPDOWN_MIN_WIDTH);
+    const height = el.offsetHeight + SESSION_DROPDOWN_EXTRA_HEIGHT;
+    getCurrentWindow()
+      .setSize(new LogicalSize(width, height))
+      .catch((err) => console.error("[session-dropdown] setSize failed:", err));
+  }, [sessionOpen]);
 
   return (
     <div
@@ -83,7 +59,6 @@ function App() {
       data-testid="app-container"
       className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""}`}
       onMouseDown={onMouseDown}
-      onContextMenu={onContextMenu}
     >
       <div className="main-col">
         {scenario && <div data-testid="scenario-badge" className="scenario-badge">SCENARIO</div>}
@@ -92,7 +67,12 @@ function App() {
         {status !== "visiting" && <Mascot status={status} />}
         {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
         <DevBuildBadge />
-        <StatusPill status={status} glow={visible} />
+        <StatusPill
+          status={status}
+          glow={visible}
+          disabled={status === "visiting"}
+          onOpenChange={setSessionOpen}
+        />
         {devMode && <DevTag />}
       </div>
       {visitors.length > 0 && (

--- a/src/PeerListApp.tsx
+++ b/src/PeerListApp.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { usePeers, type PeerInfo } from "./hooks/usePeers";
+import { useNickname } from "./hooks/useNickname";
+import { usePet } from "./hooks/usePet";
+import { useTheme } from "./hooks/useTheme";
+import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
+import "./styles/theme.css";
+import "./styles/peer-list-window.css";
+
+export function PeerListApp() {
+  const peers = usePeers();
+  const { nickname } = useNickname();
+  const { pet } = usePet();
+  const rootRef = useRef<HTMLDivElement>(null);
+  useTheme();
+  // Auto-size this popover's Tauri window to match content height —
+  // shrinks for empty state, grows as peers arrive.
+  useWindowAutoSize(rootRef);
+
+  // Auto-hide the popover when it loses focus (user clicks outside).
+  useEffect(() => {
+    const win = getCurrentWindow();
+    const unlistenP = win.onFocusChanged(({ payload: focused }) => {
+      if (!focused) {
+        void win.hide();
+      }
+    });
+    return () => {
+      unlistenP.then((fn) => fn());
+    };
+  }, []);
+
+  // Escape closes the popover.
+  useEffect(() => {
+    const win = getCurrentWindow();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") void win.hide();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const handleVisit = async (peer: PeerInfo) => {
+    try {
+      await invoke("start_visit", {
+        peerId: peer.instance_name,
+        nickname,
+        pet,
+      });
+    } catch (err) {
+      console.error("[peer-list] start_visit failed:", err);
+    } finally {
+      void getCurrentWindow().hide();
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="peer-list-shell">
+      <div className="peer-list-root" data-testid="peer-list-root">
+        <div className="peer-list-header">Mime Around You</div>
+      {peers.length === 0 ? (
+        <div className="peer-list-empty" data-testid="peer-list-empty">
+          <span className="peer-list-empty-title">No peers nearby</span>
+          <span className="peer-list-empty-hint">
+            Check Local Network permission
+          </span>
+        </div>
+      ) : (
+        <div className="peer-list-items" data-testid="peer-list-items">
+          {peers.map((p) => (
+            <button
+              key={p.instance_name}
+              type="button"
+              className="peer-list-row"
+              data-testid={`peer-list-row-${p.instance_name}`}
+              onClick={() => handleVisit(p)}
+              title={`Visit ${p.nickname} — ${p.ip}:${p.port}`}
+            >
+              <span className="peer-list-row-dot" aria-hidden="true" />
+              <span className="peer-list-row-main">
+                <span className="peer-list-row-nickname">{p.nickname}</span>
+                <span className="peer-list-row-pet">{p.pet}</span>
+              </span>
+              <span className="peer-list-row-action" aria-hidden="true">
+                visit
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+      </div>
+    </div>
+  );
+}

--- a/src/PeerListApp.tsx
+++ b/src/PeerListApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { usePeers, type PeerInfo } from "./hooks/usePeers";
@@ -9,17 +9,20 @@ import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
 import "./styles/theme.css";
 import "./styles/peer-list-window.css";
 
+/** Max length of an outgoing chat message — must match MESSAGE_MAX_LEN in lib.rs. */
+const MESSAGE_MAX_LEN = 100;
+
 export function PeerListApp() {
   const peers = usePeers();
   const { nickname } = useNickname();
   const { pet } = usePet();
   const rootRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [composingPeer, setComposingPeer] = useState<PeerInfo | null>(null);
+  const [draft, setDraft] = useState("");
   useTheme();
-  // Auto-size this popover's Tauri window to match content height —
-  // shrinks for empty state, grows as peers arrive.
   useWindowAutoSize(rootRef);
 
-  // Auto-hide the popover when it loses focus (user clicks outside).
   useEffect(() => {
     const win = getCurrentWindow();
     const unlistenP = win.onFocusChanged(({ payload: focused }) => {
@@ -32,15 +35,28 @@ export function PeerListApp() {
     };
   }, []);
 
-  // Escape closes the popover.
+  // Escape: close compose first, then the window if already in list view.
   useEffect(() => {
     const win = getCurrentWindow();
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") void win.hide();
+      if (e.key !== "Escape") return;
+      if (composingPeer) {
+        setComposingPeer(null);
+        setDraft("");
+        return;
+      }
+      void win.hide();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [composingPeer]);
+
+  // Focus textarea when compose opens.
+  useEffect(() => {
+    if (!composingPeer) return;
+    const id = requestAnimationFrame(() => textareaRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [composingPeer]);
 
   const handleVisit = async (peer: PeerInfo) => {
     try {
@@ -56,40 +72,208 @@ export function PeerListApp() {
     }
   };
 
+  const openCompose = (peer: PeerInfo) => {
+    setComposingPeer(peer);
+    setDraft("");
+  };
+
+  const cancelCompose = () => {
+    setComposingPeer(null);
+    setDraft("");
+  };
+
+  const sendMessage = async () => {
+    if (!composingPeer) return;
+    const msg = draft.trim();
+    if (!msg) return;
+    try {
+      await invoke("start_visit", {
+        peerId: composingPeer.instance_name,
+        nickname,
+        pet,
+        message: msg,
+      });
+    } catch (err) {
+      console.error("[peer-list] start_visit with message failed:", err);
+    } finally {
+      setComposingPeer(null);
+      setDraft("");
+      void getCurrentWindow().hide();
+    }
+  };
+
   return (
     <div ref={rootRef} className="peer-list-shell">
       <div className="peer-list-root" data-testid="peer-list-root">
-        <div className="peer-list-header">Mime Around You</div>
-      {peers.length === 0 ? (
-        <div className="peer-list-empty" data-testid="peer-list-empty">
-          <span className="peer-list-empty-title">No peers nearby</span>
-          <span className="peer-list-empty-hint">
-            Check Local Network permission
-          </span>
+        {composingPeer ? (
+          <ComposeView
+            peer={composingPeer}
+            draft={draft}
+            onDraftChange={setDraft}
+            onCancel={cancelCompose}
+            onSend={sendMessage}
+            textareaRef={textareaRef}
+          />
+        ) : (
+          <>
+            <div className="peer-list-header">Mime Around You</div>
+            {peers.length === 0 ? (
+              <div className="peer-list-empty" data-testid="peer-list-empty">
+                <span className="peer-list-empty-title">No peers nearby</span>
+                <span className="peer-list-empty-hint">
+                  Check Local Network permission
+                </span>
+              </div>
+            ) : (
+              <div className="peer-list-items" data-testid="peer-list-items">
+                {peers.map((p) => (
+                  <div
+                    key={p.instance_name}
+                    className="peer-list-row-wrap"
+                    data-testid={`peer-list-row-${p.instance_name}`}
+                  >
+                    <div className="peer-list-row">
+                      <span className="peer-list-row-dot" aria-hidden="true" />
+                      <span className="peer-list-row-main">
+                        <span className="peer-list-row-nickname">{p.nickname}</span>
+                        <span className="peer-list-row-pet">{p.pet}</span>
+                      </span>
+                      <button
+                        type="button"
+                        className="peer-list-row-action"
+                        data-testid={`peer-list-visit-${p.instance_name}`}
+                        onClick={() => handleVisit(p)}
+                        title={`Visit ${p.nickname}`}
+                      >
+                        visit
+                      </button>
+                      <button
+                        type="button"
+                        className="peer-list-row-action message"
+                        data-testid={`peer-list-message-${p.instance_name}`}
+                        onClick={() => openCompose(p)}
+                        aria-label={`Message ${p.nickname}`}
+                        title={`Message ${p.nickname}`}
+                      >
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ComposeViewProps {
+  peer: PeerInfo;
+  draft: string;
+  onDraftChange: (s: string) => void;
+  onCancel: () => void;
+  onSend: () => void | Promise<void>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+function ComposeView({
+  peer,
+  draft,
+  onDraftChange,
+  onCancel,
+  onSend,
+  textareaRef,
+}: ComposeViewProps) {
+  const canSend = draft.trim().length > 0;
+  const nearLimit = draft.length >= MESSAGE_MAX_LEN - 10;
+
+  return (
+    <div className="peer-compose" data-testid="peer-compose">
+      <div className="peer-compose-head">
+        <button
+          type="button"
+          className="peer-compose-back"
+          onClick={onCancel}
+          aria-label="Back to peer list"
+          title="Back"
+          data-testid="peer-compose-back"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+        </button>
+        <div className="peer-compose-target">
+          <span className="peer-compose-target-label">to</span>
+          <span className="peer-compose-target-name">{peer.nickname}</span>
+          <span className="peer-compose-target-pet">({peer.pet})</span>
         </div>
-      ) : (
-        <div className="peer-list-items" data-testid="peer-list-items">
-          {peers.map((p) => (
-            <button
-              key={p.instance_name}
-              type="button"
-              className="peer-list-row"
-              data-testid={`peer-list-row-${p.instance_name}`}
-              onClick={() => handleVisit(p)}
-              title={`Visit ${p.nickname} — ${p.ip}:${p.port}`}
-            >
-              <span className="peer-list-row-dot" aria-hidden="true" />
-              <span className="peer-list-row-main">
-                <span className="peer-list-row-nickname">{p.nickname}</span>
-                <span className="peer-list-row-pet">{p.pet}</span>
-              </span>
-              <span className="peer-list-row-action" aria-hidden="true">
-                visit
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
+      </div>
+
+      <textarea
+        ref={textareaRef}
+        className="peer-compose-textarea"
+        value={draft}
+        onChange={(e) => onDraftChange(e.target.value.slice(0, MESSAGE_MAX_LEN))}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            void onSend();
+          }
+        }}
+        placeholder="Say something nice..."
+        maxLength={MESSAGE_MAX_LEN}
+        rows={3}
+        data-testid="peer-compose-textarea"
+      />
+
+      <div className="peer-compose-footer">
+        <span
+          className={`peer-compose-count ${nearLimit ? "near-limit" : ""}`}
+          data-testid="peer-compose-count"
+        >
+          {draft.length}/{MESSAGE_MAX_LEN}
+        </span>
+        <button
+          type="button"
+          className="peer-compose-cancel"
+          onClick={onCancel}
+          data-testid="peer-compose-cancel"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="peer-compose-send"
+          onClick={() => void onSend()}
+          disabled={!canSend}
+          data-testid="peer-compose-send"
+        >
+          Send
+        </button>
       </div>
     </div>
   );

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -1,15 +1,34 @@
 import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import {
+  getCurrentWindow,
+  LogicalPosition,
+  PhysicalPosition,
+} from "@tauri-apps/api/window";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { Status } from "../types/status";
 import { fetchSessions, type SessionInfo } from "../hooks/useSessions";
 import { useSessionList } from "../hooks/useSessionList";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
+import { usePeers } from "../hooks/usePeers";
 import "../styles/status-pill.css";
 
 interface StatusPillProps {
   status: Status;
   glow?: boolean;
+  /**
+   * Disables the lan (peer) icon — used during a visit when the user
+   * can't start a second one. The task icon (session list) is always
+   * available regardless of visiting state.
+   */
+  disabled?: boolean;
+  /**
+   * Notifies parent when the session-list dropdown open state changes.
+   * App uses this to pause window auto-size and manually grow the Tauri
+   * window while the fixed-positioned dropdown is visible.
+   */
+  onOpenChange?: (open: boolean) => void;
 }
 
 const dotClassMap: Record<Status, string> = {
@@ -66,7 +85,6 @@ function groupBasename(g: { pwd: string; pretty: string; sessions: SessionInfo[]
     const leaf = g.pwd.split("/").filter(Boolean).pop();
     if (leaf) return leaf;
   }
-  // Fallback: if no pwd, use the pretty (already may be title/pid fallback).
   return g.pretty || g.sessions[0]?.title || "";
 }
 
@@ -74,7 +92,6 @@ function groupBasename(g: { pwd: string; pretty: string; sessions: SessionInfo[]
 function shellLabel(s: SessionInfo): string {
   if (s.has_claude) return "claude";
   if (s.fg_cmd) {
-    // Some commands have "-" prefix when run as login shells ("-zsh" etc) — strip it.
     return s.fg_cmd.replace(/^-/, "");
   }
   if (s.ui_state === "busy" && s.busy_type) return s.busy_type;
@@ -92,17 +109,13 @@ interface Group {
 }
 
 function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
-  // Find pid=0 (legacy Claude shared virtual) — only used as a fallback bucket.
   const claudeVirtual = sessions.find((s) => s.pid === 0);
   const anyShellHasClaude = sessions.some((s) => s.pid !== 0 && s.has_claude);
 
-  // Group real shells by PWD. If pwd is unknown (rare — scanner couldn't read
-  // cwd), fall back to title so the row still shows something meaningful
-  // instead of vanishing.
   const byKey = new Map<string, { pwd: string; list: SessionInfo[] }>();
   for (const s of sessions) {
-    if (s.pid === 0) continue;       // legacy shared virtual
-    if (s.is_claude_proc) continue;  // claude process — represented by its parent shell
+    if (s.pid === 0) continue;
+    if (s.is_claude_proc) continue;
     const key = s.pwd || s.title || String(s.pid);
     if (!byKey.has(key)) byKey.set(key, { pwd: s.pwd, list: [] });
     byKey.get(key)!.list.push(s);
@@ -123,7 +136,6 @@ function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
     });
   }
 
-  // Active groups first, then alphabetical.
   groups.sort((a, b) => {
     const pa = statePriority[a.state] ?? 0;
     const pb = statePriority[b.state] ?? 0;
@@ -131,7 +143,6 @@ function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
     return a.pretty.localeCompare(b.pretty);
   });
 
-  // Fallback: if proc_scan found no claude but hooks report one, show it.
   if (claudeVirtual && !anyShellHasClaude) {
     groups.push({
       key: "claude-virtual",
@@ -146,7 +157,6 @@ function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
   return groups;
 }
 
-// Detect user's home dir from the first absolute path we see.
 function detectHome(sessions: SessionInfo[]): string | undefined {
   for (const s of sessions) {
     const m = s.pwd.match(/^(\/Users\/[^/]+|\/home\/[^/]+)/);
@@ -155,11 +165,6 @@ function detectHome(sessions: SessionInfo[]): string | undefined {
   return undefined;
 }
 
-/** The watchdog auto-flips `ui_state` from "service" back to "idle" after 2
- *  seconds (so the global pill doesn't lock blue while a dev server runs).
- *  But `busy_type` stays "service" until precmd fires — which long-running
- *  servers never do. So in the dropdown we trust busy_type and re-assert the
- *  service color for the whole lifetime of the dev server. */
 function reflectActiveServices(sessions: SessionInfo[]): SessionInfo[] {
   return sessions.map((s) =>
     s.busy_type === "service" && s.ui_state === "idle"
@@ -168,25 +173,15 @@ function reflectActiveServices(sessions: SessionInfo[]): SessionInfo[] {
   );
 }
 
-/** Claude Code's busy/idle state lives on a separate session — either the
- *  per-claude PID (after the pid=$PPID hook migration) or the legacy shared
- *  pid=0. Overlay that state onto each shell with has_claude=true so the
- *  dropdown dot reflects what that specific Claude is doing.
- *
- *  Each claude-hosting shell gets the state of ITS OWN claude_pid session, so
- *  two Claude tabs no longer turn red together when only one is busy. */
 function overlayClaudeState(sessions: SessionInfo[]): SessionInfo[] {
   const sessionByPid = new Map<number, SessionInfo>();
   for (const s of sessions) sessionByPid.set(s.pid, s);
 
   return sessions.map((s) => {
     if (!s.has_claude) return s;
-
-    // Prefer the dedicated per-claude PID; fall back to legacy pid=0.
     const claudeSession =
       (s.claude_pid != null && sessionByPid.get(s.claude_pid)) ||
       sessionByPid.get(0);
-
     if (!claudeSession) return s;
     const claudeP = statePriority[claudeSession.ui_state] ?? 0;
     const ownP = statePriority[s.ui_state] ?? 0;
@@ -194,39 +189,76 @@ function overlayClaudeState(sessions: SessionInfo[]): SessionInfo[] {
   });
 }
 
-export function StatusPill({ status, glow }: StatusPillProps) {
-  const [open, setOpen] = useState(false);
+/** Width of the peer-list popover window — must match tauri.conf.json. */
+const POPOVER_WIDTH = 280;
+/** Negative offset overlaps the popover's 12px shadow-buffer padding. */
+const POPOVER_TOP_GAP = -8;
+
+async function computePopoverScreenPos(
+  anchorEl: HTMLElement
+): Promise<LogicalPosition> {
+  const main = getCurrentWindow();
+  const mainPos = await main.outerPosition();
+  const scale = await main.scaleFactor();
+
+  const pill = anchorEl.closest(".pill") ?? anchorEl;
+  const rect = (pill as HTMLElement).getBoundingClientRect();
+
+  const mainLogical =
+    mainPos instanceof PhysicalPosition ? mainPos.toLogical(scale) : mainPos;
+
+  const centerX = mainLogical.x + rect.left + rect.width / 2;
+  const left = centerX - POPOVER_WIDTH / 2;
+  const top = mainLogical.y + rect.bottom + POPOVER_TOP_GAP;
+  return new LogicalPosition(Math.round(left), Math.round(top));
+}
+
+export function StatusPill({ status, glow, disabled = false, onOpenChange }: StatusPillProps) {
+  // --- Session list state ---
+  const [sessionOpen, setSessionOpen] = useState(false);
   const [groups, setGroups] = useState<Group[]>([]);
+  const [dropdownTop, setDropdownTop] = useState(0);
   const wrapRef = useRef<HTMLDivElement>(null);
   const { enabled: sessionListEnabled } = useSessionList();
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
 
-  const toggleOpen = async (e: React.MouseEvent) => {
-    if (!sessionListEnabled) return; // feature disabled — pill is not clickable
+  // --- Peer popover state ---
+  const peers = usePeers();
+  const [peerOpen, setPeerOpen] = useState(false);
+  const lanButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    onOpenChange?.(sessionOpen);
+  }, [sessionOpen, onOpenChange]);
+
+  useEffect(() => {
+    if (!sessionOpen) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setDropdownTop(rect.bottom + 6);
+  }, [sessionOpen]);
+
+  const toggleSession = async (e: React.MouseEvent) => {
+    if (!sessionListEnabled) return;
     e.preventDefault();
     e.stopPropagation();
-    if (open) {
-      setOpen(false);
+    if (sessionOpen) {
+      setSessionOpen(false);
       return;
     }
     const list = await fetchSessions();
     const overlaid = overlayClaudeState(reflectActiveServices(list));
     setGroups(groupSessions(overlaid, detectHome(overlaid)));
-    setOpen(true);
+    setSessionOpen(true);
   };
 
-  // If the user disables the feature while the dropdown is open, close it.
   useEffect(() => {
-    if (!sessionListEnabled && open) setOpen(false);
-  }, [sessionListEnabled, open]);
+    if (!sessionListEnabled && sessionOpen) setSessionOpen(false);
+  }, [sessionListEnabled, sessionOpen]);
 
-  // Live updates while the dropdown is open. Hybrid strategy:
-  //   • Listen to `status-changed` Tauri events for instant busy/idle reflection
-  //   • Plus a 3s fallback poll for proc_scan-driven changes (new tabs, cd,
-  //     fg_cmd updates) that don't fire status-changed
-  // Costs ~5ms per refresh; total well under 1Hz average while open.
+  // Live session refresh while dropdown is open.
   useEffect(() => {
-    if (!open) return;
+    if (!sessionOpen) return;
     let cancelled = false;
 
     const refresh = async () => {
@@ -236,12 +268,9 @@ export function StatusPill({ status, glow }: StatusPillProps) {
       setGroups(groupSessions(overlaid, detectHome(overlaid)));
     };
 
-    // Subscribe to backend state-change events.
     const unlistenP = listen("status-changed", () => {
       void refresh();
     });
-
-    // Fallback poll covers OS-scan changes that don't emit status-changed.
     const id = setInterval(refresh, 3000);
 
     return () => {
@@ -249,42 +278,172 @@ export function StatusPill({ status, glow }: StatusPillProps) {
       clearInterval(id);
       unlistenP.then((fn) => fn());
     };
-  }, [open]);
+  }, [sessionOpen]);
 
-  // Close on outside click or Escape.
+  // Session dropdown closes ONLY on Escape, pill-toggle, or item click.
   useEffect(() => {
-    if (!open) return;
-
-    const onDown = (e: MouseEvent) => {
-      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
-    };
+    if (!sessionOpen) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") setSessionOpen(false);
     };
-    window.addEventListener("mousedown", onDown);
     window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [sessionOpen]);
+
+  // --- Peer popover effects ---
+  useEffect(() => {
+    if (!disabled) return;
+    void (async () => {
+      const popover = await WebviewWindow.getByLabel("peer-list");
+      await popover?.hide().catch(() => {});
+    })();
+    setPeerOpen(false);
+  }, [disabled]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      const popover = await WebviewWindow.getByLabel("peer-list");
+      if (!popover) return;
+      const fn = await popover.onFocusChanged(({ payload: focused }) => {
+        if (!focused) setPeerOpen(false);
+      });
+      unlisten = fn;
+    })();
     return () => {
-      window.removeEventListener("mousedown", onDown);
-      window.removeEventListener("keydown", onKey);
+      unlisten?.();
     };
-  }, [open]);
+  }, []);
+
+  useEffect(() => {
+    if (!peerOpen) return;
+    const main = getCurrentWindow();
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    (async () => {
+      const popover = await WebviewWindow.getByLabel("peer-list");
+      if (!popover || cancelled) return;
+      const handler = async () => {
+        if (!lanButtonRef.current) return;
+        if (!(await popover.isVisible())) return;
+        const pos = await computePopoverScreenPos(lanButtonRef.current);
+        await popover.setPosition(pos).catch(() => {});
+      };
+      const fn = await main.onMoved(handler);
+      unlisten = fn;
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [peerOpen]);
+
+  const togglePeer = async (e: React.MouseEvent) => {
+    if (disabled) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (!lanButtonRef.current) return;
+
+    const popover = await WebviewWindow.getByLabel("peer-list");
+    if (!popover) {
+      console.error("[status-pill] peer-list window not found");
+      return;
+    }
+
+    const visible = await popover.isVisible();
+    if (visible) {
+      await popover.hide();
+      setPeerOpen(false);
+      return;
+    }
+
+    const pos = await computePopoverScreenPos(lanButtonRef.current);
+    await popover.setPosition(pos);
+    await popover.show();
+    await popover.setFocus();
+    setPeerOpen(true);
+  };
+
+  const peerTooltip = disabled
+    ? "Already visiting someone"
+    : peers.length === 0
+      ? "No peers nearby"
+      : `${peers.length} peer${peers.length === 1 ? "" : "s"} nearby`;
 
   return (
     <div ref={wrapRef} className="pill-wrap" data-testid="status-pill-wrap">
       <div
         data-testid="status-pill"
-        className={`pill ${glow ? "neon-glow" : ""} ${status === "busy" ? "neon-busy" : ""} ${open ? "is-open" : ""} ${!sessionListEnabled ? "no-dropdown" : ""}`}
-        onClick={toggleOpen}
+        className={`pill ${glow ? "neon-glow" : ""} ${status === "busy" ? "neon-busy" : ""} ${sessionOpen || peerOpen ? "is-open" : ""}`}
       >
         <span data-testid="status-dot" className={dotClassMap[status] ?? "dot searching"} />
-        <span data-testid="status-label" className="label">{labelMap[status] ?? "Searching..."}</span>
-        {sessionListEnabled && (
-          <span className={`caret ${open ? "up" : ""}`} aria-hidden="true" />
-        )}
+        <span data-testid="status-label" className="label">
+          {labelMap[status] ?? "Searching..."}
+        </span>
+
+        <div className="pill-actions" data-testid="pill-actions">
+          {sessionListEnabled && (
+            <button
+              type="button"
+              data-testid="pill-action-task"
+              className={`pill-action-btn ${sessionOpen ? "is-active" : ""}`}
+              onClick={toggleSession}
+              aria-label="Show sessions list"
+              aria-expanded={sessionOpen}
+              title="Session list"
+            >
+              <svg
+                className="pill-action-icon"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM7 9h10v2H7V9zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" />
+              </svg>
+            </button>
+          )}
+
+          <button
+            ref={lanButtonRef}
+            type="button"
+            data-testid="pill-action-lan"
+            className={`pill-action-btn ${peerOpen ? "is-active" : ""} ${peers.length > 0 ? "has-peers" : ""}`}
+            onClick={togglePeer}
+            disabled={disabled}
+            aria-label={`Mime Around You (${peers.length})`}
+            aria-expanded={peerOpen}
+            title={peerTooltip}
+          >
+            <svg
+              className="pill-action-icon"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
+            </svg>
+            {peers.length > 0 && (
+              <span className="pill-action-badge" data-testid="pill-action-lan-badge">
+                {peers.length}
+              </span>
+            )}
+          </button>
+        </div>
       </div>
 
-      {sessionListEnabled && open && (
-        <div data-testid="session-dropdown" className="session-dropdown" role="menu">
+      {sessionListEnabled && sessionOpen && (
+        <div
+          data-testid="session-dropdown"
+          className="session-dropdown"
+          role="menu"
+          style={{ top: `${dropdownTop}px` }}
+        >
           {groups.length === 0 ? (
             <div className="session-empty">No active terminals</div>
           ) : (
@@ -316,63 +475,63 @@ export function StatusPill({ status, glow }: StatusPillProps) {
                 </>
               );
               return (
-              <div
-                key={g.key}
-                className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
-                data-testid={`session-group-${g.key}`}
-              >
-                {g.isClaudeFallback ? (
-                  <div className="session-group-head">{headContent}</div>
-                ) : (
-                  <button
-                    type="button"
-                    className={`session-group-head clickable ${isCollapsed ? "collapsed" : ""}`}
-                    data-testid={`session-group-head-${g.key}`}
-                    aria-expanded={!isCollapsed}
-                    aria-controls={`session-children-${g.key}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void toggleCollapsed(g.key);
-                    }}
-                  >
-                    {headContent}
-                  </button>
-                )}
+                <div
+                  key={g.key}
+                  className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
+                  data-testid={`session-group-${g.key}`}
+                >
+                  {g.isClaudeFallback ? (
+                    <div className="session-group-head">{headContent}</div>
+                  ) : (
+                    <button
+                      type="button"
+                      className={`session-group-head clickable ${isCollapsed ? "collapsed" : ""}`}
+                      data-testid={`session-group-head-${g.key}`}
+                      aria-expanded={!isCollapsed}
+                      aria-controls={`session-children-${g.key}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void toggleCollapsed(g.key);
+                      }}
+                    >
+                      {headContent}
+                    </button>
+                  )}
 
-                {!g.isClaudeFallback && !isCollapsed && (
-                  <div
-                    className="session-children"
-                    id={`session-children-${g.key}`}
-                  >
-                    {g.sessions.map((s) => (
-                      <button
-                        key={s.pid}
-                        type="button"
-                        className={`session-child ${s.has_claude ? "has-claude" : ""}`}
-                        data-testid={`session-item-${s.pid}`}
-                        title="Click to bring this terminal to the front"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          invoke("focus_terminal", { pid: s.pid, tty: s.tty || null })
-                            .catch((err) => console.error("[focus_terminal]", err));
-                          setOpen(false);
-                        }}
-                      >
-                        <span className={`dot small ${s.ui_state}`} />
-                        <span className="session-child-label-row">
-                          <span className="session-child-label">{shellLabel(s)}</span>
-                          {s.has_claude && (
-                            <span
-                              className="session-child-claude"
-                              aria-label="Claude Code running"
-                            />
-                          )}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+                  {!g.isClaudeFallback && !isCollapsed && (
+                    <div
+                      className="session-children"
+                      id={`session-children-${g.key}`}
+                    >
+                      {g.sessions.map((s) => (
+                        <button
+                          key={s.pid}
+                          type="button"
+                          className={`session-child ${s.has_claude ? "has-claude" : ""}`}
+                          data-testid={`session-item-${s.pid}`}
+                          title="Click to bring this terminal to the front"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            invoke("focus_terminal", { pid: s.pid, tty: s.tty || null })
+                              .catch((err) => console.error("[focus_terminal]", err));
+                            setSessionOpen(false);
+                          }}
+                        >
+                          <span className={`dot small ${s.ui_state}`} />
+                          <span className="session-child-label-row">
+                            <span className="session-child-label">{shellLabel(s)}</span>
+                            {s.has_claude && (
+                              <span
+                                className="session-child-claude"
+                                aria-label="Claude Code running"
+                              />
+                            )}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
               );
             })
           )}

--- a/src/components/VisitorDog.tsx
+++ b/src/components/VisitorDog.tsx
@@ -1,8 +1,12 @@
 import { useState, useEffect, useMemo } from "react";
 import { getSpriteMap, resolveBuiltinPet, FALLBACK_PET_ID } from "../constants/sprites";
+import { randomGreeting } from "../constants/visitorGreetings";
 import { useScale } from "../hooks/useScale";
 import { warn } from "@tauri-apps/plugin-log";
 import "../styles/visitor.css";
+
+/** How long the arrival greeting bubble stays visible. */
+const GREETING_DURATION_MS = 5000;
 
 interface VisitorDogProps {
   pet: string;
@@ -12,7 +16,16 @@ interface VisitorDogProps {
 
 export function VisitorDog({ pet, nickname, index }: VisitorDogProps) {
   const [entered, setEntered] = useState(false);
+  // Pick a greeting once on mount and show it briefly as a speech bubble.
+  // useMemo keeps the same line across re-renders (e.g. when scale changes).
+  const greeting = useMemo(() => randomGreeting(), []);
+  const [greetingVisible, setGreetingVisible] = useState(true);
   const { scale } = useScale();
+
+  useEffect(() => {
+    const id = setTimeout(() => setGreetingVisible(false), GREETING_DURATION_MS);
+    return () => clearTimeout(id);
+  }, []);
 
   // Resolve the peer's advertised pet against pets we can actually render.
   // Peers can advertise custom-* mime ids that don't exist on this instance;
@@ -47,7 +60,17 @@ export function VisitorDog({ pet, nickname, index }: VisitorDogProps) {
       className={`visitor-dog ${entered ? "entered" : ""}`}
       style={{ "--visitor-offset": `${offset}px` } as React.CSSProperties}
     >
-      <div className="visitor-name">{nickname}</div>
+      {greetingVisible && (
+        <div
+          className="visitor-greeting"
+          data-testid={`visitor-greeting-${index}`}
+          onClick={() => setGreetingVisible(false)}
+          title="Click to dismiss"
+        >
+          <span className="visitor-greeting-text">{greeting}</span>
+          <span className="visitor-greeting-tail" aria-hidden="true" />
+        </div>
+      )}
       <div
         className="visitor-sprite"
         style={{
@@ -60,6 +83,7 @@ export function VisitorDog({ pet, nickname, index }: VisitorDogProps) {
           "--sprite-duration": `${sprite.frames * 80}ms`,
         } as React.CSSProperties}
       />
+      <div className="visitor-name">{nickname}</div>
     </div>
   );
 }

--- a/src/components/VisitorDog.tsx
+++ b/src/components/VisitorDog.tsx
@@ -12,20 +12,29 @@ interface VisitorDogProps {
   pet: string;
   nickname: string;
   index: number;
+  /** Optional chat message from the sender. When present, replaces the
+   *  random greeting and stays visible the whole visit. */
+  message?: string;
 }
 
-export function VisitorDog({ pet, nickname, index }: VisitorDogProps) {
+export function VisitorDog({ pet, nickname, message, index }: VisitorDogProps) {
   const [entered, setEntered] = useState(false);
-  // Pick a greeting once on mount and show it briefly as a speech bubble.
-  // useMemo keeps the same line across re-renders (e.g. when scale changes).
-  const greeting = useMemo(() => randomGreeting(), []);
+  // If the sender attached a message, show that verbatim and keep it
+  // visible for the full visit. Otherwise pick a random greeting and
+  // auto-hide it after GREETING_DURATION_MS.
+  const hasMessage = !!message;
+  const greeting = useMemo(
+    () => message ?? randomGreeting(),
+    [message]
+  );
   const [greetingVisible, setGreetingVisible] = useState(true);
   const { scale } = useScale();
 
   useEffect(() => {
+    if (hasMessage) return; // messages stay visible for the whole visit
     const id = setTimeout(() => setGreetingVisible(false), GREETING_DURATION_MS);
     return () => clearTimeout(id);
-  }, []);
+  }, [hasMessage]);
 
   // Resolve the peer's advertised pet against pets we can actually render.
   // Peers can advertise custom-* mime ids that don't exist on this instance;
@@ -62,7 +71,7 @@ export function VisitorDog({ pet, nickname, index }: VisitorDogProps) {
     >
       {greetingVisible && (
         <div
-          className="visitor-greeting"
+          className={`visitor-greeting ${hasMessage ? "is-message" : ""}`}
           data-testid={`visitor-greeting-${index}`}
           onClick={() => setGreetingVisible(false)}
           title="Click to dismiss"

--- a/src/components/scenarios/VisitorScenario.tsx
+++ b/src/components/scenarios/VisitorScenario.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from "react";
+import { emit } from "@tauri-apps/api/event";
+
+/**
+ * Fake visiting pets for the "Visitors" scenario. Each toggle emits the
+ * same Tauri events the real visit flow uses (`visitor-arrived` /
+ * `visitor-left`), so the existing `useVisitors` hook + `VisitorDog`
+ * rendering path runs unmodified — no backend involved.
+ */
+interface FakeVisitor {
+  instance_name: string;
+  pet: string;
+  nickname: string;
+}
+
+const FAKE_VISITORS: FakeVisitor[] = [
+  { instance_name: "scenario-alice-1", pet: "rottweiler", nickname: "Alice" },
+  { instance_name: "scenario-bob-2", pet: "dalmatian", nickname: "Bob" },
+  { instance_name: "scenario-carol-3", pet: "samurai", nickname: "Carol" },
+  { instance_name: "scenario-dave-4", pet: "hancock", nickname: "Dave" },
+];
+
+async function emitArrived(v: FakeVisitor) {
+  await emit("visitor-arrived", {
+    instance_name: v.instance_name,
+    pet: v.pet,
+    nickname: v.nickname,
+    duration_secs: 9999, // effectively no auto-expiry while the scenario is active
+  });
+}
+
+async function emitLeft(v: FakeVisitor) {
+  await emit("visitor-left", {
+    instance_name: v.instance_name,
+    nickname: v.nickname,
+  });
+}
+
+export function VisitorScenario() {
+  const [active, setActive] = useState<Set<string>>(new Set());
+  // Keep a ref of `active` so the unmount cleanup sees the latest set
+  // without refreshing the effect dependency each toggle.
+  const activeRef = useRef(active);
+  activeRef.current = active;
+
+  useEffect(() => {
+    return () => {
+      // Clean up any visitors we spawned when the scenario unmounts.
+      for (const name of activeRef.current) {
+        const v = FAKE_VISITORS.find((f) => f.instance_name === name);
+        if (v) void emitLeft(v);
+      }
+    };
+  }, []);
+
+  const toggle = async (v: FakeVisitor) => {
+    if (active.has(v.instance_name)) {
+      await emitLeft(v);
+      setActive((s) => {
+        const n = new Set(s);
+        n.delete(v.instance_name);
+        return n;
+      });
+    } else {
+      await emitArrived(v);
+      setActive((s) => new Set(s).add(v.instance_name));
+    }
+  };
+
+  const clearAll = async () => {
+    for (const name of active) {
+      const v = FAKE_VISITORS.find((f) => f.instance_name === name);
+      if (v) await emitLeft(v);
+    }
+    setActive(new Set());
+  };
+
+  return (
+    <div className="scenario-panel">
+      <div className="scenario-panel-desc">
+        Toggle fake visiting pets to preview how the mascot row looks when
+        friends send their pets over. Click a name to bring them in or out;
+        your local pet stays put.
+      </div>
+      <div className="scenario-status-grid">
+        {FAKE_VISITORS.map((v) => {
+          const isActive = active.has(v.instance_name);
+          return (
+            <button
+              key={v.instance_name}
+              data-testid={`scenario-visitor-${v.nickname.toLowerCase()}`}
+              className={`scenario-status-btn ${isActive ? "active" : ""}`}
+              onClick={() => toggle(v)}
+            >
+              <div className="scenario-status-title">
+                <span className="scenario-status-label">{v.nickname}</span>
+              </div>
+              <span className="scenario-status-desc">
+                {v.pet} {isActive ? "(visiting)" : ""}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {active.size > 0 && (
+        <button
+          type="button"
+          className="scenario-stop-btn"
+          style={{ marginTop: 12 }}
+          onClick={clearAll}
+          data-testid="scenario-visitor-clear"
+        >
+          Clear all visitors ({active.size})
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/scenarios/registry.ts
+++ b/src/components/scenarios/registry.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import { PetStatusScenario } from "./PetStatusScenario";
 import { DialogPreviewScenario } from "./DialogPreviewScenario";
+import { VisitorScenario } from "./VisitorScenario";
 
 export interface ScenarioDefinition {
   id: string;
@@ -17,6 +18,13 @@ export const scenarios: ScenarioDefinition[] = [
     description: "Switch between all pet statuses for visual testing",
     icon: "\u{1F43E}",
     component: PetStatusScenario,
+  },
+  {
+    id: "visitor",
+    name: "Visitors",
+    description: "Simulate friends visiting — preview multi-pet layout",
+    icon: "\u{1F415}",
+    component: VisitorScenario,
   },
   {
     id: "dialog-preview",

--- a/src/constants/visitorGreetings.ts
+++ b/src/constants/visitorGreetings.ts
@@ -1,0 +1,30 @@
+/**
+ * Short one-line greetings shown in a speech bubble above a visiting pet
+ * when it arrives. Picked at random so repeat visits feel fresh.
+ *
+ * Keep lines short (≤ ~24 chars) so the bubble doesn't overflow the
+ * 96×96 sprite column.
+ */
+export const VISITOR_GREETINGS: readonly string[] = [
+  "Hi there, how are you?",
+  "Hey! Nice to see you",
+  "Hello friend!",
+  "Just dropping by \u{1F44B}",
+  "Came to say hi!",
+  "Woof! \u{1F436}",
+  "Can I hang out?",
+  "Miss me already?",
+  "Long time no bark!",
+  "What's up?",
+  "Ready to play?",
+  "Good to see you!",
+  "Hi pal!",
+  "Hey, how's it going?",
+  "Surprise visit!",
+  "Bark bark!",
+];
+
+export function randomGreeting(): string {
+  const i = Math.floor(Math.random() * VISITOR_GREETINGS.length);
+  return VISITOR_GREETINGS[i];
+}

--- a/src/hooks/useVisitors.ts
+++ b/src/hooks/useVisitors.ts
@@ -6,6 +6,8 @@ export interface Visitor {
   pet: string;
   nickname: string;
   duration_secs: number;
+  /** Optional one-line message the sender attached. */
+  message?: string;
 }
 
 export function useVisitors() {

--- a/src/peer-list-main.tsx
+++ b/src/peer-list-main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { PeerListApp } from "./PeerListApp";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <PeerListApp />
+  </React.StrictMode>
+);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -15,7 +15,14 @@ body {
   width: 100%;
   height: 100%;
   display: flex;
-  align-items: center;
+  /* align-items: flex-start pins to the top so the pet doesn't "jump
+     down" when we grow the window height for the session dropdown.
+     justify-content: center centers the widget horizontally inside the
+     window so, when the window gets wider for the session dropdown, the
+     pet lines up with the centered dropdown instead of hanging off to
+     the left. When window == content size (closed), both settings have
+     no visible effect. */
+  align-items: flex-start;
   justify-content: center;
   background: transparent;
 }
@@ -42,6 +49,7 @@ body {
   gap: 4px;
   flex-shrink: 0;
 }
+
 
 .container.dragging {
   cursor: grabbing;

--- a/src/styles/peer-list-window.css
+++ b/src/styles/peer-list-window.css
@@ -1,0 +1,154 @@
+/* Styles for the `peer-list` Tauri popover window. The window itself is
+   transparent + decoration-less. The .peer-list-shell is what
+   useWindowAutoSize observes — its offsetHeight includes .peer-list-root
+   + 12px of buffer on all sides so the card's box-shadow isn't clipped
+   by the window edge (offsetWidth/Height does NOT include box-shadow). */
+
+html,
+body,
+#root {
+  background: transparent;
+}
+
+#root {
+  display: inline-block;
+  width: max-content;
+}
+
+.peer-list-shell {
+  width: max-content;
+  padding: 12px;
+  display: inline-block;
+}
+
+.peer-list-root {
+  min-width: 256px;
+  max-width: 360px;
+  padding: 4px;
+  border-radius: 10px;
+  background: var(--bg-pill);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border-pill);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+  animation: peer-list-fade-in 0.12s ease-out;
+}
+
+@keyframes peer-list-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.peer-list-header {
+  padding: 6px 10px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  opacity: 0.55;
+  flex-shrink: 0;
+}
+
+.peer-list-empty {
+  padding: 8px 12px 10px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.peer-list-empty-title {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.peer-list-empty-hint {
+  font-size: 10px;
+  opacity: 0.45;
+}
+
+.peer-list-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow-y: auto;
+}
+
+.peer-list-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.peer-list-row:hover,
+.peer-list-row:focus-visible {
+  background: var(--bg-pill-hover);
+  outline: none;
+}
+
+.peer-list-row:active {
+  transform: translateY(0.5px);
+}
+
+.peer-list-row-dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #34c759;
+  box-shadow: 0 0 4px rgba(52, 199, 89, 0.55);
+}
+
+.peer-list-row-main {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.peer-list-row-nickname {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.peer-list-row-pet {
+  font-size: 10px;
+  opacity: 0.55;
+  font-family: "SF Mono", "Menlo", "Monaco", monospace;
+}
+
+.peer-list-row-action {
+  flex-shrink: 0;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  background: var(--bg-pill-hover);
+  border: 1px solid var(--border-pill);
+  opacity: 0.7;
+  transition: opacity 0.12s, background 0.12s;
+}
+
+.peer-list-row:hover .peer-list-row-action,
+.peer-list-row:focus-visible .peer-list-row-action {
+  opacity: 1;
+  background: var(--border-pill-hover);
+}

--- a/src/styles/peer-list-window.css
+++ b/src/styles/peer-list-window.css
@@ -75,35 +75,43 @@ body,
   display: flex;
   flex-direction: column;
   gap: 1px;
-  overflow-y: auto;
+  /* No overflow: auto — the popover window auto-sizes to fit all peers
+     via useWindowAutoSize, so we never need internal scrolling. Setting
+     overflow-y: auto would implicitly clip overflow-x (per CSS spec
+     when one axis is non-visible, the other becomes auto too), which
+     would crop any element that extends to the right edge of the row. */
 }
 
-.peer-list-row {
+/* Wrap that holds the row + (optional) compose box below it. */
+.peer-list-row-wrap {
   display: flex;
+  flex-direction: column;
+  border-radius: 5px;
+  transition: background 0.12s;
+}
+
+.peer-list-row-wrap.is-composing {
+  background: var(--bg-pill-hover);
+}
+
+/* Grid guarantees the row fits inside the card: fixed-width dot +
+   fixed-width action buttons + a flexible middle column that can shrink
+   all the way down to 0 via minmax(0, 1fr). Using plain flex with
+   flex: 1 on .peer-list-row-main was letting the main column cling to
+   its content width, pushing the message icon outside the card border. */
+.peer-list-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 6px 8px;
-  border: none;
-  border-radius: 5px;
-  background: transparent;
+  padding: 6px 12px 6px 8px;
   color: var(--text-primary);
   text-align: left;
   font-family: inherit;
   font-size: 12px;
   line-height: 1;
-  cursor: pointer;
-  transition: background 0.12s;
-}
-
-.peer-list-row:hover,
-.peer-list-row:focus-visible {
-  background: var(--bg-pill-hover);
-  outline: none;
-}
-
-.peer-list-row:active {
-  transform: translateY(0.5px);
+  box-sizing: border-box;
 }
 
 .peer-list-row-dot {
@@ -116,11 +124,11 @@ body,
 }
 
 .peer-list-row-main {
-  flex: 1;
   min-width: 0;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   gap: 2px;
+  overflow: hidden;
 }
 
 .peer-list-row-nickname {
@@ -134,21 +142,228 @@ body,
   font-size: 10px;
   opacity: 0.55;
   font-family: "SF Mono", "Menlo", "Monaco", monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
+/* Action buttons (visit / message). Text variant has label, icon variant
+   is a small round button. */
 .peer-list-row-action {
   flex-shrink: 0;
+  font-family: inherit;
   font-size: 10px;
-  padding: 2px 6px;
+  padding: 3px 8px;
   border-radius: 9999px;
   background: var(--bg-pill-hover);
   border: 1px solid var(--border-pill);
-  opacity: 0.7;
-  transition: opacity 0.12s, background 0.12s;
+  color: var(--text-primary);
+  cursor: pointer;
+  opacity: 0.75;
+  transition: opacity 0.12s, background 0.12s, border-color 0.12s;
 }
 
-.peer-list-row:hover .peer-list-row-action,
-.peer-list-row:focus-visible .peer-list-row-action {
+.peer-list-row-action:hover,
+.peer-list-row-action:focus-visible {
   opacity: 1;
   background: var(--border-pill-hover);
+  outline: none;
+}
+
+.peer-list-row-action:active {
+  transform: translateY(0.5px);
+}
+
+/* Message button — icon-only, square-ish. */
+.peer-list-row-action.message {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 50%;
+}
+
+.peer-list-row-action.message.is-active {
+  background: var(--border-pill-hover);
+  border-color: rgba(52, 199, 89, 0.55);
+  opacity: 1;
+}
+
+/* ============================================================
+   Compose view — replaces the peer list entirely when the user
+   clicks the chat icon on a row. Looks like a dedicated dialog
+   card: back button + target pill on top, large textarea in the
+   middle, char counter + Cancel/Send on the bottom.
+   ============================================================ */
+.peer-compose {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  animation: peer-compose-in 0.14s ease-out;
+}
+
+@keyframes peer-compose-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.peer-compose-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 2px;
+}
+
+.peer-compose-back {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 50%;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  opacity: 0.7;
+  transition: background 0.12s, border-color 0.12s, opacity 0.12s;
+}
+
+.peer-compose-back:hover {
+  background: var(--bg-pill-hover);
+  border-color: var(--border-pill-hover);
+  opacity: 1;
+}
+
+.peer-compose-target {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  overflow: hidden;
+}
+
+.peer-compose-target-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.45;
+}
+
+.peer-compose-target-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.peer-compose-target-pet {
+  font-size: 10px;
+  opacity: 0.5;
+  font-family: "SF Mono", "Menlo", "Monaco", monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.peer-compose-textarea {
+  width: 100%;
+  min-height: 64px;
+  max-height: 140px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--bg-pill);
+  border: 1px solid var(--border-pill);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  resize: none;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.peer-compose-textarea::placeholder {
+  opacity: 0.35;
+}
+
+.peer-compose-textarea:focus {
+  border-color: rgba(52, 199, 89, 0.55);
+  background: var(--bg-pill-hover);
+}
+
+.peer-compose-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.peer-compose-count {
+  flex: 1;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.4;
+}
+
+.peer-compose-count.near-limit {
+  opacity: 0.85;
+  color: #ff9f0a;
+}
+
+.peer-compose-cancel,
+.peer-compose-send {
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background 0.12s, transform 0.12s, opacity 0.12s;
+}
+
+.peer-compose-cancel {
+  background: transparent;
+  border: 1px solid var(--border-pill);
+  color: var(--text-primary);
+  opacity: 0.75;
+}
+
+.peer-compose-cancel:hover {
+  background: var(--bg-pill-hover);
+  opacity: 1;
+}
+
+.peer-compose-send {
+  background: #34c759;
+  border: 1px solid rgba(52, 199, 89, 0.65);
+  color: #000;
+}
+
+.peer-compose-send:hover:not(:disabled) {
+  background: #30b24c;
+}
+
+.peer-compose-send:active:not(:disabled) {
+  transform: translateY(0.5px);
+}
+
+.peer-compose-send:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -1,28 +1,40 @@
-/* --- Pill wrapper (stacks pill + dropdown vertically, grows container) --- */
+/* --- Pill wrapper ---
+   Holds the pill plus (when open) the absolute-positioned session
+   dropdown. position: relative establishes the positioning context for
+   the dropdown. The wrap stays exactly as wide as the pill, so opening
+   the dropdown does NOT push the peer icon to the right — App.tsx
+   manually grows the Tauri window to give the absolute dropdown room
+   to render without being clipped. */
 .pill-wrap {
   display: inline-flex;
   flex-direction: column;
   align-items: center;
   align-self: center;
-  gap: 6px;
+  position: relative;
 }
 
-/* --- Pill --- */
+/* --- Pill (unified bar) ---
+   Single bar: dot | status text | [flex spacer] | task icon | lan icon.
+   Left side (dot + label) is static; right side hosts two action buttons
+   that each own their own dropdown/popover. */
 .pill {
   display: inline-flex;
   align-items: center;
   align-self: center;
-  gap: 8px;
-  padding: 6px 16px;
+  gap: 6px;
+  padding: 3px 4px 3px 11px;
   border-radius: 9999px;
   background: var(--bg-pill);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border: 1px solid var(--border-pill);
   pointer-events: auto;
-  cursor: pointer;
   transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
   white-space: nowrap;
+  /* Minimum width keeps the layout stable when the status label is
+     short ("Free") vs long ("Initializing...") — prevents the action
+     icons from jiggling as status text changes. */
+  min-width: 150px;
 }
 
 .pill.is-open {
@@ -30,31 +42,109 @@
   border-color: var(--border-pill-hover);
 }
 
-/* When session-list feature is disabled, pill is not clickable. */
-.pill.no-dropdown {
-  cursor: default;
+/* --- Action buttons cluster on the right --- */
+.pill-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  /* margin-left: auto pushes the cluster to the right so dot+label hug
+     the left and the icons hug the right with a flexible spacer between. */
+  margin-left: auto;
+  pointer-events: auto;
 }
 
-/* --- Caret --- */
-.caret {
-  width: 0;
-  height: 0;
-  margin-left: 2px;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-top: 5px solid var(--text-primary);
-  opacity: 0.6;
-  transition: transform 0.2s;
+.pill-action-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border-radius: 50%;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  pointer-events: auto;
+  transition: background 0.12s, border-color 0.12s, box-shadow 0.12s, transform 0.12s;
 }
 
-.caret.up {
-  transform: rotate(180deg);
+.pill-action-btn:hover:not(:disabled) {
+  background: var(--bg-pill-hover);
+  border-color: var(--border-pill-hover);
 }
 
-/* --- Session dropdown (in flow so container grows & window auto-sizes) --- */
+.pill-action-btn:active:not(:disabled) {
+  transform: translateY(0.5px);
+}
+
+.pill-action-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.pill-action-btn.is-active {
+  background: var(--bg-pill-hover);
+  border-color: var(--border-pill-hover);
+}
+
+.pill-action-btn.has-peers {
+  border-color: rgba(52, 199, 89, 0.5);
+}
+
+.pill-action-icon {
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.pill-action-btn:hover:not(:disabled) .pill-action-icon,
+.pill-action-btn.is-active .pill-action-icon,
+.pill-action-btn.has-peers .pill-action-icon {
+  opacity: 1;
+}
+
+/* --- Peer-count badge on the lan icon --- */
+.pill-action-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 11px;
+  height: 11px;
+  padding: 0 3px;
+  border-radius: 6px;
+  background: #34c759;
+  color: #000;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  font-size: 8px;
+  font-weight: 700;
+  line-height: 11px;
+  text-align: center;
+  pointer-events: none;
+  box-shadow: 0 0 4px rgba(52, 199, 89, 0.5);
+}
+
+/* --- Session dropdown ---
+   Fixed-positioned (relative to the viewport / window). top is supplied
+   inline by StatusPill based on the pill's getBoundingClientRect, so it
+   drops just below the pill. left: 50% centers it in the WINDOW, not on
+   the pill — this prevents the left-clipping that would happen when the
+   pill sits near the window's left edge (pill-center - dropdown/2 can
+   be negative). App.tsx grows the main window manually when this opens
+   so the dropdown isn't clipped by the window bounds. Animation is
+   opacity-only so it doesn't replace the translateX(-50%) mid-fade. */
 .session-dropdown {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
   min-width: 240px;
   max-width: 360px;
+  /* Cap the list height so lots of shells don't produce a comically
+     tall window. Content beyond this scrolls vertically; horizontal
+     overflow is hidden (long titles ellipsize via .session-group-title). */
+  max-height: 280px;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 4px;
   border-radius: 10px;
   background: var(--bg-pill);
@@ -66,11 +156,32 @@
   animation: dropdown-in 0.12s ease-out;
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
   color: var(--text-primary);
+  z-index: 10;
+  /* Subtle custom scrollbar so it looks intentional, not browser-default. */
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-pill) transparent;
+}
+
+.session-dropdown::-webkit-scrollbar {
+  width: 6px;
+}
+
+.session-dropdown::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.session-dropdown::-webkit-scrollbar-thumb {
+  background: var(--border-pill);
+  border-radius: 3px;
+}
+
+.session-dropdown::-webkit-scrollbar-thumb:hover {
+  background: var(--border-pill-hover);
 }
 
 @keyframes dropdown-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 .session-empty {
@@ -332,8 +443,8 @@ button.session-group-head:hover {
 
 /* --- Dot --- */
 .dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   flex-shrink: 0;
   pointer-events: none;
@@ -442,7 +553,7 @@ button.session-group-head:hover {
 
 .label {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 500;
   color: var(--text-primary);
   line-height: 1;

--- a/src/styles/visitor.css
+++ b/src/styles/visitor.css
@@ -63,16 +63,31 @@
   pointer-events: auto;
 }
 
+/* Chat message variant: stays visible for the full visit duration
+   (no fade-out), wider + supports multi-line wrap since the user can
+   type up to ~100 chars. */
+.visitor-greeting.is-message {
+  max-width: 220px;
+  animation: visitor-greeting-pop 0.3s ease-out;
+}
+
 .visitor-greeting-text {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
   font-size: 10px;
   font-weight: 500;
   color: var(--text-bubble);
-  line-height: 1.2;
+  line-height: 1.3;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   display: block;
+}
+
+.visitor-greeting.is-message .visitor-greeting-text {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  word-break: break-word;
 }
 
 .visitor-greeting-tail {

--- a/src/styles/visitor.css
+++ b/src/styles/visitor.css
@@ -28,7 +28,7 @@
   background: var(--bg-pill);
   padding: 2px 8px;
   border-radius: 8px;
-  margin-bottom: 2px;
+  margin-top: 2px;
   white-space: nowrap;
 }
 
@@ -43,4 +43,65 @@
 @keyframes visitor-play {
   from { background-position: 0 0; }
   to { background-position: calc(-1 * var(--sprite-width)) 0; }
+}
+
+/* --- Arrival greeting bubble --- */
+.visitor-greeting {
+  position: relative;
+  align-self: center;
+  max-width: 180px;
+  margin-bottom: 2px;
+  padding: 4px 10px;
+  border-radius: 10px;
+  background: var(--bg-bubble);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--border-pill);
+  animation: visitor-greeting-pop 0.3s ease-out,
+    visitor-greeting-fade 0.35s ease-in 4.65s forwards;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.visitor-greeting-text {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-bubble);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.visitor-greeting-tail {
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid var(--bg-bubble);
+  filter: drop-shadow(0 1px 0 var(--border-pill));
+}
+
+@keyframes visitor-greeting-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.8) translateY(4px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes visitor-greeting-fade {
+  to {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(async () => ({
         main: resolve(__dirname, "index.html"),
         settings: resolve(__dirname, "settings.html"),
         superpower: resolve(__dirname, "superpower.html"),
+        "peer-list": resolve(__dirname, "peer-list.html"),
       },
     },
   },


### PR DESCRIPTION
## Summary

Three UX refactors in one PR:

1. **Peer list runs in its own Tauri window** (`label: peer-list`) instead of an in-window dropdown. The main widget stays exactly its current size when the list opens — no growing, no layout shifts. The popover follows the pet on drag, auto-hides on focus-loss / Escape.
2. **Status pill + peer button merged into one action bar**: `● Free  ——————  [📋]  [🌐ⁿ]`. Dot + label on the left, task icon + lan icon on the right. Each icon owns its own dropdown/popover; the bar itself is not clickable.
3. **Visitor polish**:
   - Name tag moved from above to below the sprite
   - Random arrival greeting bubbles (16-line pool, 5s display, click-to-dismiss)
   - New `Visitors` scenario in SuperpowerTool — emits the same `visitor-arrived` / `visitor-left` events real peers use, so multi-pet layout can be tested without a live LAN peer
   - Visit duration: 15s → 8s (`lib.rs` + docs)

## Notable changes

| Area | Change |
|------|--------|
| **New window** | `peer-list` added to `tauri.conf.json` (transparent, no-decorations, alwaysOnTop, skipTaskbar) |
| **New entry** | `peer-list.html` + `src/peer-list-main.tsx` mounting `PeerListApp` |
| **New component** | `src/PeerListApp.tsx` — list renderer, focus-loss auto-hide, Escape close, direct `start_visit` invoke |
| **Merged pills** | `src/components/StatusPill.tsx` now hosts both session-list logic and peer-popover trigger; `PeerPill.tsx` and `peer-pill.css` deleted |
| **Session dropdown** | `position: fixed` centered on viewport — no more left-clipping when pill sits near window edge. `max-height: 280px` + `overflow-y: auto` for scrollable lists. Opacity-only animation (no transform jump). |
| **Visitors** | `VisitorDog` picks a random greeting on mount, auto-hides after 5s. `VisitorScenario.tsx` toggles fake visitors via Tauri event emit. |
| **Capabilities** | Added `peer-list` + `superpower` windows to default capability; explicit `allow-show/-hide/-set-focus/-is-visible` permissions so the popover can self-manage and be controlled from the main window. |
| **Docs** | `constants-reference.md` and `peer-discovery.md` updated for new 8s visit duration. |

## Not included

- `.c3/` updates — hard rule (c3x-only, DB not migrated yet). Follow-up.
- Session list as a separate window. User considered and rejected for now (`"if its a window its not flexible anymore"`) — kept in main window via fixed positioning + manual `setSize`.

## Test plan

- [ ] `bun run tauri dev` — widget renders with new unified bar (dot + text on left, 2 icons on right)
- [ ] Click clipboard icon → session list appears centered under pill; press Escape to close
- [ ] Click network icon → peer-list popover appears as separate window; click desktop → closes; drag the pet → popover follows
- [ ] Superpower Tool → Scenarios → **Visitors** → toggle Alice, Bob, etc. → visitors render next to pet with greeting bubbles for 5s each
- [ ] Each real visit lasts 8s before returning home
- [ ] `npx tsc --noEmit` clean
- [ ] `cargo check` in `src-tauri/` clean
- [ ] No regressions in existing flows: speech bubbles, drag, dev mode, scenarios, settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)