### PR TITLE
fix(ui): stop mascot jitter on status change and bubble toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,9 +136,14 @@ function App() {
       <div className="main-col">
         {scenario && <div data-testid="scenario-badge" className="scenario-badge">SCENARIO</div>}
         <EffectOverlay onActiveChange={setEffectActive} />
-        <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
-        {status !== "visiting" && <Mascot status={status} />}
-        {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
+        {/* mascot-wrap anchors the absolute-positioned speech bubble.
+            Keeping the bubble out of the flex flow prevents it from
+            nudging the sprite's Y position when it appears/disappears. */}
+        <div className="mascot-wrap">
+          <SpeechBubble visible={visible} message={message} onDismiss={dismiss} />
+          {status !== "visiting" && <Mascot status={status} />}
+          {status === "visiting" && <div style={{ width: 128 * scale, height: 128 * scale }} />}
+        </div>
         <DevBuildBadge />
         <StatusPill
           status={status}

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef } from "react";
 import type { Status } from "../types/status";
 import { getSpriteMap, autoStopStatuses } from "../constants/sprites";
 import { usePet } from "../hooks/usePet";
@@ -108,9 +108,16 @@ export function Mascot({ status }: MascotProps) {
 
   const frameSize = FRAME_BASE_PX * scale;
 
-  // Read sheet dimensions when URL changes (needed to compute grid layout)
-  useEffect(() => {
+  // Read sheet dimensions when URL changes (needed to compute grid layout).
+  // useLayoutEffect so setSheetDims(null) commits before paint — otherwise
+  // the first render after a status change uses the NEW spriteUrl + frames
+  // with the OLD sheetDims, which inferGrid turns into a wildly stretched
+  // backgroundSize for one frame. Also reset backgroundPosition so the
+  // stale offset from the previous status' rAF loop doesn't briefly show
+  // an off-grid region of the new sprite.
+  useLayoutEffect(() => {
     setSheetDims(null);
+    if (spriteRef.current) spriteRef.current.style.backgroundPosition = "0 0";
     if (!spriteUrl) return;
     let cancelled = false;
     const img = new Image();

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -50,6 +50,15 @@ body {
   flex-shrink: 0;
 }
 
+/* Anchor for the absolute-positioned speech bubble. Sized to the sprite
+   by its Mascot child; the bubble lives on top of the sprite without
+   adding to the flex flow, so bubble visibility can't shift the sprite
+   vertically. */
+.mascot-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
 
 .container.dragging {
   cursor: grabbing;

--- a/src/styles/speech-bubble.css
+++ b/src/styles/speech-bubble.css
@@ -1,11 +1,15 @@
 .speech-bubble {
-  position: relative;
+  /* Anchored to .mascot-wrap so the sprite's layout position doesn't
+     change when the bubble appears/disappears. bottom = sprite height
+     minus overlap, which puts the bubble's bottom edge 46*scale px
+     below the top of the sprite (tail sits on the pet's head). */
+  position: absolute;
+  bottom: calc(128px * var(--sprite-scale, 1) - 46px * var(--sprite-scale, 1));
+  left: 50%;
   display: inline-flex;
   align-items: center;
   padding: 8px 14px;
-  margin-bottom: calc(-46px * var(--sprite-scale, 1));
   z-index: 1;
-  align-self: center;
   border-radius: 12px;
   background: var(--bg-bubble);
   backdrop-filter: blur(10px);
@@ -14,6 +18,7 @@
   cursor: pointer;
   animation: bubble-pop-in 0.3s ease-out;
   pointer-events: auto;
+  transform: translateX(-50%);
 }
 
 .speech-bubble-text {
@@ -40,10 +45,10 @@
 @keyframes bubble-pop-in {
   0% {
     opacity: 0;
-    transform: scale(0.8) translateY(4px);
+    transform: translateX(-50%) scale(0.8) translateY(4px);
   }
   100% {
     opacity: 1;
-    transform: scale(1) translateY(0);
+    transform: translateX(-50%) scale(1) translateY(0);
   }
 }


### PR DESCRIPTION
## Summary

Fixes two independent sources of visible pet jitter:

- **Status change flash** (e.g. busy → idle): the first render after a status change used the new `spriteUrl` + frame count with the *old* `sheetDims`, making `inferGrid` produce a wildly stretched `backgroundSize` for one paint. Stale `backgroundPosition` from the previous rAF loop also briefly pointed off-grid on the new sprite. Switched to `useLayoutEffect` so `setSheetDims(null)` commits before paint, and reset `backgroundPosition` on URL change.
- **Speech bubble toggle**: the bubble sat in the flex column with `margin-bottom: -46px * scale`, which pulled the sprite up ~16px when visible and let it drop back down on hide. Wrapped the sprite + bubble in a new `.mascot-wrap` and made the bubble absolute-positioned against it. Overlap with the sprite's head preserved via `bottom: calc((128px - 46px) * var(--sprite-scale))`.

## Test plan

- [ ] `bun run tauri dev`, run a Claude Code task → watch for no flash when the pet transitions busy → idle
- [ ] Trigger a speech bubble (task-completed) → pet stays anchored, bubble appears above with tail on head
- [ ] Dismiss the bubble → pet does not drop downward
- [ ] Try at non-default sprite scale (Settings → sprite size) — bubble still anchors correctly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)