### PR TITLE
feat(ui): window auto-grows around the speech bubble

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,3 +98,4 @@ End-to-end flow from shell command to pixel on screen:
 | [Shell Integration](./shell-integration.md) | Hook scripts for zsh, bash, fish |
 | [Setup Flow](./setup-flow.md) | First-launch auto-setup, shell detection |
 | [Peer Discovery](./peer-discovery.md) | mDNS discovery, visit protocol |
+| [Window Sizing](./window-sizing.md) | Root-window baseline (320×250), growth modes (session / visitors / bubble), how to add a new one |

--- a/docs/constants-reference.md
+++ b/docs/constants-reference.md
@@ -78,6 +78,22 @@ All hardcoded values, timeouts, and configurable parameters in the codebase.
 | Log poll interval | 1,000ms | `SuperpowerTool.tsx` | Log viewer refresh rate |
 | Dev mode clicks | 10 | `Settings.tsx` | Clicks on version to enable dev mode |
 
+### Window sizing (see [window-sizing.md](./window-sizing.md) for the full pipeline)
+
+| Constant | Value | File | Purpose |
+|----------|-------|------|---------|
+| `BASELINE_WIDTH` | 320 | `App.tsx` | Root window width floor |
+| `.container` `min-width` | 320 px | `app.css` | CSS-level width floor |
+| `.container` `min-height` | 250 px | `app.css` | CSS-level height floor |
+| `.container.has-visitors` `min-width` | 500 px | `app.css` | Visitor-mode width |
+| Visitor-mode window width | 500 | `App.tsx` (visitor effect) | Explicit `setSize` target while visitors present |
+| `SESSION_DROPDOWN_MIN_WIDTH` | 320 | `App.tsx` | Width floor while session list is open |
+| `SESSION_DROPDOWN_WINDOW_HEIGHT` | 400 | `App.tsx` | Total window height while session list is open |
+| `BASE_PAD_TOP` | 20 | `App.tsx` | Container base top padding (used by bubble math) |
+| `BASE_PAD_HORIZONTAL` | 50 | `App.tsx` | Container base L+R padding (used by bubble math) |
+| `BUBBLE_OVERLAP_PX` | 46 | `App.tsx` | Bubble–sprite overlap in CSS px at scale=1 |
+| `SPRITE_NATIVE_WIDTH` | 128 | `App.tsx` | Pre-scale sprite width |
+
 ### Tauri Store Keys
 
 | Key | Type | Default | Hook |
@@ -93,9 +109,10 @@ All hardcoded values, timeouts, and configurable parameters in the codebase.
 
 | Window | Size | Decorations | Always on Top | Visible |
 |--------|------|-------------|---------------|---------|
-| main | 500x220 | No | Yes | Yes |
-| settings | 620x440 | Yes | No | Hidden |
+| main | 320x250 (baseline, auto-resizes at runtime — see [window-sizing.md](./window-sizing.md)) | No | Yes | Yes |
+| settings | 620x560 | Yes | No | Hidden |
 | superpower | 800x500 | Yes | No | Hidden |
+| peer-list | 280x260 | No | No | Hidden |
 
 ## Environment Variables
 

--- a/docs/window-sizing.md
+++ b/docs/window-sizing.md
@@ -1,0 +1,151 @@
+# Window Sizing & Bounds
+
+The Ani-Mime main window auto-sizes to fit its content, with a stable baseline and named "growth modes" for content that temporarily needs more room (a speech bubble, a session list, visiting pets). This doc is the reference for how that pipeline fits together — read it before touching any `setSize` call or any CSS that affects `.container` dimensions.
+
+## Baseline
+
+**320 × 250** CSS px. Always at least this big, on every platform, in every state.
+
+| Where | What |
+|---|---|
+| `src/styles/app.css` → `.container` | `min-width: 320px; min-height: 250px` |
+| `src-tauri/tauri.conf.json` main window | `width: 320, height: 250` (matches baseline so the first frame paints correctly with no shrink-to-fit flash) |
+| `src/App.tsx` | `BASELINE_WIDTH = 320` constant |
+
+When no growth mode is active the window collapses back to this size.
+
+## Mechanics
+
+The native Tauri window tracks the **container's** layout box.
+
+```
+┌─ Tauri window (native) ──────────────────────┐
+│ #root (100% × 100%, flex)                    │
+│   ┌─ .container (min 320 × 250) ─────────┐   │
+│   │                                       │   │
+│   │   .main-col     .visitors-col         │   │
+│   │                                       │   │
+│   └───────────────────────────────────────┘   │
+└──────────────────────────────────────────────┘
+```
+
+- **`useWindowAutoSize`** (`src/hooks/useWindowAutoSize.ts`) puts a `ResizeObserver` + `MutationObserver` on `.container` and calls `win.setSize(offsetWidth, offsetHeight)` whenever it changes.
+- **`.container` min-width / min-height** sets the floor. `useWindowAutoSize` propagates that to the native window.
+- **`#root`** is always `100% × 100%` — i.e. it matches the webview which matches the Tauri window.
+
+The invariant is: **`window = container`**. Anything that wants to change the window size must change the container size (via CSS / padding), or explicitly call `setSize` while `useWindowAutoSize` is paused.
+
+## Growth modes
+
+Each mode follows the same "session-dropdown pattern":
+
+1. `useWindowAutoSize` is paused for the duration (via a flag in its `paused` argument in `App.tsx`).
+2. An effect in `App.tsx` (or `StatusPill.tsx` for the dropdown's max-height) computes the target size.
+3. `setPosition` + `setSize` are fired together in `Promise.all` so macOS applies both in the same native frame — this is what actually makes the resize land reliably on a `resizable: false` + `transparent: true` window.
+4. `setPosition` shifts by `dx/2` (half the width delta) so the sprite stays visually anchored — the window grows outward from its center instead of from its top-left.
+5. On mode-end, a saved pre-grow position is restored and `setSize` falls back to `container.offsetWidth/Height`.
+
+### Session dropdown
+
+**File:** `src/App.tsx` (the `sessionOpen` effect) + `src/components/StatusPill.tsx` (dropdown max-height).
+
+- Window height → **`max(currentHeight, SESSION_DROPDOWN_WINDOW_HEIGHT)`**, which is **400**.
+- Width is not changed.
+- The dropdown itself is `position: fixed`, inside the window. `StatusPill` computes its `max-height` as `400 - dropdownTop - 10` (bottom margin), so long session lists scroll (`overflow-y: auto`) inside the dropdown instead of running past the window edge.
+- Constant: `SESSION_DROPDOWN_WINDOW_HEIGHT` in `App.tsx`.
+
+### Visitors (1–3 other pets)
+
+**File:** `src/App.tsx` (the `visitors.length` effect).
+
+- Window width → **500** (hardcoded).
+- Window height → `max(250, container.offsetHeight)` — height follows natural content, but never below baseline.
+- The `.container.has-visitors` class (set when `visitors.length > 0`) also lifts `.container`'s `min-width` from 320 → 500 in CSS so layout stays consistent with the native window size.
+
+**Important:** `src/styles/visitor.css` absolute-positions `.visitor-greeting` *above* each `visitor-dog`. If the greeting were in the flex flow, each visitor-dog would grow to the greeting's `max-width` (180–220 px), which would push 3 visitors well past 500. Don't revert that.
+
+### Speech bubble
+
+**File:** `src/App.tsx` (the `visible` / `bubbleExtra` effect) + `src/styles/app.css` + `src/styles/speech-bubble.css`.
+
+The speech bubble is `position: absolute` inside `.mascot-wrap`, so it doesn't contribute to `offsetWidth/Height`. To make the window grow around it:
+
+1. A `useLayoutEffect` measures the rendered bubble with `ResizeObserver` after it mounts.
+2. It computes `extraTop` (height overflow above the sprite) and `extraH` (width overflow past the 320 baseline).
+3. Those values feed two CSS custom properties set inline on `.container`: `--bubble-extra-top` and `--bubble-extra-h`.
+4. `.container`'s padding uses `calc()` to absorb those extras, so `offsetWidth/Height` grows.
+5. A separate `useEffect` drives `setPosition` + `setSize` from the new dimensions and shifts the window position by `(−extraH, −extraTop)` to keep the sprite anchored.
+
+Constants (`App.tsx`): `BASE_PAD_TOP`, `BASE_PAD_HORIZONTAL`, `BUBBLE_OVERLAP_PX`, `SPRITE_NATIVE_WIDTH`, `BASELINE_WIDTH`. If you change the bubble's CSS `max-width` or the `.container` base padding, update these so the math stays consistent.
+
+### How modes combine
+
+They can stack — e.g. a visitor arrives while the session list is open. In that case:
+
+- `useWindowAutoSize` pause condition is an `OR` of all mode flags.
+- Each effect's `return`-early guards prevent the "inner" modes from fighting the "outer" one (session-dropdown explicitly reads `currentWidth` and keeps it, so 500 from visitor mode survives).
+- Restore paths rely on saved positions, so un-stacking restores the correct previous state.
+
+If you add a fourth mode, follow the same rules:
+- Add a pause flag to `useWindowAutoSize`.
+- Use the session-dropdown setSize + setPosition pattern inside a `Promise.all`.
+- Save pre-grow position in a ref; clear it on restore.
+- Consider what happens when another mode is already active (the new mode can read `containerRef.current.offsetWidth/Height` to compute its target relative to the current state, same as session-dropdown does).
+
+## Sprite scale (0.5, 1, 1.5, 2)
+
+Changing the sprite scale (Settings → pet size) only updates the `--sprite-scale` CSS variable on `documentElement`. The sprite grows in CSS, `.container` naturally grows with it (mascot gets wider/taller), `useWindowAutoSize`'s `ResizeObserver` fires, and the window resizes.
+
+No hardcoded per-scale window dimensions anymore (the previous `WINDOW_SIZES` map in `useScale.ts` was removed because it was calling `setSize(500, 220)` at scale=1, which fought the auto-size pipeline).
+
+## Dev outlines (App Bounds / Container / Root)
+
+Visual debugging tool for the sizing pipeline. Enable dev mode (click the Version label 10 times in Settings) and three outlines appear on the main window:
+
+| Toggle | Color | Element |
+|---|---|---|
+| App Bounds | purple `#5e5ce6` | `.container` |
+| Container | red `#ff3b30` | `.container` content area (inside base padding) |
+| Root | green `#34c759` | `#root` (= full webview) |
+
+Hooks: `src/hooks/useDevAppBounds.ts`, `useDevContainerBounds.ts`, `useDevRootBounds.ts`. Each listens to both its own `dev-*-bounds-changed` event (for individual toggling in the Superpower tool) and `dev-mode-changed` (to auto-sync with dev mode).
+
+In `App.tsx` the outline states are gated with `devMode && toggle`, so if dev mode is off, outlines never render — even if a `dev-*-bounds-changed` event leaks in.
+
+## Change recipes
+
+### Change the baseline size
+
+1. `src/styles/app.css` → `.container { min-width: …; min-height: … }`
+2. `src-tauri/tauri.conf.json` → main window `width` / `height` (match baseline)
+3. `src/App.tsx` → update `BASELINE_WIDTH` constant
+4. Check `SESSION_DROPDOWN_MIN_WIDTH` (currently 320) — it's the floor the session effect uses for `max(currentWidth, …)`. Keep ≥ baseline width.
+
+### Change the visitor-mode width
+
+1. `src/App.tsx` → inside the `visitors` effect, change `newWidth = 500`.
+2. `src/styles/app.css` → `.container.has-visitors { min-width: 500px }` — keep in sync.
+
+### Change the session-dropdown height
+
+1. `src/App.tsx` → `SESSION_DROPDOWN_WINDOW_HEIGHT`.
+2. `src/components/StatusPill.tsx` → the `SESSION_WINDOW_HEIGHT` local constant inside the `sessionOpen` effect (same number, used to compute the dropdown's `max-height`).
+
+### Add a new growth mode
+
+See "How modes combine" above. The implementation template is the session-dropdown effect in `App.tsx` — copy its shape.
+
+## Related files
+
+| Path | Responsibility |
+|---|---|
+| `src/hooks/useWindowAutoSize.ts` | Base auto-size pipeline (container → window) |
+| `src/App.tsx` | All growth-mode effects, pause coordination, constants |
+| `src/components/StatusPill.tsx` | Session dropdown's max-height |
+| `src/hooks/useBubble.ts` | Speech bubble state source |
+| `src/hooks/useVisitors.ts` | Visitor state source (with Strict-Mode dedup) |
+| `src/hooks/useScale.ts` | Sprite scale — writes CSS var only |
+| `src/styles/app.css` | `.container` baseline + `.has-visitors` + dev-outline CSS |
+| `src/styles/speech-bubble.css` | Bubble sizing, absolute position, animation |
+| `src/styles/visitor.css` | Visitor-dog layout, absolute-positioned greeting |
+| `src-tauri/tauri.conf.json` | Native initial size |

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,23 +204,28 @@ fn preview_dialog(dialog_id: String, app: tauri::AppHandle) {
 #[tauri::command]
 fn request_local_network() {
     crate::app_log!("[app] request_local_network permission trigger");
-    // Attempt an mDNS browse — this triggers the macOS Local Network permission prompt
-    // if the user hasn't been asked yet. If already denied, open System Preferences.
-    std::thread::spawn(|| {
-        match mdns_sd::ServiceDaemon::new() {
-            Ok(mdns) => {
-                let _ = mdns.browse("_ani-mime._tcp.local.");
-                // Keep daemon alive briefly so the OS has time to show the prompt
-                std::thread::sleep(std::time::Duration::from_secs(2));
-                let _ = mdns.shutdown();
-                crate::app_log!("[app] local network permission probe completed");
-            }
-            Err(e) => {
-                crate::app_warn!("[app] mDNS probe failed ({}), opening system settings", e);
-                platform::open_local_network_settings();
-            }
+    // 1. Fire an mDNS browse on a background thread — if the user has
+    //    not been prompted yet, macOS shows the Local Network prompt.
+    //    If they've already been prompted (granted OR denied), this is
+    //    a no-op and macOS shows nothing.
+    // 2. Open System Settings → Privacy & Security → Local Network
+    //    unconditionally. When the OS shows the prompt, this is a
+    //    slight duplication (both appear). When the prompt path is
+    //    dead (already answered), opening settings gives the user a
+    //    direct path to the toggle instead of a silent click.
+    std::thread::spawn(|| match mdns_sd::ServiceDaemon::new() {
+        Ok(mdns) => {
+            let _ = mdns.browse("_ani-mime._tcp.local.");
+            // Keep daemon alive briefly so the OS has time to show the prompt
+            std::thread::sleep(std::time::Duration::from_secs(2));
+            let _ = mdns.shutdown();
+            crate::app_log!("[app] local network permission probe completed");
+        }
+        Err(e) => {
+            crate::app_warn!("[app] mDNS probe failed ({})", e);
         }
     });
+    platform::open_local_network_settings();
 }
 
 #[tauri::command]

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -169,9 +169,51 @@ pub fn show_choose_list(title: &str, message: &str, items: &[&str]) -> Vec<Strin
 
 /// Open System Settings → Privacy & Security → Local Network so the user can
 /// grant mDNS permission manually when the first-run probe was denied.
+///
+/// The `x-apple.systempreferences:` URL scheme opens the right pane but
+/// — starting with Sonoma — silently ignores the `?Privacy_LocalNetwork`
+/// anchor, leaving the user at the top of Privacy & Security. AppleScript
+/// `reveal anchor` still works and actually scrolls the view to the
+/// Local Network row, so we use osascript as the primary path and fall
+/// back to the URL scheme only if scripting the app fails (e.g. if
+/// System Settings isn't automation-approved yet).
 pub fn open_local_network_settings() {
+    // Ventura+ — app is called "System Settings", pane lives under
+    // com.apple.settings.PrivacySecurity.extension
+    let modern = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(
+            r#"tell application "System Settings"
+    activate
+    reveal anchor "Privacy_LocalNetwork" of pane id "com.apple.settings.PrivacySecurity.extension"
+end tell"#,
+        )
+        .status();
+
+    if matches!(modern, Ok(s) if s.success()) {
+        return;
+    }
+
+    // Monterey and older — app is "System Preferences", pane is
+    // com.apple.preference.security. The anchor does still scroll on
+    // this older stack.
+    let legacy = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(
+            r#"tell application "System Preferences"
+    activate
+    reveal anchor "Privacy_LocalNetwork" of pane id "com.apple.preference.security"
+end tell"#,
+        )
+        .status();
+
+    if matches!(legacy, Ok(s) if s.success()) {
+        return;
+    }
+
+    // Last-ditch fallback — open the pane even if we can't reach the row.
     let _ = std::process::Command::new("open")
-        .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_LocalNetwork")
+        .arg("x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_LocalNetwork")
         .spawn();
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
     "windows": [
       {
         "title": "Ani-Mime",
-        "width": 250,
+        "width": 320,
         "height": 220,
         "resizable": false,
         "fullscreen": false,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
       {
         "title": "Ani-Mime",
         "width": 320,
-        "height": 220,
+        "height": 250,
         "resizable": false,
         "fullscreen": false,
         "alwaysOnTop": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,13 +25,12 @@ import {
 import "./styles/theme.css";
 import "./styles/app.css";
 
-// Extra height to add to the widget window while the fixed-positioned
-// session-list dropdown is open. Gives the dropdown room to render
-// without being clipped (the dropdown itself is position: fixed so it
-// doesn't inflate the container, which means useWindowAutoSize would
-// otherwise leave the window at its compact size). 300 = dropdown
-// max-height (280px) + top gap (6) + shadow buffer (~14).
-const SESSION_DROPDOWN_EXTRA_HEIGHT = 300;
+// Total window height while the session-list dropdown is open.
+// The dropdown itself is position: fixed so it doesn't inflate the
+// container; StatusPill caps the dropdown's max-height to
+// (this value - dropdownTop - bottom margin) so long lists scroll
+// inside this budget instead of running past the window edge.
+const SESSION_DROPDOWN_WINDOW_HEIGHT = 400;
 const SESSION_DROPDOWN_MIN_WIDTH = 320;
 
 // Base container padding, duplicated from app.css. Used by the bubble
@@ -57,9 +56,17 @@ function App() {
   const visitors = useVisitors();
   const { scale } = useScale();
   const devMode = useDevMode();
-  const devAppBounds = useDevAppBounds();
-  const devContainerBounds = useDevContainerBounds();
-  const devRootBounds = useDevRootBounds();
+  const appBoundsToggle = useDevAppBounds();
+  const containerBoundsToggle = useDevContainerBounds();
+  const rootBoundsToggle = useDevRootBounds();
+  // Outline visibility is gated behind dev mode so the outlines never
+  // show for normal users: toggling them individually in the Superpower
+  // tool is only meaningful while dev mode is active. If dev mode is
+  // ever turned off, all three outlines hide regardless of their
+  // individual toggle state.
+  const devAppBounds = devMode && appBoundsToggle;
+  const devContainerBounds = devMode && containerBoundsToggle;
+  const devRootBounds = devMode && rootBoundsToggle;
 
   // #root lives in the HTML template outside React's tree, so we toggle
   // its class imperatively when the dev toggle flips.
@@ -91,9 +98,13 @@ function App() {
   // useWindowAutoSize so it doesn't race our setSize/setPosition.
   const bubbleGrowActive = visible && (bubbleExtra.top > 0 || bubbleExtra.horizontal > 0);
   useTheme();
+  // Pause useWindowAutoSize while visitors are present — the visitor
+  // effect below owns the window size in that mode (fixed 500 wide)
+  // and useWindowAutoSize would otherwise shrink back to whatever
+  // container.offsetWidth reports.
   useWindowAutoSize(
     containerRef,
-    effectActive || sessionOpen || sessionClosing || bubbleGrowActive
+    effectActive || sessionOpen || sessionClosing || bubbleGrowActive || visitors.length > 0
   );
 
   // Measure the rendered speech bubble (via ResizeObserver) and compute
@@ -212,6 +223,81 @@ function App() {
     }
   }, [visible, bubbleExtra, sessionOpen, sessionClosing]);
 
+  // Visitor count change → drive the window size directly.
+  //
+  // With visitors: window fixed at 500 wide × max(250, content-height).
+  // Without visitors: hand control back to useWindowAutoSize, which
+  // will resize to container.offsetWidth (>= 320 via min-width) on
+  // its next ResizeObserver tick.
+  //
+  // requestAnimationFrame waits one frame so React/CSS have committed
+  // the new layout (visitor-col mounted/unmounted) before we measure.
+  // Saved position when visitor mode grows the window, restored on
+  // last-visitor-leaves. Parallel to savedPosRef used by the session
+  // dropdown effect.
+  const visitorSavedPosRef = useRef<LogicalPosition | null>(null);
+
+  // When visitors arrive, grow the window to 500px wide and shift it
+  // left by half the delta so the sprite stays visually anchored —
+  // same pattern the session-dropdown effect uses for its own resize.
+  // On the last visitor leaving, restore the saved position and let
+  // the container's natural (min-width 320) size take over via setSize.
+  useEffect(() => {
+    const win = getCurrentWindow();
+
+    if (visitors.length > 0) {
+      const el = containerRef.current;
+      if (!el) return;
+      const currentWidth = el.offsetWidth;
+      const currentHeight = el.offsetHeight;
+      const newWidth = 500;
+      const newHeight = Math.max(250, currentHeight);
+      const dx = newWidth - currentWidth;
+
+      void (async () => {
+        try {
+          const sf = await win.scaleFactor();
+          const pos = await win.outerPosition();
+          const logical = pos.toLogical(sf);
+          const origX = Math.round(logical.x);
+          const origY = Math.round(logical.y);
+          if (!visitorSavedPosRef.current) {
+            visitorSavedPosRef.current = new LogicalPosition(origX, origY);
+          }
+          await Promise.all([
+            win.setPosition(
+              new LogicalPosition(origX - Math.round(dx / 2), origY)
+            ),
+            win.setSize(new LogicalSize(newWidth, newHeight)),
+          ]);
+        } catch (err) {
+          console.error("[visitors] grow failed:", err);
+        }
+      })();
+      return;
+    }
+
+    // Restore path
+    const savedPos = visitorSavedPosRef.current;
+    if (!savedPos) return;
+    visitorSavedPosRef.current = null;
+
+    void (async () => {
+      try {
+        const el = containerRef.current;
+        const ops: Promise<void>[] = [win.setPosition(savedPos)];
+        if (el) {
+          ops.push(
+            win.setSize(new LogicalSize(el.offsetWidth, el.offsetHeight))
+          );
+        }
+        await Promise.all(ops);
+      } catch (err) {
+        console.error("[visitors] restore failed:", err);
+      }
+    })();
+  }, [visitors.length]);
+
   // When the dropdown opens the window grows wider (>= SESSION_DROPDOWN_MIN_WIDTH).
   // Because #root centers its content, a wider window visibly shifts the
   // pet + pill rightward. To keep the pet visually anchored we also move
@@ -231,7 +317,10 @@ function App() {
       const currentWidth = el.offsetWidth;
       const currentHeight = el.offsetHeight;
       const newWidth = Math.max(currentWidth, SESSION_DROPDOWN_MIN_WIDTH);
-      const newHeight = currentHeight + SESSION_DROPDOWN_EXTRA_HEIGHT;
+      // Cap total window height at SESSION_DROPDOWN_WINDOW_HEIGHT (400).
+      // Uses max() so taller pre-existing content (e.g. a multi-line
+      // bubble) keeps its height rather than being squeezed.
+      const newHeight = Math.max(currentHeight, SESSION_DROPDOWN_WINDOW_HEIGHT);
       const dx = newWidth - currentWidth;
 
       void (async () => {
@@ -286,12 +375,18 @@ function App() {
     <div
       ref={containerRef}
       data-testid="app-container"
-      className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${devAppBounds ? "dev-bounds" : ""} ${devContainerBounds ? "dev-container-bounds" : ""}`}
+      className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${visitors.length > 0 ? "has-visitors" : ""} ${devAppBounds ? "dev-bounds" : ""} ${devContainerBounds ? "dev-container-bounds" : ""}`}
       style={{
         // Driven by the bubble measurement effect above. 0 when the
         // bubble is hidden or fits in the default padding.
         "--bubble-extra-top": `${bubbleExtra.top}px`,
         "--bubble-extra-h": `${bubbleExtra.horizontal}px`,
+        // Enforced inline (as well as via .has-visitors CSS rule) to
+        // guarantee the highest specificity wins: whichever stylesheet
+        // ordering or hot-reload state we're in, the min-width here
+        // is authoritative.
+        minWidth: visitors.length > 0 ? "500px" : "320px",
+        minHeight: "250px",
       } as React.CSSProperties}
       onMouseDown={onMouseDown}
     >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,16 +37,18 @@ const SESSION_DROPDOWN_MIN_WIDTH = 320;
 // Base container padding, duplicated from app.css. Used by the bubble
 // window-grow logic to compute how much extra padding the container
 // needs so the bubble fits inside the window without clipping.
-const BASE_PAD_LEFT = 20;
 const BASE_PAD_TOP = 20;
+const BASE_PAD_HORIZONTAL = 50; // padding-left + padding-right base
 // The bubble overlaps the top 46*scale px of the sprite (see
 // speech-bubble.css `bottom` calc). Anything taller than the overlap
 // plus the container's base top padding needs extra vertical room.
 const BUBBLE_OVERLAP_PX = 46;
-// Half the sprite's native frame — the bubble is centered on the
-// sprite's horizontal midpoint, so half of the sprite width is the
-// horizontal budget before the bubble overflows the container edge.
-const SPRITE_HALF_PX = 64;
+// The sprite's native frame width (css px, pre-scale).
+const SPRITE_NATIVE_WIDTH = 128;
+// Baseline root width — see app.css .container min-width. The bubble
+// grow effect only kicks in horizontally when the bubble exceeds this,
+// because anything narrower already fits inside the min-width baseline.
+const BASELINE_WIDTH = 320;
 
 function App() {
   const { status, scenario } = useStatus();
@@ -113,15 +115,20 @@ function App() {
 
     const recompute = () => {
       const rect = el.getBoundingClientRect();
-      // Horizontal: bubble is centered on the sprite. Budget before
-      // overflow = SPRITE_HALF_PX * scale (distance from mascot center
-      // to mascot edge) + BASE_PAD_LEFT (distance from mascot edge to
-      // container edge). We add the same extraH to both left and right
-      // padding so the bubble stays centered.
-      const extraH = Math.max(
-        0,
-        Math.ceil(rect.width / 2 - SPRITE_HALF_PX * scale - BASE_PAD_LEFT)
-      );
+      // Horizontal: container is centered (justify-content: center) and
+      // guaranteed BASELINE_WIDTH by min-width, so any bubble that fits
+      // within 320px needs zero extras. For wider bubbles we add enough
+      // padding to push `content + padding` past min-width and match
+      // the bubble's actual width, split evenly across both sides.
+      const extraH =
+        rect.width > BASELINE_WIDTH
+          ? Math.max(
+              0,
+              Math.ceil(
+                (rect.width - SPRITE_NATIVE_WIDTH * scale - BASE_PAD_HORIZONTAL) / 2
+              )
+            )
+          : 0;
       // Vertical: bubble bottom is at BUBBLE_OVERLAP_PX * scale below
       // the mascot top. Budget above = overlap + BASE_PAD_TOP.
       const extraTop = Math.max(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { useDevAppBounds } from "./hooks/useDevAppBounds";
 import { useDevContainerBounds } from "./hooks/useDevContainerBounds";
 import { useDevRootBounds } from "./hooks/useDevRootBounds";
 import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   getCurrentWindow,
   LogicalPosition,
@@ -33,6 +33,20 @@ import "./styles/app.css";
 // max-height (280px) + top gap (6) + shadow buffer (~14).
 const SESSION_DROPDOWN_EXTRA_HEIGHT = 300;
 const SESSION_DROPDOWN_MIN_WIDTH = 320;
+
+// Base container padding, duplicated from app.css. Used by the bubble
+// window-grow logic to compute how much extra padding the container
+// needs so the bubble fits inside the window without clipping.
+const BASE_PAD_LEFT = 20;
+const BASE_PAD_TOP = 20;
+// The bubble overlaps the top 46*scale px of the sprite (see
+// speech-bubble.css `bottom` calc). Anything taller than the overlap
+// plus the container's base top padding needs extra vertical room.
+const BUBBLE_OVERLAP_PX = 46;
+// Half the sprite's native frame — the bubble is centered on the
+// sprite's horizontal midpoint, so half of the sprite width is the
+// horizontal budget before the bubble overflows the container edge.
+const SPRITE_HALF_PX = 64;
 
 function App() {
   const { status, scenario } = useStatus();
@@ -64,11 +78,132 @@ function App() {
   // Window position captured when the dropdown opens, restored on close.
   // Keeping this as a ref avoids triggering a re-render when we record it.
   const savedPosRef = useRef<LogicalPosition | null>(null);
+  // Extra padding the container needs so a multi-line / wide bubble
+  // fits inside the window without clipping. Driven by a ResizeObserver
+  // on the bubble; applied via CSS vars on .container.
+  const [bubbleExtra, setBubbleExtra] = useState<{ top: number; horizontal: number }>({ top: 0, horizontal: 0 });
+  // Window position recorded at the moment the bubble first starts
+  // growing the window, used to restore position on hide.
+  const bubbleSavedPosRef = useRef<LogicalPosition | null>(null);
+  // True while our bubble effect owns the window geometry — pauses
+  // useWindowAutoSize so it doesn't race our setSize/setPosition.
+  const bubbleGrowActive = visible && (bubbleExtra.top > 0 || bubbleExtra.horizontal > 0);
   useTheme();
   useWindowAutoSize(
     containerRef,
-    effectActive || sessionOpen || sessionClosing
+    effectActive || sessionOpen || sessionClosing || bubbleGrowActive
   );
+
+  // Measure the rendered speech bubble (via ResizeObserver) and compute
+  // how much extra container padding is needed so the bubble fits
+  // inside the window. Extras are applied via CSS variables (see
+  // `.container` in app.css) so `container.offsetWidth/offsetHeight`
+  // reflects the new size — that's what the window-grow effect reads
+  // to compute the setSize target.
+  useLayoutEffect(() => {
+    if (!visible) {
+      setBubbleExtra((prev) =>
+        prev.top === 0 && prev.horizontal === 0 ? prev : { top: 0, horizontal: 0 }
+      );
+      return;
+    }
+
+    const el = document.querySelector<HTMLDivElement>('[data-testid="speech-bubble"]');
+    if (!el) return;
+
+    const recompute = () => {
+      const rect = el.getBoundingClientRect();
+      // Horizontal: bubble is centered on the sprite. Budget before
+      // overflow = SPRITE_HALF_PX * scale (distance from mascot center
+      // to mascot edge) + BASE_PAD_LEFT (distance from mascot edge to
+      // container edge). We add the same extraH to both left and right
+      // padding so the bubble stays centered.
+      const extraH = Math.max(
+        0,
+        Math.ceil(rect.width / 2 - SPRITE_HALF_PX * scale - BASE_PAD_LEFT)
+      );
+      // Vertical: bubble bottom is at BUBBLE_OVERLAP_PX * scale below
+      // the mascot top. Budget above = overlap + BASE_PAD_TOP.
+      const extraTop = Math.max(
+        0,
+        Math.ceil(rect.height - BUBBLE_OVERLAP_PX * scale - BASE_PAD_TOP)
+      );
+      setBubbleExtra((prev) =>
+        prev.top === extraTop && prev.horizontal === extraH
+          ? prev
+          : { top: extraTop, horizontal: extraH }
+      );
+    };
+
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [visible, scale]);
+
+  // Grow the window around the bubble so it doesn't clip at the window
+  // edge, and keep the sprite visually anchored by shifting window
+  // position by the same deltas. Mirrors the session-dropdown pattern
+  // above; skipped while the session is resizing the window so the
+  // two effects don't fight.
+  useEffect(() => {
+    if (sessionOpen || sessionClosing) return;
+
+    const win = getCurrentWindow();
+    const { top: extraTop, horizontal: extraH } = bubbleExtra;
+    const shouldGrow = visible && (extraTop > 0 || extraH > 0);
+
+    if (shouldGrow) {
+      void (async () => {
+        try {
+          const el = containerRef.current;
+          if (!el) return;
+
+          if (!bubbleSavedPosRef.current) {
+            const sf = await win.scaleFactor();
+            const pos = await win.outerPosition();
+            const logical = pos.toLogical(sf);
+            bubbleSavedPosRef.current = new LogicalPosition(
+              Math.round(logical.x),
+              Math.round(logical.y)
+            );
+          }
+          const savedPos = bubbleSavedPosRef.current;
+          const newWidth = el.offsetWidth;
+          const newHeight = el.offsetHeight;
+
+          await Promise.all([
+            win.setPosition(
+              new LogicalPosition(savedPos.x - extraH, savedPos.y - extraTop)
+            ),
+            win.setSize(new LogicalSize(newWidth, newHeight)),
+          ]);
+        } catch (err) {
+          console.error("[bubble-grow] resize failed:", err);
+        }
+      })();
+      return;
+    }
+
+    if (bubbleSavedPosRef.current) {
+      const savedPos = bubbleSavedPosRef.current;
+      bubbleSavedPosRef.current = null;
+      void (async () => {
+        try {
+          const el = containerRef.current;
+          const ops: Promise<void>[] = [win.setPosition(savedPos)];
+          if (el) {
+            ops.push(
+              win.setSize(new LogicalSize(el.offsetWidth, el.offsetHeight))
+            );
+          }
+          await Promise.all(ops);
+        } catch (err) {
+          console.error("[bubble-grow] restore failed:", err);
+        }
+      })();
+    }
+  }, [visible, bubbleExtra, sessionOpen, sessionClosing]);
 
   // When the dropdown opens the window grows wider (>= SESSION_DROPDOWN_MIN_WIDTH).
   // Because #root centers its content, a wider window visibly shifts the
@@ -145,6 +280,12 @@ function App() {
       ref={containerRef}
       data-testid="app-container"
       className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${devAppBounds ? "dev-bounds" : ""} ${devContainerBounds ? "dev-container-bounds" : ""}`}
+      style={{
+        // Driven by the bubble measurement effect above. 0 when the
+        // bubble is hidden or fits in the default padding.
+        "--bubble-extra-top": `${bubbleExtra.top}px`,
+        "--bubble-extra-h": `${bubbleExtra.horizontal}px`,
+      } as React.CSSProperties}
       onMouseDown={onMouseDown}
     >
       <div className="main-col">

--- a/src/components/DevBuildBadge.tsx
+++ b/src/components/DevBuildBadge.tsx
@@ -1,12 +1,22 @@
 import "../styles/dev-build-badge.css";
 
 /** Renders only in `bun run tauri dev` builds — Vite sets
- *  `import.meta.env.DEV` to true there and false for `vite build` (release). */
+ *  `import.meta.env.DEV` to true there and false for `vite build` (release).
+ *  Hover shows a guideline tooltip that tells the developer how to unlock
+ *  the Superpower tool: click the Version label in Settings 10 times. */
 export function DevBuildBadge() {
   if (!import.meta.env.DEV) return null;
   return (
-    <div className="dev-build-badge" data-testid="dev-build-badge" aria-hidden="true">
+    <div
+      className="dev-build-badge"
+      data-testid="dev-build-badge"
+      role="tooltip"
+      aria-label="Click the Version label in Settings 10 times to enable the Superpower debug tool"
+    >
       DEV
+      <span className="dev-build-badge-tip" aria-hidden="true">
+        Click <strong>Version</strong> in Settings <strong>10×</strong> to unlock <strong>Superpower</strong>.
+      </span>
     </div>
   );
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -622,7 +622,11 @@ export function Settings() {
               <div className="settings-row with-hint">
                 <div>
                   <span className="settings-row-label">Local Network Access</span>
-                  <span className="settings-row-hint">Required for peer visits. Grant permission so nearby pets can discover each other.</span>
+                  <span className="settings-row-hint">
+                    Required for peer visits so nearby pets can discover each other. <br/><br/>
+                    Clicking opens <strong>System Settings → Privacy &amp; Security</strong> —
+                    scroll to <strong>Local Network</strong> and enable the toggle for <strong>Ani-Mime</strong>.
+                  </span>
                 </div>
                 <button
                   className="settings-action-btn"

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -227,6 +227,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
   const [sessionOpen, setSessionOpen] = useState(false);
   const [groups, setGroups] = useState<Group[]>([]);
   const [dropdownTop, setDropdownTop] = useState(0);
+  const [dropdownMaxHeight, setDropdownMaxHeight] = useState(280);
   const wrapRef = useRef<HTMLDivElement>(null);
   const { enabled: sessionListEnabled } = useSessionList();
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
@@ -264,7 +265,18 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
     if (!sessionOpen) return;
     const rect = wrapRef.current?.getBoundingClientRect();
     if (!rect) return;
-    setDropdownTop(rect.bottom + 6);
+    const top = rect.bottom + 6;
+    setDropdownTop(top);
+    // The window grows to 400 tall when the session list opens (see
+    // SESSION_DROPDOWN_WINDOW_HEIGHT in App.tsx). Cap the dropdown's
+    // max-height so it fits between `top` and the window's bottom —
+    // the 10px tail leaves room for the shadow buffer. overflow-y:auto
+    // (in status-pill.css) scrolls when the list is taller.
+    const SESSION_WINDOW_HEIGHT = 400;
+    const BOTTOM_MARGIN = 10;
+    setDropdownMaxHeight(
+      Math.max(120, SESSION_WINDOW_HEIGHT - top - BOTTOM_MARGIN)
+    );
   }, [sessionOpen]);
 
   const toggleSession = async (e: React.MouseEvent) => {
@@ -484,7 +496,10 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
           data-testid="session-dropdown"
           className="session-dropdown"
           role="menu"
-          style={{ top: `${dropdownTop}px` }}
+          style={{
+            top: `${dropdownTop}px`,
+            maxHeight: `${dropdownMaxHeight}px`,
+          }}
         >
           {groups.length === 0 ? (
             <div className="session-empty">No active terminals</div>

--- a/src/hooks/useDevAppBounds.ts
+++ b/src/hooks/useDevAppBounds.ts
@@ -4,17 +4,26 @@ import { listen } from "@tauri-apps/api/event";
 /**
  * Session-only dev toggle: when true, the main window draws a visible
  * outline + tint so the developer can see the exact bounds of the app
- * area (= the auto-sized Tauri window). Starts off on every launch.
+ * area (= the auto-sized Tauri window).
+ *
+ * Auto-synced with dev mode: enabling dev mode turns this on, and
+ * disabling dev mode turns it off. The Superpower tool can still
+ * individually toggle it via `dev-app-bounds-changed` while dev mode
+ * is active.
  */
 export function useDevAppBounds() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const unlisten = listen<boolean>("dev-app-bounds-changed", (e) => {
+    const unlistenOutline = listen<boolean>("dev-app-bounds-changed", (e) => {
+      setVisible(Boolean(e.payload));
+    });
+    const unlistenDevMode = listen<boolean>("dev-mode-changed", (e) => {
       setVisible(Boolean(e.payload));
     });
     return () => {
-      unlisten.then((fn) => fn());
+      unlistenOutline.then((fn) => fn());
+      unlistenDevMode.then((fn) => fn());
     };
   }, []);
 

--- a/src/hooks/useDevContainerBounds.ts
+++ b/src/hooks/useDevContainerBounds.ts
@@ -6,16 +6,25 @@ import { listen } from "@tauri-apps/api/event";
  * outline around the container's content area (inside the padding that
  * reserves space for the status-pill neon glow) so the developer can
  * see where the actual UI content sits vs. the full window bounds.
+ *
+ * Auto-synced with dev mode: enabling dev mode turns this on, and
+ * disabling dev mode turns it off. The Superpower tool can still
+ * individually toggle it via `dev-container-bounds-changed` while
+ * dev mode is active.
  */
 export function useDevContainerBounds() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const unlisten = listen<boolean>("dev-container-bounds-changed", (e) => {
+    const unlistenOutline = listen<boolean>("dev-container-bounds-changed", (e) => {
+      setVisible(Boolean(e.payload));
+    });
+    const unlistenDevMode = listen<boolean>("dev-mode-changed", (e) => {
       setVisible(Boolean(e.payload));
     });
     return () => {
-      unlisten.then((fn) => fn());
+      unlistenOutline.then((fn) => fn());
+      unlistenDevMode.then((fn) => fn());
     };
   }, []);
 

--- a/src/hooks/useDevRootBounds.ts
+++ b/src/hooks/useDevRootBounds.ts
@@ -6,16 +6,25 @@ import { listen } from "@tauri-apps/api/event";
  * React mount node that always fills the Tauri webview (100% × 100%),
  * so it reveals the full window surface even when the session dropdown
  * temporarily grows the window past the auto-sized container.
+ *
+ * Auto-synced with dev mode: enabling dev mode turns this on, and
+ * disabling dev mode turns it off. The Superpower tool can still
+ * individually toggle it via `dev-root-bounds-changed` while dev
+ * mode is active.
  */
 export function useDevRootBounds() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const unlisten = listen<boolean>("dev-root-bounds-changed", (e) => {
+    const unlistenOutline = listen<boolean>("dev-root-bounds-changed", (e) => {
+      setVisible(Boolean(e.payload));
+    });
+    const unlistenDevMode = listen<boolean>("dev-mode-changed", (e) => {
       setVisible(Boolean(e.payload));
     });
     return () => {
-      unlisten.then((fn) => fn());
+      unlistenOutline.then((fn) => fn());
+      unlistenDevMode.then((fn) => fn());
     };
   }, []);
 

--- a/src/hooks/useScale.ts
+++ b/src/hooks/useScale.ts
@@ -1,8 +1,6 @@
 import { useState, useLayoutEffect, useEffect } from "react";
 import { load } from "@tauri-apps/plugin-store";
 import { emit, listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
-import { LogicalSize } from "@tauri-apps/api/dpi";
 
 const STORE_FILE = "settings.json";
 const STORE_KEY = "displayScale";
@@ -11,23 +9,16 @@ export type DisplayScale = 0.5 | 1 | 1.5 | 2;
 
 const SCALE_PRESETS: DisplayScale[] = [0.5, 1, 1.5, 2];
 
-const WINDOW_SIZES: Record<number, { width: number; height: number }> = {
-  0.5: { width: 300, height: 140 },
-  1: { width: 500, height: 220 },
-  1.5: { width: 400, height: 280 },
-  2: { width: 450, height: 350 },
-};
-
 function applyScale(scale: number) {
   document.documentElement.style.setProperty("--sprite-scale", String(scale));
 }
 
-async function resizeMainWindow(scale: number) {
-  const win = getCurrentWindow();
-  if (win.label !== "main") return;
-  const size = WINDOW_SIZES[scale] ?? WINDOW_SIZES[1];
-  await win.setSize(new LogicalSize(size.width, size.height));
-}
+// Window size is no longer driven from here — useWindowAutoSize watches
+// .container and resizes the window to match content (which grows with
+// the sprite scale via the CSS --sprite-scale variable). Previously this
+// hook set fixed per-scale sizes (scale=1 → 500x220) which fought the
+// min-width: 320 baseline and caused the window to snap back to 500
+// after any content-driven resize.
 
 export function useScale() {
   const [scale, setScaleState] = useState<DisplayScale>(1);
@@ -38,7 +29,6 @@ export function useScale() {
         const s = SCALE_PRESETS.includes(saved as DisplayScale) ? (saved as DisplayScale) : 1;
         setScaleState(s);
         applyScale(s);
-        resizeMainWindow(s);
       });
     });
   }, []);
@@ -47,7 +37,6 @@ export function useScale() {
     const unlisten = listen<DisplayScale>("scale-changed", (event) => {
       setScaleState(event.payload);
       applyScale(event.payload);
-      resizeMainWindow(event.payload);
     });
 
     return () => {
@@ -58,7 +47,6 @@ export function useScale() {
   const setScale = async (next: DisplayScale) => {
     setScaleState(next);
     applyScale(next);
-    resizeMainWindow(next);
     const store = await load(STORE_FILE);
     await store.set(STORE_KEY, next);
     await store.save();

--- a/src/hooks/useVisitors.ts
+++ b/src/hooks/useVisitors.ts
@@ -15,7 +15,15 @@ export function useVisitors() {
 
   useEffect(() => {
     const unlistenArrived = listen<Visitor>("visitor-arrived", (e) => {
-      setVisitors((prev) => [...prev, e.payload]);
+      // Dedupe by instance_name — the listener briefly doubles up under
+      // React Strict Mode's useEffect double-invoke, so a single arrival
+      // event would otherwise add the same visitor twice.
+      setVisitors((prev) => {
+        if (prev.some((v) => v.instance_name === e.payload.instance_name)) {
+          return prev;
+        }
+        return [...prev, e.payload];
+      });
     });
 
     const unlistenLeft = listen<{ instance_name: string; nickname: string }>("visitor-left", (e) => {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -36,13 +36,22 @@ body {
   user-select: none;
   -webkit-user-select: none;
   position: relative;
+  /* 320px is the baseline "root" width. useWindowAutoSize reads
+     offsetWidth, so enforcing a min-width here guarantees the Tauri
+     window is always at least 320px after any transient growth
+     (session dropdown, bubble grow) collapses. */
+  min-width: 320px;
+  /* Center main-col (and visitors-col, when present) horizontally
+     inside the 320px baseline so the sprite sits at the window's
+     midpoint instead of flex-starting at the left. */
+  justify-content: center;
   /* Padding has two jobs:
      - Base values (20 / 30 / 30 / 20) reserve room for the status pill's
        neon-glow box-shadow — offsetWidth doesn't include box-shadow, so
        without this reserve the glow gets clipped by the Tauri window.
      - --bubble-extra-top and --bubble-extra-h are set from App.tsx when
-       the speech bubble grows beyond its default footprint. Adding them
-       here makes the container grow the same amount, which (paired with
+       the speech bubble is WIDER than the 320px baseline. Adding them
+       here pushes content + padding past min-width, which (paired with
        the setSize + setPosition effect in App.tsx) expands the Tauri
        window around the bubble without jittering the sprite. */
   padding-top: calc(20px + var(--bubble-extra-top, 0px));

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -36,10 +36,19 @@ body {
   user-select: none;
   -webkit-user-select: none;
   position: relative;
-  /* Right/bottom/top padding gives the status pill's neon-glow box-shadow
-     room to render — the window auto-sizes to offsetWidth/Height, which
-     does NOT include box-shadow, so without this the glow is clipped. */
-  padding: 20px 30px 30px 20px;
+  /* Padding has two jobs:
+     - Base values (20 / 30 / 30 / 20) reserve room for the status pill's
+       neon-glow box-shadow — offsetWidth doesn't include box-shadow, so
+       without this reserve the glow gets clipped by the Tauri window.
+     - --bubble-extra-top and --bubble-extra-h are set from App.tsx when
+       the speech bubble grows beyond its default footprint. Adding them
+       here makes the container grow the same amount, which (paired with
+       the setSize + setPosition effect in App.tsx) expands the Tauri
+       window around the bubble without jittering the sprite. */
+  padding-top: calc(20px + var(--bubble-extra-top, 0px));
+  padding-right: calc(30px + var(--bubble-extra-h, 0px));
+  padding-bottom: 30px;
+  padding-left: calc(20px + var(--bubble-extra-h, 0px));
 }
 
 .main-col {
@@ -82,10 +91,13 @@ body {
 .container.dev-container-bounds::before {
   content: "";
   position: absolute;
-  top: 20px;
-  right: 30px;
+  /* Track the same padding formulas the container uses, so when the
+     bubble-extra vars grow the padding, the content-bounds overlay
+     grows with them and keeps marking the real content box. */
+  top: calc(20px + var(--bubble-extra-top, 0px));
+  right: calc(30px + var(--bubble-extra-h, 0px));
   bottom: 30px;
-  left: 20px;
+  left: calc(20px + var(--bubble-extra-h, 0px));
   outline: 1px dashed #ff3b30;
   outline-offset: -1px;
   background: rgba(255, 59, 48, 0.06);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -36,11 +36,16 @@ body {
   user-select: none;
   -webkit-user-select: none;
   position: relative;
-  /* 320px is the baseline "root" width. useWindowAutoSize reads
-     offsetWidth, so enforcing a min-width here guarantees the Tauri
-     window is always at least 320px after any transient growth
-     (session dropdown, bubble grow) collapses. */
+  /* 320 × 250 is the baseline "root" size. useWindowAutoSize reads
+     offsetWidth/offsetHeight, so enforcing both min-width and
+     min-height here guarantees the Tauri window is always at least
+     320 × 250 after any transient growth (session dropdown, bubble
+     grow) collapses.
+     While visitors are present the baseline widens to 500 (see
+     .container.has-visitors below) so 1–3 visiting pets fit without
+     the window expanding further each time a greeting appears. */
   min-width: 320px;
+  min-height: 250px;
   /* Center main-col (and visitors-col, when present) horizontally
      inside the 320px baseline so the sprite sits at the window's
      midpoint instead of flex-starting at the left. */
@@ -80,6 +85,16 @@ body {
 
 .container.dragging {
   cursor: grabbing;
+}
+
+/* Visitor mode baseline: up to 3 other pets visit at once, each
+   ~96 * scale wide with a transient greeting up to 180 wide. 500px
+   fits all three sprites + greetings next to the host pet without
+   the window having to resize mid-visit. When the last visitor
+   leaves, this class is removed and the container snaps back to
+   the 320 baseline via min-width. */
+.container.has-visitors {
+  min-width: 500px;
 }
 
 /* Dev tool: outlines the container (== the auto-sized Tauri window)

--- a/src/styles/dev-build-badge.css
+++ b/src/styles/dev-build-badge.css
@@ -18,6 +18,69 @@
   border: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: 6px;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  /* pointer-events enabled so the hover tooltip can fire. The badge is
+     small and sits above the mascot's center; the mascot doesn't have
+     click handlers of its own, so capturing pointer events here is
+     harmless. cursor: help signals the hint-only interaction. */
+  pointer-events: auto;
+  cursor: help;
+  /* High z-index so the tooltip child (which inherits this stacking
+     context) sits above every sibling in .container — speech bubble,
+     visitors column, status pill, session dropdown, dev outlines. */
+  z-index: 9999;
+}
+
+/* Hover tooltip — tells the developer how to unlock the Superpower
+   debug tool (click the Version label in Settings 10 times). Anchored
+   to the RIGHT of the badge (not above) because the badge sits near
+   the container's left edge; positioning above-and-centered was
+   overflowing the window. Invisible until :hover on the parent. */
+.dev-build-badge-tip {
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 8px 12px;
+  width: max-content;
+  max-width: 200px;
+  white-space: normal;
+  text-align: left;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: normal;
+  color: rgba(255, 255, 255, 0.95);
+  background: rgba(0, 0, 0, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
   pointer-events: none;
-  z-index: 5;
+  opacity: 0;
+  transition: opacity 0.15s ease-out;
+  z-index: 9999;
+}
+
+/* Little triangle pointing LEFT at the DEV badge */
+.dev-build-badge-tip::after {
+  content: "";
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-right: 6px solid rgba(0, 0, 0, 0.9);
+}
+
+.dev-build-badge-tip strong {
+  color: #ffd60a;
+  font-weight: 700;
+}
+
+.dev-build-badge:hover .dev-build-badge-tip,
+.dev-build-badge:focus-visible .dev-build-badge-tip {
+  opacity: 1;
 }

--- a/src/styles/visitor.css
+++ b/src/styles/visitor.css
@@ -45,12 +45,16 @@
   to { background-position: calc(-1 * var(--sprite-width)) 0; }
 }
 
-/* --- Arrival greeting bubble --- */
+/* --- Arrival greeting bubble ---
+   Absolute-positioned above the visitor-dog's top edge so it doesn't
+   contribute to the dog's horizontal footprint. If it were in the
+   flex flow, each visitor-dog would grow to 180–220px (greeting
+   max-width), pushing 3 visitors past the 500px root baseline. */
 .visitor-greeting {
-  position: relative;
-  align-self: center;
+  position: absolute;
+  bottom: calc(100% + 2px);
+  left: 50%;
   max-width: 180px;
-  margin-bottom: 2px;
   padding: 4px 10px;
   border-radius: 10px;
   background: var(--bg-bubble);
@@ -61,6 +65,8 @@
     visitor-greeting-fade 0.35s ease-in 4.65s forwards;
   cursor: pointer;
   pointer-events: auto;
+  transform: translateX(-50%);
+  z-index: 1;
 }
 
 /* Chat message variant: stays visible for the full visit duration
@@ -106,17 +112,17 @@
 @keyframes visitor-greeting-pop {
   0% {
     opacity: 0;
-    transform: scale(0.8) translateY(4px);
+    transform: translateX(-50%) scale(0.8) translateY(4px);
   }
   100% {
     opacity: 1;
-    transform: scale(1) translateY(0);
+    transform: translateX(-50%) scale(1) translateY(0);
   }
 }
 
 @keyframes visitor-greeting-fade {
   to {
     opacity: 0;
-    transform: translateY(-2px);
+    transform: translateX(-50%) translateY(-2px);
   }
 }


### PR DESCRIPTION
## Summary

Implements Option C from the bubble-sizing brainstorm: when the speech bubble appears, the Tauri window grows around it and shifts position to keep the sprite visually anchored — same per-source compensation pattern as the session-dropdown effect.

Stacked on top of #110 (Superpower dev tools).

## What changed

- **Measure** the rendered bubble with \`useLayoutEffect\` + \`ResizeObserver\` on \`[data-testid=\"speech-bubble\"]\`.
- **Compute extras** needed so the bubble fits the container:
  - \`extraH   = max(0, bubble.width/2 − spriteHalf·scale − basePadLeft)\`
  - \`extraTop = max(0, bubble.height − overlap·scale − basePadTop)\`
- **Feed extras** into \`--bubble-extra-top\` / \`--bubble-extra-h\` CSS vars on \`.container\`; \`container.offsetWidth/Height\` grows naturally.
- **Grow window** in a single \`Promise.all\`: \`setSize\` to new container dims, \`setPosition\` shifted by \`(−extraH, −extraTop)\`. Sprite stays at the same screen pixel.
- **Restore** on hide (or when extras return to 0).
- **Pause** \`useWindowAutoSize\` while the bubble grow effect owns the window; **skip** entirely while the session dropdown is open.
- Dev \"Container\" outline also tracks the dynamic padding so it still marks the real content box.

## Test plan

- [ ] \`bun run tauri dev\`
- [ ] Short bubble (\"Let's get started!\"): no visible window change, sprite stays put.
- [ ] Long bubble scenario: window grows up+wider, sprite pixel position unchanged, bubble fully visible.
- [ ] Ultra-long bubble: same as above, bubble wraps further, window grows taller. Confirm sprite does not jump.
- [ ] Dismiss / auto-hide: window snaps back to original size + position.
- [ ] Open session dropdown: bubble-grow effect no-ops, session geometry wins.
- [ ] \`npx tsc --noEmit\` passes.

## Known caveats

- Native \`setSize\` is instant, no smooth animation. A large bubble \"snaps\" the window to a larger state alongside the \`bubble-pop-in\` animation (0.3s). Worth watching in practice.
- Without #111's multi-line wrap, a long message stays on a single line and will grow the window very wide. Combining with #111 keeps the bubble wrapped to 280px max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)