### PR TITLE
fix(ui): speech bubble wraps long messages instead of overflowing

### DIFF
--- a/src/styles/speech-bubble.css
+++ b/src/styles/speech-bubble.css
@@ -8,6 +8,14 @@
   left: 50%;
   display: inline-flex;
   align-items: center;
+  /* Sizing: the bubble is absolute-positioned inside .mascot-wrap
+     (~128px wide), so the default shrink-to-fit algorithm caps the
+     bubble to that containing block and produces a painfully narrow
+     column. `width: max-content` opts out of shrink-to-fit so the
+     bubble grows to its natural single-line size, and `max-width`
+     wraps longer messages to multiple lines at a reasonable width. */
+  width: max-content;
+  max-width: 280px;
   padding: 8px 14px;
   z-index: 1;
   border-radius: 12px;
@@ -26,14 +34,23 @@
   font-size: 12px;
   font-weight: 500;
   color: var(--text-bubble);
-  line-height: 1;
-  white-space: nowrap;
+  /* line-height > 1 keeps wrapped lines from touching; overflow-wrap
+     lets a single very long token (URL, path, etc.) break only when
+     the word would otherwise overflow — we avoid `word-break:
+     break-word` because it breaks inside normal words too, which
+     produces fragments like "cha/nge/log". */
+  line-height: 1.35;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .speech-bubble-tail {
+  /* Centered on the bubble (which is centered on the pet) so the tail
+     points at the pet's head regardless of how wide the bubble grows. */
   position: absolute;
   bottom: -6px;
-  right: 16px;
+  left: 50%;
+  transform: translateX(-50%);
   width: 0;
   height: 0;
   border-left: 6px solid transparent;


### PR DESCRIPTION
## Summary

Makes the speech bubble wrap long messages to multiple lines instead of extending horizontally past the window.

- \`width: max-content\` + \`max-width: 280px\` — bubble grows to its natural single-line width up to the cap, then wraps.
- \`white-space: normal\` + \`overflow-wrap: break-word\` (not \`word-break\`) — normal words stay intact; only tokens that would still overflow get broken.
- \`line-height\` 1 → 1.35 for readable multi-line text.
- Tail recentered (\`left:50% + translateX(-50%)\`) so it keeps pointing at the pet regardless of bubble width.

## Known follow-up

At 280px max-width the bubble can still extend past the auto-sized Tauri window. Follow-up PR will grow the window around the bubble when it's visible (session-dropdown-style \`setSize\` + \`setPosition\`) instead of capping the bubble narrower.

## Test plan

- [ ] \`bun run tauri dev\`
- [ ] Superpower → Scenarios → Long Bubble → confirm wraps to 2–3 lines within window
- [ ] Ultra Long Bubble → wraps to 5–6 lines; still flag any residual clipping for the follow-up
- [ ] Short messages (\"Task complete!\", \"Hey!\") still render at natural width, no wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)