### PR TITLE
fix(ui): mutually exclusive session and peer popovers

### DIFF
--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -275,6 +275,13 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
       setSessionOpen(false);
       return;
     }
+    // Only one popover at a time — hide the peer popover before showing
+    // the session dropdown.
+    if (peerOpen) {
+      const popover = await WebviewWindow.getByLabel("peer-list");
+      await popover?.hide().catch(() => {});
+      setPeerOpen(false);
+    }
     const list = await fetchSessions();
     const overlaid = overlayClaudeState(reflectActiveServices(list));
     setGroups(groupSessions(overlaid, detectHome(overlaid)));
@@ -387,6 +394,10 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
       setPeerOpen(false);
       return;
     }
+
+    // Only one popover at a time — close the session dropdown before
+    // showing the peer list.
+    if (sessionOpen) setSessionOpen(false);
 
     const pos = await computePopoverScreenPos(lanButtonRef.current);
     await popover.setPosition(pos);


### PR DESCRIPTION
## Summary

Only one pill popover can be open at a time now. Opening the peer list closes the session dropdown, and opening the session list hides the peer popover. Previously both could be visible simultaneously, which overlapped visually and showed two conflicting \"active\" icons in the pill.

Changes in \`src/components/StatusPill.tsx\`:
- \`toggleSession\`: if \`peerOpen\` is true when opening, hide the peer-list webview and clear \`peerOpen\` first.
- \`togglePeer\`: if \`sessionOpen\` is true when opening, clear \`sessionOpen\` first.

Each toggle's \"close self\" path is unchanged.

## Test plan

- [ ] \`bun run tauri dev\`
- [ ] Open the session dropdown, then click the peer (LAN) icon — session dropdown closes, peer popover appears
- [ ] Open the peer popover, then click the session (task) icon — peer popover hides, session dropdown appears
- [ ] Clicking the active icon still toggles only that popover closed
- [ ] \`npx tsc --noEmit\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)