### PR TITLE
refactor(dev): Superpower tool — layout outlines + ultra-long-bubble scenario

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,9 @@ import { useBubble } from "./hooks/useBubble";
 import { useVisitors } from "./hooks/useVisitors";
 import { useScale } from "./hooks/useScale";
 import { useDevMode } from "./hooks/useDevMode";
+import { useDevAppBounds } from "./hooks/useDevAppBounds";
+import { useDevContainerBounds } from "./hooks/useDevContainerBounds";
+import { useDevRootBounds } from "./hooks/useDevRootBounds";
 import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
 import { useEffect, useRef, useState } from "react";
 import {
@@ -38,6 +41,17 @@ function App() {
   const visitors = useVisitors();
   const { scale } = useScale();
   const devMode = useDevMode();
+  const devAppBounds = useDevAppBounds();
+  const devContainerBounds = useDevContainerBounds();
+  const devRootBounds = useDevRootBounds();
+
+  // #root lives in the HTML template outside React's tree, so we toggle
+  // its class imperatively when the dev toggle flips.
+  useEffect(() => {
+    const root = document.getElementById("root");
+    if (!root) return;
+    root.classList.toggle("dev-root-bounds", devRootBounds);
+  }, [devRootBounds]);
   const containerRef = useRef<HTMLDivElement>(null);
   const [effectActive, setEffectActive] = useState(false);
   const [sessionOpen, setSessionOpen] = useState(false);
@@ -130,7 +144,7 @@ function App() {
     <div
       ref={containerRef}
       data-testid="app-container"
-      className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""}`}
+      className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${devAppBounds ? "dev-bounds" : ""} ${devContainerBounds ? "dev-container-bounds" : ""}`}
       onMouseDown={onMouseDown}
     >
       <div className="main-col">

--- a/src/components/SuperpowerTool.tsx
+++ b/src/components/SuperpowerTool.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
 import { useTheme } from "../hooks/useTheme";
 import { ScenarioViewer } from "./scenarios";
 import "../styles/theme.css";
@@ -171,12 +172,43 @@ function LogViewer() {
 export function SuperpowerTool() {
   const [activeMenu, setActiveMenu] = useState<MenuItem>("logs");
   const [devTagVisible, setDevTagVisible] = useState(true);
+  const [appBoundsVisible, setAppBoundsVisible] = useState(true);
+  const [containerBoundsVisible, setContainerBoundsVisible] = useState(true);
+  const [rootBoundsVisible, setRootBoundsVisible] = useState(true);
   useTheme();
+
+  // Push the initial state to the main window so the outlines turn on
+  // the moment the Superpower tool mounts (i.e. when dev mode is opened).
+  // Without this, the main app stays at its defaults (false) until each
+  // toggle is clicked.
+  useEffect(() => {
+    void emit("dev-app-bounds-changed", true);
+    void emit("dev-container-bounds-changed", true);
+    void emit("dev-root-bounds-changed", true);
+  }, []);
 
   const handleDevTagToggle = () => {
     const next = !devTagVisible;
     setDevTagVisible(next);
     invoke("set_dev_mode", { enabled: next });
+  };
+
+  const handleAppBoundsToggle = () => {
+    const next = !appBoundsVisible;
+    setAppBoundsVisible(next);
+    void emit("dev-app-bounds-changed", next);
+  };
+
+  const handleContainerBoundsToggle = () => {
+    const next = !containerBoundsVisible;
+    setContainerBoundsVisible(next);
+    void emit("dev-container-bounds-changed", next);
+  };
+
+  const handleRootBoundsToggle = () => {
+    const next = !rootBoundsVisible;
+    setRootBoundsVisible(next);
+    void emit("dev-root-bounds-changed", next);
   };
 
   return (
@@ -207,6 +239,42 @@ export function SuperpowerTool() {
               onClick={handleDevTagToggle}
               data-testid="dev-tag-toggle"
               aria-label="Toggle DEV tag visibility"
+            >
+              <span className="toggle-knob" />
+            </button>
+          </div>
+          <div className="superpower-toolbar-item">
+            <span className="superpower-toolbar-label">App Bounds</span>
+            <button
+              className={`toggle-switch ${appBoundsVisible ? "active" : ""}`}
+              onClick={handleAppBoundsToggle}
+              data-testid="app-bounds-toggle"
+              aria-label="Toggle app bounds outline"
+              title="Show an outline around the app area to reveal the window size"
+            >
+              <span className="toggle-knob" />
+            </button>
+          </div>
+          <div className="superpower-toolbar-item">
+            <span className="superpower-toolbar-label">Container</span>
+            <button
+              className={`toggle-switch ${containerBoundsVisible ? "active" : ""}`}
+              onClick={handleContainerBoundsToggle}
+              data-testid="container-bounds-toggle"
+              aria-label="Toggle container area outline"
+              title="Show a red outline around the content area (inside the window padding)"
+            >
+              <span className="toggle-knob" />
+            </button>
+          </div>
+          <div className="superpower-toolbar-item">
+            <span className="superpower-toolbar-label">Root</span>
+            <button
+              className={`toggle-switch ${rootBoundsVisible ? "active" : ""}`}
+              onClick={handleRootBoundsToggle}
+              data-testid="root-bounds-toggle"
+              aria-label="Toggle root element outline"
+              title="Show a green outline around the #root element (full webview surface)"
             >
               <span className="toggle-knob" />
             </button>

--- a/src/components/scenarios/PetStatusScenario.tsx
+++ b/src/components/scenarios/PetStatusScenario.tsx
@@ -12,6 +12,7 @@ const statuses: { status: Status; label: string; desc: string; color: string; bu
   { status: "visiting", label: "Visiting", desc: "Dog visiting a peer", color: "#af52de" },
   { status: "idle", label: "Free + Bubble", desc: "Idle with short bubble", color: "#30d158", bubble: "Task complete!" },
   { status: "idle", label: "Long Bubble", desc: "Test long text overflow", color: "#30d158", bubble: "Hey! Your build finished successfully after 42 seconds. Everything looks good!" },
+  { status: "idle", label: "Ultra Long Bubble", desc: "Test very long text overflow (2x long)", color: "#30d158", bubble: "Hey! Your build finished successfully after 42 seconds. Everything looks good! I also ran the full test suite, linted every file, and updated the changelog." },
 ];
 
 export function PetStatusScenario() {

--- a/src/hooks/useDevAppBounds.ts
+++ b/src/hooks/useDevAppBounds.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Session-only dev toggle: when true, the main window draws a visible
+ * outline + tint so the developer can see the exact bounds of the app
+ * area (= the auto-sized Tauri window). Starts off on every launch.
+ */
+export function useDevAppBounds() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>("dev-app-bounds-changed", (e) => {
+      setVisible(Boolean(e.payload));
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  return visible;
+}

--- a/src/hooks/useDevContainerBounds.ts
+++ b/src/hooks/useDevContainerBounds.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Session-only dev toggle: when true, the main window draws a red
+ * outline around the container's content area (inside the padding that
+ * reserves space for the status-pill neon glow) so the developer can
+ * see where the actual UI content sits vs. the full window bounds.
+ */
+export function useDevContainerBounds() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>("dev-container-bounds-changed", (e) => {
+      setVisible(Boolean(e.payload));
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  return visible;
+}

--- a/src/hooks/useDevRootBounds.ts
+++ b/src/hooks/useDevRootBounds.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Session-only dev toggle: when true, outlines the #root element — the
+ * React mount node that always fills the Tauri webview (100% × 100%),
+ * so it reveals the full window surface even when the session dropdown
+ * temporarily grows the window past the auto-sized container.
+ */
+export function useDevRootBounds() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>("dev-root-bounds-changed", (e) => {
+      setVisible(Boolean(e.payload));
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  return visible;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -64,6 +64,46 @@ body {
   cursor: grabbing;
 }
 
+/* Dev tool: outlines the container (== the auto-sized Tauri window)
+   so the developer can see the app's exact bounds. outline-offset: -1px
+   keeps the stroke inside the window so it can't be clipped. The faint
+   fill makes the transparent padding region visible too. */
+.container.dev-bounds {
+  outline: 1px dashed #5e5ce6;
+  outline-offset: -1px;
+  background: rgba(94, 92, 230, 0.08);
+}
+
+/* Dev tool: red outline around the container's content area (inside the
+   padding that reserves room for the status-pill's neon glow). Drawn as
+   a ::before pseudo-element positioned to match the padding box, so it
+   visualizes the difference between window bounds (.dev-bounds) and the
+   area where actual UI content lives. */
+.container.dev-container-bounds::before {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 30px;
+  bottom: 30px;
+  left: 20px;
+  outline: 1px dashed #ff3b30;
+  outline-offset: -1px;
+  background: rgba(255, 59, 48, 0.06);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Dev tool: green outline around #root — the React mount node that
+   fills the entire webview (100% × 100%). Distinct from .dev-bounds on
+   .container because the session dropdown temporarily grows the window
+   past the auto-sized container, at which point #root shows the real
+   window surface while .container stays at its content size. */
+#root.dev-root-bounds {
+  outline: 1px dashed #34c759;
+  outline-offset: -1px;
+  background: rgba(52, 199, 89, 0.06);
+}
+
 /* Scenario mode indicator */
 .scenario-badge {
   align-self: center;


### PR DESCRIPTION
## Summary

Consolidates the Superpower-tool dev enhancements into a single PR. Supersedes #108 and #109.

### 1. Layout outline toggles (was #108)

Three independent dev-only outline toggles added to the Superpower toolbar (next to the existing DEV Tag toggle) so the full window / content-box / webview-surface layering is visible at a glance:

| Toggle | Color | What it outlines |
|--------|-------|------------------|
| **App Bounds** | Purple \`#5e5ce6\` | \`.container\` — the element \`useWindowAutoSize\` keeps the Tauri window matched to. |
| **Container** | Red \`#ff3b30\` | Content area inside \`.container\`'s padding (where \`main-col\` + \`visitors-col\` actually render). |
| **Root** | Green \`#34c759\` | \`#root\` — stays at 100% × 100% of the webview, so it differs from \`.container\` when the session dropdown grows the window past the auto-sized content. |

Each toggle has its own session-only hook (\`useDevAppBounds\`, \`useDevContainerBounds\`, \`useDevRootBounds\`) that listens for its \`dev-*-bounds-changed\` event. The Superpower tool emits the initial \`true\` for all three on mount so the outlines turn on the moment dev mode is opened.

### 2. Ultra-long-bubble scenario (was #109)

Adds an **Ultra Long Bubble** preview to the Pet Status scenario grid (Superpower → Scenarios), roughly 2× the length of the existing \"Long Bubble\" case (~156 chars vs 79 chars). Lets the developer eyeball how the speech bubble renders (or overflows) with clearly-too-long messages so wrap/truncate behavior can be tuned.

## Test plan

- [ ] \`bun run tauri dev\`
- [ ] Enable dev mode (click version 10× in Settings) and click the DEV tag to open Superpower
- [ ] All three outlines visible immediately on the main window; toggle each independently
- [ ] Open the session list — green Root outline grows with the window; purple App Bounds and red Container stay put
- [ ] Switch to Scenarios tab → click **Ultra Long Bubble** → confirm the bubble renders with ~156 chars
- [ ] \`npx tsc --noEmit\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)