### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - **Status bar opacity slider** in the same section — fades the status pill independently of the mime.
 
 ### Changed
-- **Renamed "Pet" → "Mime"** in the Transparency section label for consistency with the rest of the app.
 - **Session dropdown open/close** is smoother and the path tooltip is no longer clipped by the dropdown's overflow bounds.
 - **LAN peer list toggle** added under Settings → General → Status Bar so the peer icon can be hidden entirely.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.17.1] - 2026-04-20
+
+### Added
+- **Mime opacity slider** in Settings → General → Transparency — drag to fade the mime live, click Save to persist.
+- **Status bar opacity slider** in the same section — fades the status pill independently of the mime.
+
+### Changed
+- **Renamed "Pet" → "Mime"** in the Transparency section label for consistency with the rest of the app.
+- **Session dropdown open/close** is smoother and the path tooltip is no longer clipped by the dropdown's overflow bounds.
+- **LAN peer list toggle** added under Settings → General → Status Bar so the peer icon can be hidden entirely.
+
 ## [0.17.0] - 2026-04-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.0"
+version = "0.17.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1165,7 +1165,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.0{devMode && " (Dev Mode)"}
+                  Version 0.17.1{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
Patch release bundling the opacity sliders and session-dropdown polish from #103.

### Added
- Mime opacity slider (Settings → General → Transparency)
- Status bar opacity slider (same section)

### Changed
- Smoother session dropdown open/close
- LAN peer list toggle

## Test plan
- [ ] Settings → General → Transparency shows both sliders; dragging gives live preview on the mascot and status pill
- [ ] Closing Settings without Save reverts the preview
- [ ] Save persists across app restart
- [ ] About tab shows Version 0.17.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)