### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.17.0] - 2026-04-20
+
+### Added
+- **Chat-message visits** — click the new chat icon next to any peer in the network list to open a compose dialog. Write up to 100 chars, press Enter (or Send), and your pet visits theirs for 8 seconds carrying the message as a persistent speech bubble. Uses the existing `/visit` HTTP route + `visitor-arrived` event with an optional `message` field — no new endpoints, no stored history. (#101)
+- **Unified status bar** — the status pill and the peer (p2p) button are merged into a single action bar: `● Free ——— [task] [lan]`. Left: status dot + label. Right: task icon opens the session list, lan icon opens the peer list. Peer-count badge shows on the lan icon when peers are nearby. (#101)
+- **Peer list in a dedicated Tauri popover window** — `Mime Around You` no longer grows the main widget. Clicking the lan icon opens a transparent popover next to the pet; the popover follows the pet when you drag, closes on focus loss / Escape. (#101)
+- **Visitor greeting bubbles** — each arriving visitor now shows a random one-line greeting (5s auto-fade) from a 16-line pool. When a visit carries a chat message, that message is shown instead and stays visible for the full visit. (#101)
+- **Visitors scenario** in SuperpowerTool — emits the same `visitor-arrived` / `visitor-left` events real peers use, so multi-pet layout + greeting bubbles can be previewed without a live LAN peer. (#101)
+- **`.animime` v2 export format** for Smart Import mimes — embeds only the source sheet + frame-input strings instead of per-status base64 sprite blobs. Cuts typical export size ~8x (Naruto Kyuubi: 2.2 MB → 1.2 MB, now under the 2 MB marketplace upload cap). v1 files (manual-creator mimes, older Smart Import exports) continue to import via the unchanged v1 code path. (#100, @yanmad27)
+- **Import errors now surface in the Settings UI** instead of being swallowed into the log. (#100, @yanmad27)
+
+### Fixed
+- **Smart Import was silently dropping sprite frames** — `removeSmallComponents()` was filtering every detected region classified as "text noise", shrinking the Naruto Kyuubi sheet from 277 → 228 frames and breaking round-trips for any frame range above 228. Removed the filter so every detected region survives. (#100, @yanmad27)
+- **Session-list dropdown clipping on the left edge** — the dropdown was centered on the status pill, but the pill sits near the window's left edge so half the dropdown was cut off by the window bounds. Dropdown is now fixed-positioned and centered on the viewport instead of the pill. Max-height 280px with internal vertical scroll so many-session lists don't produce a comically tall window. (#101)
+- **Peer icon being pushed to the right when session list opened** — the session dropdown was inflating the pill-wrap's width, shifting the peer button. Session dropdown is now absolute-positioned and doesn't affect layout; the main window grows only when the dropdown opens. (#101)
+
+### Changed
+- **Visit duration 15s → 8s.** Both plain visits and message visits last the same 8s. Kept as separate constants (`VISIT_DURATION_SECS`, `MESSAGE_VISIT_DURATION_SECS`) so they can diverge later without touching the plain-visit path. (#101)
+- **Visitor name tag moved below the sprite** (was above). (#101)
+- **Status bar is tighter** — label font 13px → 11px, action buttons 24×24 → 20×20, dot 8px → 7px. Whole bar is ~20% shorter vertically. (#101)
+- `parseFrameInput` / `serializeFrames` moved to `spriteSheetProcessor.ts` to break the `useCustomMimes` ↔ `SmartImport` import cycle. `SmartImport` re-exports them for existing test imports. (#100, @yanmad27)
+
 ## [0.16.6] - 2026-04-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.16.6",
+  "version": "0.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.16.6"
+version = "0.17.0"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.16.6"
+version = "0.17.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.16.6",
+  "version": "0.17.0",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1038,7 +1038,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.16.6{devMode && " (Dev Mode)"}
+                  Version 0.17.0{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary

- Bumps version to v0.17.0 across all 4 files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src/components/Settings.tsx`)
- Regenerates `Cargo.lock`
- Adds CHANGELOG entry under `## [0.17.0]`

## Release notes (v0.17.0)

**Added**
- Chat-message visits — dialog-style compose from the peer list, up to 100 chars, message shown as a persistent speech bubble for the visit
- Unified status bar — status pill + peer button merged into one action bar with task + lan icons
- Peer list in a dedicated Tauri popover window — widget never grows, popover follows on drag
- Visitor greeting bubbles (random, 5s) when a visit arrives without a message
- Visitors scenario in SuperpowerTool for previewing multi-pet layout without a live peer
- `.animime` v2 export format — ~8x smaller, fits the 2 MB marketplace cap
- Smart Import errors surface in the Settings UI

**Fixed**
- Smart Import was silently dropping detected sprite frames as "text noise"
- Session-list dropdown clipping on the left edge
- Peer icon pushed to the right when session list opened

**Changed**
- Visit duration 15s → 8s (plain + message visits both)
- Visitor name tag moved below the sprite
- Status bar is ~20% shorter vertically
- Smart Import helper refactor to break an import cycle

## Test plan

- [ ] CI green (type check, cargo check, tests)
- [ ] After merge: `git tag v0.17.0 && git push origin v0.17.0`
- [ ] Verify CI `create-release` + build jobs succeed → DMGs + Linux bundles attached to the GitHub Release
- [ ] Update Homebrew cask (`Casks/ani-mime.rb`) with new SHA256s

🤖 Generated with [Claude Code](https://claude.com/claude-code)