### PR TITLE
feat(ui): session dropdown polish and pet opacity slider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,19 +41,31 @@ function App() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [effectActive, setEffectActive] = useState(false);
   const [sessionOpen, setSessionOpen] = useState(false);
+  // Stays true from the moment the dropdown starts closing until the
+  // window has been fully resized and repositioned. Keeps
+  // useWindowAutoSize paused across the whole transition so it can't
+  // race this effect with its own setSize (which would otherwise flash
+  // the content at the wrong position for a frame).
+  const [sessionClosing, setSessionClosing] = useState(false);
   // Window position captured when the dropdown opens, restored on close.
   // Keeping this as a ref avoids triggering a re-render when we record it.
   const savedPosRef = useRef<LogicalPosition | null>(null);
   useTheme();
-  // Pause auto-size while the session dropdown is open — we manually
-  // grow the window so the absolute-positioned dropdown has room.
-  useWindowAutoSize(containerRef, effectActive || sessionOpen);
+  useWindowAutoSize(
+    containerRef,
+    effectActive || sessionOpen || sessionClosing
+  );
 
   // When the dropdown opens the window grows wider (>= SESSION_DROPDOWN_MIN_WIDTH).
   // Because #root centers its content, a wider window visibly shifts the
   // pet + pill rightward. To keep the pet visually anchored we also move
   // the window left by half the width growth. On close we restore both
   // size and position so the pet returns to its original spot.
+  //
+  // setSize + setPosition are fired in parallel via Promise.all so they
+  // commit close to the same native-window frame — otherwise the
+  // sequential awaits make one change visible before the other and the
+  // pet flickers between positions.
   useEffect(() => {
     const win = getCurrentWindow();
 
@@ -74,10 +86,12 @@ function App() {
           const origX = Math.round(logical.x);
           const origY = Math.round(logical.y);
           savedPosRef.current = new LogicalPosition(origX, origY);
-          await win.setPosition(
-            new LogicalPosition(origX - Math.round(dx / 2), origY)
-          );
-          await win.setSize(new LogicalSize(newWidth, newHeight));
+          await Promise.all([
+            win.setPosition(
+              new LogicalPosition(origX - Math.round(dx / 2), origY)
+            ),
+            win.setSize(new LogicalSize(newWidth, newHeight)),
+          ]);
         } catch (err) {
           console.error("[session-dropdown] open resize failed:", err);
         }
@@ -86,18 +100,28 @@ function App() {
     }
 
     const savedPos = savedPosRef.current;
-    if (!savedPos) return;
+    if (!savedPos) {
+      // Nothing to revert — make sure we don't leave sessionClosing
+      // stuck true (onOpenChange flipped it optimistically).
+      setSessionClosing(false);
+      return;
+    }
     savedPosRef.current = null;
 
     void (async () => {
       try {
         const el = containerRef.current;
+        const ops: Promise<void>[] = [win.setPosition(savedPos)];
         if (el) {
-          await win.setSize(new LogicalSize(el.offsetWidth, el.offsetHeight));
+          ops.push(
+            win.setSize(new LogicalSize(el.offsetWidth, el.offsetHeight))
+          );
         }
-        await win.setPosition(savedPos);
+        await Promise.all(ops);
       } catch (err) {
         console.error("[session-dropdown] close resize failed:", err);
+      } finally {
+        setSessionClosing(false);
       }
     })();
   }, [sessionOpen]);
@@ -120,7 +144,16 @@ function App() {
           status={status}
           glow={visible}
           disabled={status === "visiting"}
-          onOpenChange={setSessionOpen}
+          onOpenChange={(open) => {
+            // Flip sessionClosing to true in the SAME render batch that
+            // sessionOpen becomes false — this keeps useWindowAutoSize
+            // paused across the whole close transition, otherwise its
+            // effect re-runs synchronously with paused=false and fires
+            // an extra setSize that flashes the content at the wrong
+            // position for a frame.
+            if (!open) setSessionClosing(true);
+            setSessionOpen(open);
+          }}
         />
         {devMode && <DevTag />}
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,11 @@ import { useScale } from "./hooks/useScale";
 import { useDevMode } from "./hooks/useDevMode";
 import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
 import { useEffect, useRef, useState } from "react";
-import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import {
+  getCurrentWindow,
+  LogicalPosition,
+  LogicalSize,
+} from "@tauri-apps/api/window";
 import "./styles/theme.css";
 import "./styles/app.css";
 
@@ -37,20 +41,65 @@ function App() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [effectActive, setEffectActive] = useState(false);
   const [sessionOpen, setSessionOpen] = useState(false);
+  // Window position captured when the dropdown opens, restored on close.
+  // Keeping this as a ref avoids triggering a re-render when we record it.
+  const savedPosRef = useRef<LogicalPosition | null>(null);
   useTheme();
   // Pause auto-size while the session dropdown is open — we manually
   // grow the window so the absolute-positioned dropdown has room.
   useWindowAutoSize(containerRef, effectActive || sessionOpen);
 
+  // When the dropdown opens the window grows wider (>= SESSION_DROPDOWN_MIN_WIDTH).
+  // Because #root centers its content, a wider window visibly shifts the
+  // pet + pill rightward. To keep the pet visually anchored we also move
+  // the window left by half the width growth. On close we restore both
+  // size and position so the pet returns to its original spot.
   useEffect(() => {
-    if (!sessionOpen) return;
-    const el = containerRef.current;
-    if (!el) return;
-    const width = Math.max(el.offsetWidth, SESSION_DROPDOWN_MIN_WIDTH);
-    const height = el.offsetHeight + SESSION_DROPDOWN_EXTRA_HEIGHT;
-    getCurrentWindow()
-      .setSize(new LogicalSize(width, height))
-      .catch((err) => console.error("[session-dropdown] setSize failed:", err));
+    const win = getCurrentWindow();
+
+    if (sessionOpen) {
+      const el = containerRef.current;
+      if (!el) return;
+      const currentWidth = el.offsetWidth;
+      const currentHeight = el.offsetHeight;
+      const newWidth = Math.max(currentWidth, SESSION_DROPDOWN_MIN_WIDTH);
+      const newHeight = currentHeight + SESSION_DROPDOWN_EXTRA_HEIGHT;
+      const dx = newWidth - currentWidth;
+
+      void (async () => {
+        try {
+          const scale = await win.scaleFactor();
+          const pos = await win.outerPosition();
+          const logical = pos.toLogical(scale);
+          const origX = Math.round(logical.x);
+          const origY = Math.round(logical.y);
+          savedPosRef.current = new LogicalPosition(origX, origY);
+          await win.setPosition(
+            new LogicalPosition(origX - Math.round(dx / 2), origY)
+          );
+          await win.setSize(new LogicalSize(newWidth, newHeight));
+        } catch (err) {
+          console.error("[session-dropdown] open resize failed:", err);
+        }
+      })();
+      return;
+    }
+
+    const savedPos = savedPosRef.current;
+    if (!savedPos) return;
+    savedPosRef.current = null;
+
+    void (async () => {
+      try {
+        const el = containerRef.current;
+        if (el) {
+          await win.setSize(new LogicalSize(el.offsetWidth, el.offsetHeight));
+        }
+        await win.setPosition(savedPos);
+      } catch (err) {
+        console.error("[session-dropdown] close resize failed:", err);
+      }
+    })();
   }, [sessionOpen]);
 
   return (

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -39,7 +39,7 @@ export function Mascot({ status }: MascotProps) {
   const { pet } = usePet();
   const { mode: glowMode } = useGlow();
   const { scale } = useScale();
-  const { opacity } = useOpacity();
+  const { opacity } = useOpacity("mime");
   const { mimes } = useCustomMimes();
   const [frozen, setFrozen] = useState(false);
   const [customSpriteUrl, setCustomSpriteUrl] = useState<string | null>(null);

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -4,6 +4,7 @@ import { getSpriteMap, autoStopStatuses } from "../constants/sprites";
 import { usePet } from "../hooks/usePet";
 import { useGlow } from "../hooks/useGlow";
 import { useScale } from "../hooks/useScale";
+import { useOpacity } from "../hooks/useOpacity";
 import { useCustomMimes } from "../hooks/useCustomMimes";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { appDataDir, join } from "@tauri-apps/api/path";
@@ -38,6 +39,7 @@ export function Mascot({ status }: MascotProps) {
   const { pet } = usePet();
   const { mode: glowMode } = useGlow();
   const { scale } = useScale();
+  const { opacity } = useOpacity();
   const { mimes } = useCustomMimes();
   const [frozen, setFrozen] = useState(false);
   const [customSpriteUrl, setCustomSpriteUrl] = useState<string | null>(null);
@@ -173,6 +175,7 @@ export function Mascot({ status }: MascotProps) {
         width: frameSize,
         height: frameSize,
         backgroundSize: `${sheetWidth}px ${sheetHeight}px`,
+        opacity,
       }}
     />
   );

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -15,6 +15,7 @@ import { useSessionList } from "../hooks/useSessionList";
 import { useLanList } from "../hooks/useLanList";
 import { mimeCategories, getMimesByCategory } from "../constants/sprites";
 import { useScale } from "../hooks/useScale";
+import { useOpacity, OPACITY_MIN, OPACITY_MAX } from "../hooks/useOpacity";
 import { effects, useEffectEnabled } from "../effects";
 import { useCustomMimes, ALL_STATUSES } from "../hooks/useCustomMimes";
 import { SmartImport } from "./SmartImport";
@@ -88,6 +89,22 @@ export function Settings() {
   const { enabled: sessionListEnabled, setEnabled: setSessionListEnabled } = useSessionList();
   const { enabled: lanListEnabled, setEnabled: setLanListEnabled } = useLanList();
   const { scale, setScale, SCALE_PRESETS } = useScale();
+  const { setOpacity, previewOpacity, loadSavedOpacity } = useOpacity();
+  const [draftOpacity, setDraftOpacity] = useState(1);
+  const [savedOpacity, setSavedOpacity] = useState(1);
+  const [opacityLoaded, setOpacityLoaded] = useState(false);
+  const opacityChanged = opacityLoaded && Math.abs(draftOpacity - savedOpacity) > 0.001;
+
+  useEffect(() => {
+    loadSavedOpacity().then((v) => {
+      setDraftOpacity(v);
+      setSavedOpacity(v);
+      setOpacityLoaded(true);
+    });
+    return () => {
+      loadSavedOpacity().then((v) => previewOpacity(v));
+    };
+  }, []);
   const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, updateMimeFromSmartImport, deleteMime, exportMime, importMime } = useCustomMimes();
   const claude = useClaudeConfig();
   const [expandedCommand, setExpandedCommand] = useState<string | null>(null);
@@ -389,6 +406,48 @@ export function Settings() {
               {effects.map((effect) => (
                 <EffectToggle key={effect.id} effectId={effect.id} name={effect.name} />
               ))}
+            </div>
+          </div>
+          <div className="settings-section">
+            <div className="settings-section-title">Transparency</div>
+            <div className="settings-card">
+              <div className="settings-row-stack">
+                <div>
+                  <span className="settings-row-label">Pet Opacity</span>
+                  <span className="settings-row-hint">Adjust how transparent your pet appears on screen. Drag the slider to preview the change in real time, then click Save to keep it.</span>
+                </div>
+                <div className="opacity-slider-group">
+                  <input
+                    type="range"
+                    className="opacity-slider"
+                    min={OPACITY_MIN}
+                    max={OPACITY_MAX}
+                    step={0.05}
+                    value={draftOpacity}
+                    onChange={(e) => {
+                      const v = parseFloat(e.target.value);
+                      setDraftOpacity(v);
+                      previewOpacity(v);
+                    }}
+                    data-testid="pet-opacity-slider"
+                    aria-label="Pet opacity"
+                  />
+                  <span className="opacity-value" data-testid="pet-opacity-value">
+                    {Math.round(draftOpacity * 100)}%
+                  </span>
+                  <button
+                    className={`nickname-save ${opacityChanged ? "active" : ""}`}
+                    disabled={!opacityChanged}
+                    onClick={async () => {
+                      await setOpacity(draftOpacity);
+                      setSavedOpacity(draftOpacity);
+                    }}
+                    data-testid="pet-opacity-save"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
           <div className="settings-section">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -12,6 +12,7 @@ import { useAutoInstall } from "../hooks/useAutoInstall";
 import { useDockVisible } from "../hooks/useDockVisible";
 import { useTrayVisible } from "../hooks/useTrayVisible";
 import { useSessionList } from "../hooks/useSessionList";
+import { useLanList } from "../hooks/useLanList";
 import { mimeCategories, getMimesByCategory } from "../constants/sprites";
 import { useScale } from "../hooks/useScale";
 import { effects, useEffectEnabled } from "../effects";
@@ -85,6 +86,7 @@ export function Settings() {
   const { hidden: dockHidden, setHidden: setDockHidden } = useDockVisible();
   const { hidden: trayHidden, setHidden: setTrayHidden } = useTrayVisible();
   const { enabled: sessionListEnabled, setEnabled: setSessionListEnabled } = useSessionList();
+  const { enabled: lanListEnabled, setEnabled: setLanListEnabled } = useLanList();
   const { scale, setScale, SCALE_PRESETS } = useScale();
   const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, updateMimeFromSmartImport, deleteMime, exportMime, importMime } = useCustomMimes();
   const claude = useClaudeConfig();
@@ -390,6 +392,37 @@ export function Settings() {
             </div>
           </div>
           <div className="settings-section">
+            <div className="settings-section-title">Status Bar</div>
+            <div className="settings-card">
+              <div className="settings-row with-hint">
+                <div>
+                  <span className="settings-row-label">Session List</span>
+                  <span className="settings-row-hint">Click the status pill to see all open terminals grouped by project, with click-to-focus.</span>
+                </div>
+                <button
+                  className={`toggle-switch ${sessionListEnabled ? "active" : ""}`}
+                  onClick={() => setSessionListEnabled(!sessionListEnabled)}
+                  data-testid="session-list-toggle"
+                >
+                  <span className="toggle-knob" />
+                </button>
+              </div>
+              <div className="settings-row with-hint">
+                <div>
+                  <span className="settings-row-label">LAN Peer List</span>
+                  <span className="settings-row-hint">Show the nearby-peers icon on the status pill. Turn off to hide it entirely.</span>
+                </div>
+                <button
+                  className={`toggle-switch ${lanListEnabled ? "active" : ""}`}
+                  onClick={() => setLanListEnabled(!lanListEnabled)}
+                  data-testid="lan-list-toggle"
+                >
+                  <span className="toggle-knob" />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="settings-section">
             <div className="settings-section-title">Behavior</div>
             <div className="settings-card">
               <div className="settings-row">
@@ -475,19 +508,6 @@ export function Settings() {
                   aria-disabled={dockHidden}
                   title={dockHidden ? "Locked on while Dock is hidden" : undefined}
                   data-testid="show-tray-toggle"
-                >
-                  <span className="toggle-knob" />
-                </button>
-              </div>
-              <div className="settings-row with-hint">
-                <div>
-                  <span className="settings-row-label">Session List</span>
-                  <span className="settings-row-hint">Click the status pill to see all open terminals grouped by project, with click-to-focus.</span>
-                </div>
-                <button
-                  className={`toggle-switch ${sessionListEnabled ? "active" : ""}`}
-                  onClick={() => setSessionListEnabled(!sessionListEnabled)}
-                  data-testid="session-list-toggle"
                 >
                   <span className="toggle-knob" />
                 </button>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -89,20 +89,31 @@ export function Settings() {
   const { enabled: sessionListEnabled, setEnabled: setSessionListEnabled } = useSessionList();
   const { enabled: lanListEnabled, setEnabled: setLanListEnabled } = useLanList();
   const { scale, setScale, SCALE_PRESETS } = useScale();
-  const { setOpacity, previewOpacity, loadSavedOpacity } = useOpacity();
-  const [draftOpacity, setDraftOpacity] = useState(1);
-  const [savedOpacity, setSavedOpacity] = useState(1);
-  const [opacityLoaded, setOpacityLoaded] = useState(false);
-  const opacityChanged = opacityLoaded && Math.abs(draftOpacity - savedOpacity) > 0.001;
+  const mimeOpacityHook = useOpacity("mime");
+  const statusOpacityHook = useOpacity("status");
+  const [draftMimeOpacity, setDraftMimeOpacity] = useState(1);
+  const [savedMimeOpacity, setSavedMimeOpacity] = useState(1);
+  const [mimeOpacityLoaded, setMimeOpacityLoaded] = useState(false);
+  const [draftStatusOpacity, setDraftStatusOpacity] = useState(1);
+  const [savedStatusOpacity, setSavedStatusOpacity] = useState(1);
+  const [statusOpacityLoaded, setStatusOpacityLoaded] = useState(false);
+  const mimeOpacityChanged = mimeOpacityLoaded && Math.abs(draftMimeOpacity - savedMimeOpacity) > 0.001;
+  const statusOpacityChanged = statusOpacityLoaded && Math.abs(draftStatusOpacity - savedStatusOpacity) > 0.001;
 
   useEffect(() => {
-    loadSavedOpacity().then((v) => {
-      setDraftOpacity(v);
-      setSavedOpacity(v);
-      setOpacityLoaded(true);
+    mimeOpacityHook.loadSavedOpacity().then((v) => {
+      setDraftMimeOpacity(v);
+      setSavedMimeOpacity(v);
+      setMimeOpacityLoaded(true);
+    });
+    statusOpacityHook.loadSavedOpacity().then((v) => {
+      setDraftStatusOpacity(v);
+      setSavedStatusOpacity(v);
+      setStatusOpacityLoaded(true);
     });
     return () => {
-      loadSavedOpacity().then((v) => previewOpacity(v));
+      mimeOpacityHook.loadSavedOpacity().then((v) => mimeOpacityHook.previewOpacity(v));
+      statusOpacityHook.loadSavedOpacity().then((v) => statusOpacityHook.previewOpacity(v));
     };
   }, []);
   const { mimes: customMimes, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, updateMimeFromSmartImport, deleteMime, exportMime, importMime } = useCustomMimes();
@@ -413,8 +424,8 @@ export function Settings() {
             <div className="settings-card">
               <div className="settings-row-stack">
                 <div>
-                  <span className="settings-row-label">Pet Opacity</span>
-                  <span className="settings-row-hint">Adjust how transparent your pet appears on screen. Drag the slider to preview the change in real time, then click Save to keep it.</span>
+                  <span className="settings-row-label">Mime Opacity</span>
+                  <span className="settings-row-hint">How transparent your mime looks. Drag to preview, Save to keep.</span>
                 </div>
                 <div className="opacity-slider-group">
                   <input
@@ -423,26 +434,63 @@ export function Settings() {
                     min={OPACITY_MIN}
                     max={OPACITY_MAX}
                     step={0.05}
-                    value={draftOpacity}
+                    value={draftMimeOpacity}
                     onChange={(e) => {
                       const v = parseFloat(e.target.value);
-                      setDraftOpacity(v);
-                      previewOpacity(v);
+                      setDraftMimeOpacity(v);
+                      mimeOpacityHook.previewOpacity(v);
                     }}
-                    data-testid="pet-opacity-slider"
-                    aria-label="Pet opacity"
+                    data-testid="mime-opacity-slider"
+                    aria-label="Mime opacity"
                   />
-                  <span className="opacity-value" data-testid="pet-opacity-value">
-                    {Math.round(draftOpacity * 100)}%
+                  <span className="opacity-value" data-testid="mime-opacity-value">
+                    {Math.round(draftMimeOpacity * 100)}%
                   </span>
                   <button
-                    className={`nickname-save ${opacityChanged ? "active" : ""}`}
-                    disabled={!opacityChanged}
+                    className={`nickname-save ${mimeOpacityChanged ? "active" : ""}`}
+                    disabled={!mimeOpacityChanged}
                     onClick={async () => {
-                      await setOpacity(draftOpacity);
-                      setSavedOpacity(draftOpacity);
+                      await mimeOpacityHook.setOpacity(draftMimeOpacity);
+                      setSavedMimeOpacity(draftMimeOpacity);
                     }}
-                    data-testid="pet-opacity-save"
+                    data-testid="mime-opacity-save"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+              <div className="settings-row-stack">
+                <div>
+                  <span className="settings-row-label">Status Bar Opacity</span>
+                  <span className="settings-row-hint">How transparent the status pill looks. Drag to preview, Save to keep.</span>
+                </div>
+                <div className="opacity-slider-group">
+                  <input
+                    type="range"
+                    className="opacity-slider"
+                    min={OPACITY_MIN}
+                    max={OPACITY_MAX}
+                    step={0.05}
+                    value={draftStatusOpacity}
+                    onChange={(e) => {
+                      const v = parseFloat(e.target.value);
+                      setDraftStatusOpacity(v);
+                      statusOpacityHook.previewOpacity(v);
+                    }}
+                    data-testid="status-opacity-slider"
+                    aria-label="Status bar opacity"
+                  />
+                  <span className="opacity-value" data-testid="status-opacity-value">
+                    {Math.round(draftStatusOpacity * 100)}%
+                  </span>
+                  <button
+                    className={`nickname-save ${statusOpacityChanged ? "active" : ""}`}
+                    disabled={!statusOpacityChanged}
+                    onClick={async () => {
+                      await statusOpacityHook.setOpacity(draftStatusOpacity);
+                      setSavedStatusOpacity(draftStatusOpacity);
+                    }}
+                    data-testid="status-opacity-save"
                   >
                     Save
                   </button>

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -10,6 +10,7 @@ import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { Status } from "../types/status";
 import { fetchSessions, type SessionInfo } from "../hooks/useSessions";
 import { useSessionList } from "../hooks/useSessionList";
+import { useLanList } from "../hooks/useLanList";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import { usePeers } from "../hooks/usePeers";
 import "../styles/status-pill.css";
@@ -224,6 +225,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
 
   // --- Peer popover state ---
   const peers = usePeers();
+  const { enabled: lanListEnabled } = useLanList();
   const [peerOpen, setPeerOpen] = useState(false);
   const lanButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -292,13 +294,13 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
 
   // --- Peer popover effects ---
   useEffect(() => {
-    if (!disabled) return;
+    if (!disabled && lanListEnabled) return;
     void (async () => {
       const popover = await WebviewWindow.getByLabel("peer-list");
       await popover?.hide().catch(() => {});
     })();
     setPeerOpen(false);
-  }, [disabled]);
+  }, [disabled, lanListEnabled]);
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -376,7 +378,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
     <div ref={wrapRef} className="pill-wrap" data-testid="status-pill-wrap">
       <div
         data-testid="status-pill"
-        className={`pill ${glow ? "neon-glow" : ""} ${status === "busy" ? "neon-busy" : ""} ${sessionOpen || peerOpen ? "is-open" : ""}`}
+        className={`pill ${glow ? "neon-glow" : ""} ${status === "busy" ? "neon-busy" : ""} ${sessionOpen || peerOpen ? "is-open" : ""} ${!lanListEnabled ? "no-lan" : ""} ${!sessionListEnabled ? "no-tasks" : ""}`}
       >
         <span data-testid="status-dot" className={dotClassMap[status] ?? "dot searching"} />
         <span data-testid="status-label" className="label">
@@ -407,6 +409,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
             </button>
           )}
 
+          {lanListEnabled && (
           <button
             ref={lanButtonRef}
             type="button"
@@ -434,6 +437,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
               </span>
             )}
           </button>
+          )}
         </div>
       </div>
 

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -12,6 +12,7 @@ import type { Status } from "../types/status";
 import { fetchSessions, type SessionInfo } from "../hooks/useSessions";
 import { useSessionList } from "../hooks/useSessionList";
 import { useLanList } from "../hooks/useLanList";
+import { useOpacity } from "../hooks/useOpacity";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import { usePeers } from "../hooks/usePeers";
 import "../styles/status-pill.css";
@@ -233,6 +234,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
   // --- Peer popover state ---
   const peers = usePeers();
   const { enabled: lanListEnabled } = useLanList();
+  const { opacity: statusOpacity } = useOpacity("status");
   const [peerOpen, setPeerOpen] = useState(false);
   const lanButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -400,7 +402,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
       : `${peers.length} peer${peers.length === 1 ? "" : "s"} nearby`;
 
   return (
-    <div ref={wrapRef} className="pill-wrap" data-testid="status-pill-wrap">
+    <div ref={wrapRef} className="pill-wrap" data-testid="status-pill-wrap" style={{ opacity: statusOpacity }}>
       <div
         data-testid="status-pill"
         className={`pill ${glow ? "neon-glow" : ""} ${status === "busy" ? "neon-busy" : ""} ${sessionOpen || peerOpen ? "is-open" : ""} ${!lanListEnabled ? "no-lan" : ""} ${!sessionListEnabled ? "no-tasks" : ""}`}

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import {
@@ -127,6 +128,12 @@ function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
     const pretty = pwd
       ? prettyPath(pwd, home)
       : list[0].title || `pid ${list[0].pid}`;
+    // Sort children within a group by pid so row order stays stable
+    // across refreshes. The backend returns sessions from a HashMap,
+    // so iteration order can change between invocations — without this
+    // sort, rows can swap under the cursor every 3s refresh and the
+    // CSS :hover highlight flickers off the row you're hovering.
+    list.sort((a, b) => a.pid - b.pid);
     groups.push({
       key,
       pwd,
@@ -228,6 +235,24 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
   const { enabled: lanListEnabled } = useLanList();
   const [peerOpen, setPeerOpen] = useState(false);
   const lanButtonRef = useRef<HTMLButtonElement>(null);
+
+  // --- Session-group path tooltip (portaled to body so the dropdown's
+  // overflow:auto doesn't clip it when it renders above the first row). ---
+  const [pathTooltip, setPathTooltip] = useState<{
+    text: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const showPathTooltip = (el: HTMLElement, text: string) => {
+    const rect = el.getBoundingClientRect();
+    setPathTooltip({
+      text,
+      x: Math.round(rect.left + rect.width / 2),
+      y: Math.round(rect.top),
+    });
+  };
+  const hidePathTooltip = () => setPathTooltip(null);
 
   useEffect(() => {
     onOpenChange?.(sessionOpen);
@@ -466,8 +491,11 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
                     {g.pretty && g.pretty !== groupBasename(g) && (
                       <span
                         className="session-group-info"
-                        data-path={g.pretty}
                         aria-label={`Full path: ${g.pretty}`}
+                        onMouseEnter={(e) =>
+                          showPathTooltip(e.currentTarget, g.pretty)
+                        }
+                        onMouseLeave={hidePathTooltip}
                       >
                         ?
                       </span>
@@ -541,6 +569,18 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
           )}
         </div>
       )}
+
+      {pathTooltip &&
+        createPortal(
+          <div
+            className="session-path-tooltip"
+            style={{ left: pathTooltip.x, top: pathTooltip.y }}
+            role="tooltip"
+          >
+            {pathTooltip.text}
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/src/hooks/useLanList.ts
+++ b/src/hooks/useLanList.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useLayoutEffect } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { emit, listen } from "@tauri-apps/api/event";
+
+const STORAGE_KEY = "lanListEnabled";
+const EVENT_NAME = "lan-list-changed";
+
+/** Whether the LAN (peers) icon in the status pill is shown. Defaults to on. */
+export function useLanList() {
+  const [enabled, setEnabledState] = useState(true);
+
+  useLayoutEffect(() => {
+    load("settings.json").then(async (store) => {
+      const val = await store.get<boolean>(STORAGE_KEY);
+      if (val !== null && val !== undefined) {
+        setEnabledState(val);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>(EVENT_NAME, (event) => {
+      setEnabledState(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const setEnabled = async (next: boolean) => {
+    const store = await load("settings.json");
+    await store.set(STORAGE_KEY, next);
+    await store.save();
+    setEnabledState(next);
+    await emit(EVENT_NAME, next);
+  };
+
+  return { enabled, setEnabled };
+}

--- a/src/hooks/useOpacity.ts
+++ b/src/hooks/useOpacity.ts
@@ -1,0 +1,59 @@
+import { useState, useLayoutEffect, useEffect } from "react";
+import { load } from "@tauri-apps/plugin-store";
+import { emit, listen } from "@tauri-apps/api/event";
+
+const STORE_FILE = "settings.json";
+const STORE_KEY = "petOpacity";
+
+export const OPACITY_MIN = 0.1;
+export const OPACITY_MAX = 1;
+export const OPACITY_DEFAULT = 1;
+
+function clamp(v: number): number {
+  if (Number.isNaN(v)) return OPACITY_DEFAULT;
+  return Math.min(OPACITY_MAX, Math.max(OPACITY_MIN, v));
+}
+
+export function useOpacity() {
+  const [opacity, setOpacityState] = useState<number>(OPACITY_DEFAULT);
+
+  useLayoutEffect(() => {
+    load(STORE_FILE).then((store) => {
+      store.get<number>(STORE_KEY).then((saved) => {
+        if (typeof saved === "number") setOpacityState(clamp(saved));
+      });
+    });
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<number>("opacity-changed", (event) => {
+      setOpacityState(clamp(event.payload));
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const setOpacity = async (next: number) => {
+    const v = clamp(next);
+    setOpacityState(v);
+    const store = await load(STORE_FILE);
+    await store.set(STORE_KEY, v);
+    await store.save();
+    await emit("opacity-changed", v);
+  };
+
+  const previewOpacity = async (next: number) => {
+    const v = clamp(next);
+    setOpacityState(v);
+    await emit("opacity-changed", v);
+  };
+
+  const loadSavedOpacity = async (): Promise<number> => {
+    const store = await load(STORE_FILE);
+    const saved = await store.get<number>(STORE_KEY);
+    return typeof saved === "number" ? clamp(saved) : OPACITY_DEFAULT;
+  };
+
+  return { opacity, setOpacity, previewOpacity, loadSavedOpacity };
+}

--- a/src/hooks/useOpacity.ts
+++ b/src/hooks/useOpacity.ts
@@ -3,55 +3,62 @@ import { load } from "@tauri-apps/plugin-store";
 import { emit, listen } from "@tauri-apps/api/event";
 
 const STORE_FILE = "settings.json";
-const STORE_KEY = "petOpacity";
 
 export const OPACITY_MIN = 0.1;
 export const OPACITY_MAX = 1;
 export const OPACITY_DEFAULT = 1;
+
+export type OpacityTarget = "mime" | "status";
+
+const CONFIG: Record<OpacityTarget, { key: string; event: string }> = {
+  mime: { key: "mimeOpacity", event: "mime-opacity-changed" },
+  status: { key: "statusOpacity", event: "status-opacity-changed" },
+};
 
 function clamp(v: number): number {
   if (Number.isNaN(v)) return OPACITY_DEFAULT;
   return Math.min(OPACITY_MAX, Math.max(OPACITY_MIN, v));
 }
 
-export function useOpacity() {
+export function useOpacity(target: OpacityTarget) {
+  const { key, event } = CONFIG[target];
   const [opacity, setOpacityState] = useState<number>(OPACITY_DEFAULT);
 
   useLayoutEffect(() => {
     load(STORE_FILE).then((store) => {
-      store.get<number>(STORE_KEY).then((saved) => {
+      store.get<number>(key).then((saved) => {
         if (typeof saved === "number") setOpacityState(clamp(saved));
       });
     });
-  }, []);
+  }, [key]);
 
   useEffect(() => {
-    const unlisten = listen<number>("opacity-changed", (event) => {
-      setOpacityState(clamp(event.payload));
+    const unlisten = listen<number>(event, (e) => {
+      setOpacityState(clamp(e.payload));
     });
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, []);
+  }, [event]);
 
   const setOpacity = async (next: number) => {
     const v = clamp(next);
     setOpacityState(v);
     const store = await load(STORE_FILE);
-    await store.set(STORE_KEY, v);
+    await store.set(key, v);
     await store.save();
-    await emit("opacity-changed", v);
+    await emit(event, v);
   };
 
   const previewOpacity = async (next: number) => {
     const v = clamp(next);
     setOpacityState(v);
-    await emit("opacity-changed", v);
+    await emit(event, v);
   };
 
   const loadSavedOpacity = async (): Promise<number> => {
     const store = await load(STORE_FILE);
-    const saved = await store.get<number>(STORE_KEY);
+    const saved = await store.get<number>(key);
     return typeof saved === "number" ? clamp(saved) : OPACITY_DEFAULT;
   };
 

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -418,6 +418,10 @@
   padding: 10px 12px;
 }
 
+.settings-row-stack + .settings-row-stack {
+  border-top: 1px solid rgba(128, 128, 128, 0.15);
+}
+
 .opacity-slider-group {
   display: flex;
   align-items: center;

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -406,6 +406,69 @@
   background: #0063d1;
 }
 
+.nickname-save:disabled {
+  cursor: default;
+}
+
+/* Opacity slider */
+.settings-row-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.opacity-slider-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
+
+.opacity-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  flex: 1;
+  height: 4px;
+  background: rgba(128, 128, 128, 0.25);
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+}
+
+.opacity-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #007aff;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.1s;
+}
+
+.opacity-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+
+.opacity-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #007aff;
+  cursor: pointer;
+  border: none;
+}
+
+.opacity-value {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  min-width: 32px;
+  text-align: right;
+  opacity: 0.7;
+}
+
 /* Custom mime creator */
 .custom-creator {
   margin-top: 4px;

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -234,6 +234,7 @@ button.session-group-head {
   text-align: left;
   cursor: pointer;
   border-radius: 4px;
+  transition: background 0.15s;
 }
 
 button.session-group-head:hover {
@@ -316,14 +317,14 @@ button.session-group-head:hover {
   background: var(--border-pill-hover);
 }
 
-/* Instant custom tooltip: no OS-delay, fires on hover immediately. Positioned
-   ABOVE the ? icon so it doesn't get covered by other dropdown rows. */
-.session-group-info::after {
-  content: attr(data-path);
-  position: absolute;
-  bottom: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
+/* Full-path tooltip for the ? icon. Rendered via a React portal into
+   document.body so the dropdown's overflow:auto can't clip it. Positioned
+   as `position: fixed` using viewport coords computed from the ?'s
+   getBoundingClientRect — `left/top` come from inline style, and the
+   transform parks the tooltip just above the icon. */
+.session-path-tooltip {
+  position: fixed;
+  transform: translate(-50%, calc(-100% - 6px));
   padding: 5px 8px;
   background: rgba(0, 0, 0, 0.9);
   color: rgba(255, 255, 255, 0.95);
@@ -333,36 +334,25 @@ button.session-group-head:hover {
   font-weight: 400;
   white-space: nowrap;
   pointer-events: none;
-  opacity: 0;
-  visibility: hidden;
-  z-index: 100;
+  z-index: 10000;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  transition: opacity 0.08s ease-out, visibility 0s linear 0.08s;
+  animation: path-tooltip-in 0.08s ease-out;
 }
 
-.session-group-info:hover::after {
-  opacity: 1;
-  visibility: visible;
-  transition: opacity 0.08s ease-out, visibility 0s linear 0s;
-}
-
-/* Small arrow pointing down from the tooltip to the ? icon. */
-.session-group-info::before {
+/* Arrow pointing down from the tooltip toward the ? icon. */
+.session-path-tooltip::after {
   content: "";
   position: absolute;
-  bottom: calc(100% + 1px);
+  top: 100%;
   left: 50%;
   transform: translateX(-50%);
   border: 4px solid transparent;
   border-top-color: rgba(0, 0, 0, 0.9);
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.08s ease-out;
-  z-index: 101;
 }
 
-.session-group-info:hover::before {
-  opacity: 1;
+@keyframes path-tooltip-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 .session-state {

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -31,10 +31,18 @@
   pointer-events: auto;
   transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
   white-space: nowrap;
-  /* Minimum width keeps the layout stable when the status label is
-     short ("Free") vs long ("Initializing...") — prevents the action
-     icons from jiggling as status text changes. */
-  min-width: 150px;
+}
+
+/* When no action buttons are visible, tighten the right padding so
+   the pill symmetrically hugs the label. */
+.pill.no-lan.no-tasks {
+  padding-right: 11px;
+}
+
+/* Collapse the actions container when it has no visible children so
+   the parent flex `gap` stops reserving space before it. */
+.pill-actions:empty {
+  display: none;
 }
 
 .pill.is-open {
@@ -42,14 +50,16 @@
   border-color: var(--border-pill-hover);
 }
 
-/* --- Action buttons cluster on the right --- */
+/* --- Action buttons cluster on the right ---
+   Sits after the label with ~12px of breathing room: 6px flex gap
+   from the parent plus an extra 6px margin-left. We no longer use
+   `margin-left: auto` because the pill is content-sized, so there's
+   no excess space to push through. */
 .pill-actions {
   display: inline-flex;
   align-items: center;
   gap: 2px;
-  /* margin-left: auto pushes the cluster to the right so dot+label hug
-     the left and the icons hug the right with a flexible spacer between. */
-  margin-left: auto;
+  margin-left: 6px;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary
- LAN peer list toggle and anchored session dropdown (ddba5f7)
- Smoother session dropdown open/close and unclipped path tooltip (b14b87e)
- New Pet Opacity slider under Settings → General → Transparency with live preview and Save-to-persist (7786776)

## Test plan
- [ ] Open Settings → General → Transparency; drag the slider and confirm the mascot fades live
- [ ] Close Settings without clicking Save; confirm the mascot reverts to its previous opacity
- [ ] Drag slider, click Save, restart app; confirm opacity persists
- [ ] Verify session dropdown still opens/closes smoothly and path tooltip is not clipped
- [ ] Verify LAN peer list toggle hides/shows the peer pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)