### PR TITLE
feat(ui): session-list webview window scaffold

### DIFF
--- a/session-list.html
+++ b/session-list.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sessions</title>
+    <style>html, body, #root { margin: 0; padding: 0; overflow: hidden; height: 100%; background: transparent; }</style>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/session-list-main.tsx"></script>
+  </body>
+</html>

--- a/src/SessionListApp.tsx
+++ b/src/SessionListApp.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { fetchSessions, type SessionInfo } from "./hooks/useSessions";
+import { useCollapsedSessionGroups } from "./hooks/useCollapsedSessionGroups";
+import { useTheme } from "./hooks/useTheme";
+import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
+import "./styles/theme.css";
+import "./styles/session-list-window.css";
+
+const statePriority: Record<string, number> = {
+  busy: 3,
+  service: 2,
+  idle: 1,
+};
+
+function groupState(sessions: SessionInfo[]): string {
+  let best = "idle";
+  let bestP = 0;
+  for (const s of sessions) {
+    const p = statePriority[s.ui_state] ?? 0;
+    if (p > bestP) {
+      bestP = p;
+      best = s.ui_state;
+    }
+  }
+  return best;
+}
+
+function prettyPath(pwd: string, home?: string): string {
+  if (!pwd) return "";
+  if (home && pwd.startsWith(home)) return "~" + pwd.slice(home.length);
+  return pwd;
+}
+
+function groupBasename(g: {
+  pwd: string;
+  pretty: string;
+  sessions: SessionInfo[];
+}): string {
+  if (g.pwd) {
+    const leaf = g.pwd.split("/").filter(Boolean).pop();
+    if (leaf) return leaf;
+  }
+  return g.pretty || g.sessions[0]?.title || "";
+}
+
+function shellLabel(s: SessionInfo): string {
+  if (s.has_claude) return "claude";
+  if (s.fg_cmd) return s.fg_cmd.replace(/^-/, "");
+  if (s.ui_state === "busy" && s.busy_type) return s.busy_type;
+  if (s.ui_state === "service") return "service";
+  return "idle";
+}
+
+interface Group {
+  key: string;
+  pwd: string;
+  pretty: string;
+  sessions: SessionInfo[];
+  state: string;
+  isClaudeFallback: boolean;
+}
+
+function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
+  const claudeVirtual = sessions.find((s) => s.pid === 0);
+  const anyShellHasClaude = sessions.some((s) => s.pid !== 0 && s.has_claude);
+
+  const byKey = new Map<string, { pwd: string; list: SessionInfo[] }>();
+  for (const s of sessions) {
+    if (s.pid === 0) continue;
+    if (s.is_claude_proc) continue;
+    const key = s.pwd || s.title || String(s.pid);
+    if (!byKey.has(key)) byKey.set(key, { pwd: s.pwd, list: [] });
+    byKey.get(key)!.list.push(s);
+  }
+
+  const groups: Group[] = [];
+  for (const [key, { pwd, list }] of byKey.entries()) {
+    const pretty = pwd
+      ? prettyPath(pwd, home)
+      : list[0].title || `pid ${list[0].pid}`;
+    // Sort children by pid so refresh-induced HashMap reorders don't
+    // shuffle rows under the cursor and break :hover.
+    list.sort((a, b) => a.pid - b.pid);
+    groups.push({
+      key,
+      pwd,
+      pretty,
+      sessions: list,
+      state: groupState(list),
+      isClaudeFallback: false,
+    });
+  }
+
+  groups.sort((a, b) => {
+    const pa = statePriority[a.state] ?? 0;
+    const pb = statePriority[b.state] ?? 0;
+    if (pa !== pb) return pb - pa;
+    return a.pretty.localeCompare(b.pretty);
+  });
+
+  if (claudeVirtual && !anyShellHasClaude) {
+    groups.push({
+      key: "claude-virtual",
+      pwd: "",
+      pretty: "Claude Code",
+      sessions: [claudeVirtual],
+      state: claudeVirtual.ui_state,
+      isClaudeFallback: true,
+    });
+  }
+
+  return groups;
+}
+
+function detectHome(sessions: SessionInfo[]): string | undefined {
+  for (const s of sessions) {
+    const m = s.pwd.match(/^(\/Users\/[^/]+|\/home\/[^/]+)/);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+function reflectActiveServices(sessions: SessionInfo[]): SessionInfo[] {
+  return sessions.map((s) =>
+    s.busy_type === "service" && s.ui_state === "idle"
+      ? { ...s, ui_state: "service" }
+      : s
+  );
+}
+
+function overlayClaudeState(sessions: SessionInfo[]): SessionInfo[] {
+  const sessionByPid = new Map<number, SessionInfo>();
+  for (const s of sessions) sessionByPid.set(s.pid, s);
+
+  return sessions.map((s) => {
+    if (!s.has_claude) return s;
+    const claudeSession =
+      (s.claude_pid != null && sessionByPid.get(s.claude_pid)) ||
+      sessionByPid.get(0);
+    if (!claudeSession) return s;
+    const claudeP = statePriority[claudeSession.ui_state] ?? 0;
+    const ownP = statePriority[s.ui_state] ?? 0;
+    return ownP >= claudeP ? s : { ...s, ui_state: claudeSession.ui_state };
+  });
+}
+
+export function SessionListApp() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
+  const [pathTooltip, setPathTooltip] = useState<{
+    text: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  useTheme();
+  useWindowAutoSize(rootRef);
+
+  // Refresh sessions on mount, on status-changed, and every 3s while shown.
+  useEffect(() => {
+    let cancelled = false;
+
+    const refresh = async () => {
+      const list = await fetchSessions();
+      if (cancelled) return;
+      const overlaid = overlayClaudeState(reflectActiveServices(list));
+      setGroups(groupSessions(overlaid, detectHome(overlaid)));
+    };
+
+    void refresh();
+
+    const unlistenP = listen("status-changed", () => {
+      void refresh();
+    });
+    const id = setInterval(refresh, 3000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+      unlistenP.then((fn) => fn());
+    };
+  }, []);
+
+  // Hide on focus loss or Escape.
+  useEffect(() => {
+    const win = getCurrentWindow();
+    const unlistenP = win.onFocusChanged(({ payload: focused }) => {
+      if (!focused) void win.hide();
+    });
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") void win.hide();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      unlistenP.then((fn) => fn());
+      window.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
+  const showPathTooltip = (el: HTMLElement, text: string) => {
+    const rect = el.getBoundingClientRect();
+    setPathTooltip({
+      text,
+      x: Math.round(rect.left + rect.width / 2),
+      y: Math.round(rect.top),
+    });
+  };
+  const hidePathTooltip = () => setPathTooltip(null);
+
+  const onItemClick = (s: SessionInfo) => {
+    invoke("focus_terminal", { pid: s.pid, tty: s.tty || null }).catch((err) =>
+      console.error("[session-list] focus_terminal", err)
+    );
+    void getCurrentWindow().hide();
+  };
+
+  return (
+    <div ref={rootRef} className="session-list-shell">
+      <div
+        className="session-list-root"
+        data-testid="session-list-root"
+        role="menu"
+      >
+        {groups.length === 0 ? (
+          <div className="session-empty">No active terminals</div>
+        ) : (
+          groups.map((g) => {
+            const isCollapsed = collapsed.has(g.key);
+            const headContent = (
+              <>
+                {!g.isClaudeFallback && (
+                  <span className="session-group-caret" aria-hidden="true" />
+                )}
+                <span className={`dot small ${g.state}`} />
+                <span className="session-group-title-row">
+                  <span className="session-group-title">{groupBasename(g)}</span>
+                  {g.pretty && g.pretty !== groupBasename(g) && (
+                    <span
+                      className="session-group-info"
+                      aria-label={`Full path: ${g.pretty}`}
+                      onMouseEnter={(e) =>
+                        showPathTooltip(e.currentTarget, g.pretty)
+                      }
+                      onMouseLeave={hidePathTooltip}
+                    >
+                      ?
+                    </span>
+                  )}
+                </span>
+                {g.sessions.length > 1 && (
+                  <span className="session-count">{g.sessions.length}</span>
+                )}
+              </>
+            );
+            return (
+              <div
+                key={g.key}
+                className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
+                data-testid={`session-group-${g.key}`}
+              >
+                {g.isClaudeFallback ? (
+                  <div className="session-group-head">{headContent}</div>
+                ) : (
+                  <button
+                    type="button"
+                    className={`session-group-head clickable ${isCollapsed ? "collapsed" : ""}`}
+                    data-testid={`session-group-head-${g.key}`}
+                    aria-expanded={!isCollapsed}
+                    aria-controls={`session-children-${g.key}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void toggleCollapsed(g.key);
+                    }}
+                  >
+                    {headContent}
+                  </button>
+                )}
+
+                {!g.isClaudeFallback && !isCollapsed && (
+                  <div
+                    className="session-children"
+                    id={`session-children-${g.key}`}
+                  >
+                    {g.sessions.map((s) => (
+                      <button
+                        key={s.pid}
+                        type="button"
+                        className={`session-child ${s.has_claude ? "has-claude" : ""}`}
+                        data-testid={`session-item-${s.pid}`}
+                        title="Click to bring this terminal to the front"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onItemClick(s);
+                        }}
+                      >
+                        <span className={`dot small ${s.ui_state}`} />
+                        <span className="session-child-label-row">
+                          <span className="session-child-label">{shellLabel(s)}</span>
+                          {s.has_claude && (
+                            <span
+                              className="session-child-claude"
+                              aria-label="Claude Code running"
+                            />
+                          )}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {pathTooltip &&
+        createPortal(
+          <div
+            className="session-path-tooltip"
+            style={{ left: pathTooltip.x, top: pathTooltip.y }}
+            role="tooltip"
+          >
+            {pathTooltip.text}
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/src/session-list-main.tsx
+++ b/src/session-list-main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { SessionListApp } from "./SessionListApp";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <SessionListApp />
+  </React.StrictMode>
+);

--- a/src/styles/session-list-window.css
+++ b/src/styles/session-list-window.css
@@ -1,0 +1,321 @@
+/* Styles for the `session-list` Tauri popover window. The window itself
+   is transparent + decoration-less; the .session-list-shell wrapper adds
+   12px of padding on all sides so the card's box-shadow isn't clipped
+   by the window edge (offsetWidth/Height does NOT include box-shadow). */
+
+html,
+body,
+#root {
+  background: transparent;
+}
+
+#root {
+  display: inline-block;
+  width: max-content;
+}
+
+.session-list-shell {
+  width: max-content;
+  padding: 12px;
+  display: inline-block;
+}
+
+.session-list-root {
+  min-width: 240px;
+  max-width: 360px;
+  padding: 4px;
+  border-radius: 10px;
+  background: var(--bg-pill);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border-pill);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  color: var(--text-primary);
+  animation: session-list-fade-in 0.1s ease-out;
+}
+
+@keyframes session-list-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.session-empty {
+  padding: 8px 12px;
+  font-size: 12px;
+  opacity: 0.6;
+  text-align: center;
+}
+
+/* --- Group (one per unique PWD, plus Claude Code) --- */
+.session-group {
+  padding: 4px 4px 2px;
+  border-radius: 6px;
+}
+
+.session-group + .session-group {
+  margin-top: 2px;
+  border-top: 1px solid var(--border-pill);
+  padding-top: 6px;
+}
+
+.session-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+/* When the head is a real <button> (collapsible group) reset button chrome
+ * so it visually matches the non-collapsible div variant. */
+button.session-group-head {
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+button.session-group-head:hover {
+  background: var(--bg-pill-hover);
+}
+
+.session-group-caret {
+  flex-shrink: 0;
+  width: 0;
+  height: 0;
+  border-left: 4px solid currentColor;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  opacity: 0.5;
+  transform: rotate(90deg);
+  transition: transform 120ms ease;
+}
+
+.session-group-head.collapsed .session-group-caret {
+  transform: rotate(0deg);
+}
+
+.session-group-title-row {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.session-group-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-group.claude .session-group-title {
+  font-style: italic;
+  opacity: 0.9;
+}
+
+.session-count {
+  flex-shrink: 0;
+  min-width: 16px;
+  padding: 1px 5px;
+  border-radius: 9999px;
+  background: var(--bg-pill-hover);
+  border: 1px solid var(--border-pill);
+  font-size: 10px;
+  font-weight: 600;
+  text-align: center;
+  opacity: 0.75;
+}
+
+.session-group-info {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bg-pill-hover);
+  border: 1px solid var(--border-pill);
+  color: var(--text-primary);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  opacity: 0.45;
+  cursor: help;
+  transition: opacity 0.12s, background 0.12s;
+}
+
+.session-group-info:hover {
+  opacity: 0.95;
+  background: var(--border-pill-hover);
+}
+
+/* Full-path tooltip rendered via React portal to document.body so it
+   escapes any clipping ancestor. Positioned with fixed coords from the
+   ? icon's getBoundingClientRect. */
+.session-path-tooltip {
+  position: fixed;
+  transform: translate(-50%, calc(-100% - 6px));
+  padding: 5px 8px;
+  background: rgba(0, 0, 0, 0.9);
+  color: rgba(255, 255, 255, 0.95);
+  border-radius: 6px;
+  font-family: "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 10px;
+  font-weight: 400;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10000;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  animation: path-tooltip-in 0.08s ease-out;
+}
+
+.session-path-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: rgba(0, 0, 0, 0.9);
+}
+
+@keyframes path-tooltip-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* --- Child rows (individual shells within a group) --- */
+.session-children {
+  padding: 2px 0 2px 14px;
+}
+
+.session-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  font-family: inherit;
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0.85;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.session-child:hover,
+.session-child:focus-visible {
+  background: var(--bg-pill-hover);
+  opacity: 1;
+  outline: none;
+}
+
+.session-child:active {
+  transform: translateY(0.5px);
+}
+
+.session-child-claude {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  margin-left: 4px;
+  background-image: url("../assets/claude-logo.png");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  border-radius: 2px;
+}
+
+.session-child-label-row {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.session-child-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: "SF Mono", "Menlo", "Monaco", monospace;
+}
+
+/* --- Status dots --- */
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  pointer-events: none;
+  transition: background 0.3s, box-shadow 0.3s;
+}
+
+.dot.small {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+}
+
+.dot.idle {
+  background: #34c759;
+  box-shadow: 0 0 6px rgba(52, 199, 89, 0.6);
+}
+
+.dot.busy {
+  background: #ff3b30;
+  box-shadow: 0 0 6px rgba(255, 59, 48, 0.6);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.dot.service {
+  background: #5e5ce6;
+  box-shadow: 0 0 8px rgba(94, 92, 230, 0.5);
+}
+
+.dot.disconnected {
+  background: #636366;
+  box-shadow: none;
+}
+
+.dot.initializing {
+  background: #ff9f0a;
+  box-shadow: 0 0 6px rgba(255, 159, 10, 0.5);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.dot.searching {
+  background: #ffcc00;
+  box-shadow: 0 0 6px rgba(255, 204, 0, 0.5);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.dot.visiting {
+  background: #af52de;
+  box-shadow: 0 0 6px rgba(175, 82, 222, 0.6);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Summary

Adds a standalone Tauri webview entrypoint for the session list, mirroring the peer-list window pattern.

- \`session-list.html\` — webview HTML shell
- \`src/session-list-main.tsx\` — React entrypoint
- \`src/SessionListApp.tsx\` — session grouping/rendering (extracted from the inline dropdown in StatusPill, minus the open/close plumbing)
- \`src/styles/session-list-window.css\` — window-local styles with a 12px shadow buffer so \`box-shadow\` isn't clipped by the window edge

## Note

This is **scaffold only** — the new window is not yet registered in \`tauri.conf.json\` or \`vite.config.ts\`, and \`StatusPill\` still uses its inline dropdown. Follow-up work will wire those up and switch the pill's task button to open this window instead of the inline dropdown.

## Test plan

- [ ] \`npx tsc --noEmit\` passes (the new files compile cleanly against existing hooks)
- [ ] No behavior change to the running app until the follow-up lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)