### PR TITLE
feat(dev): ultra-long-bubble scenario for overflow testing

### DIFF
--- a/src/components/scenarios/PetStatusScenario.tsx
+++ b/src/components/scenarios/PetStatusScenario.tsx
@@ -12,6 +12,7 @@ const statuses: { status: Status; label: string; desc: string; color: string; bu
   { status: "visiting", label: "Visiting", desc: "Dog visiting a peer", color: "#af52de" },
   { status: "idle", label: "Free + Bubble", desc: "Idle with short bubble", color: "#30d158", bubble: "Task complete!" },
   { status: "idle", label: "Long Bubble", desc: "Test long text overflow", color: "#30d158", bubble: "Hey! Your build finished successfully after 42 seconds. Everything looks good!" },
+  { status: "idle", label: "Ultra Long Bubble", desc: "Test very long text overflow (2x long)", color: "#30d158", bubble: "Hey! Your build finished successfully after 42 seconds. Everything looks good! I also ran the full test suite, linted every file, and updated the changelog." },
 ];
 
 export function PetStatusScenario() {


### PR DESCRIPTION
## Summary

Adds an **Ultra Long Bubble** preview to the Pet Status scenario grid (Superpower → Scenarios), roughly 2× the length of the existing \"Long Bubble\" case (~156 chars vs 79 chars). Lets the developer eyeball how the speech bubble renders (or overflows) with clearly-too-long messages so wrap/truncate behavior can be tuned.

## Test plan

- [ ] \`bun run tauri dev\`
- [ ] Enable dev mode (click version 10× in Settings) and open the Superpower tool
- [ ] Switch to the Scenarios tab → click **Ultra Long Bubble**
- [ ] Speech bubble appears with the ~156-char message; confirm current \`white-space: nowrap\` causes it to extend horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)