### PR TITLE
Deeplink install: animime:// scheme + install dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ test-results/
 *.sln
 *.sw?
 .gitnexus
+
+.worktrees/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
@@ -93,6 +94,7 @@ dependencies = [
  "tauri-plugin-store",
  "tiny_http",
  "ureq",
+ "url",
  "urlencoding",
 ]
 
@@ -709,6 +711,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +850,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1062,6 +1090,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1771,6 +1808,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2807,6 +2850,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,6 +3630,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4432,6 +4495,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94deb2e2e4641514ac496db2cddcfc850d6fc9d51ea17b82292a0490bd20ba5b"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4738,6 +4822,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5659,6 +5752,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,12 +19,13 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
-tauri-plugin-opener = "2"
-tauri-plugin-store = "2"
 tauri-plugin-autostart = "2"
+tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-log = "2"
+tauri-plugin-opener = "2"
+tauri-plugin-store = "2"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -33,6 +34,7 @@ dirs = "6"
 mdns-sd = { version = "0.19", features = ["async"] }
 hostname = "0.4"
 ureq = { version = "3", features = ["json"] }
+url = "2"
 urlencoding = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -8,5 +8,14 @@
 	<array>
 		<string>_ani-mime._tcp</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.ani-mime.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array><string>animime</string></array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -44,6 +44,7 @@
     "fs:write-all",
     "fs:scope-appdata-recursive",
     "log:default",
-    "core:path:default"
+    "core:path:default",
+    "deep-link:default"
   ]
 }

--- a/src-tauri/src/deeplink.rs
+++ b/src-tauri/src/deeplink.rs
@@ -1,0 +1,147 @@
+use tauri::{AppHandle, Emitter};
+use url::Url;
+
+const MARKETPLACE_BASE: &str = "https://snor-oh.vercel.app";
+
+#[derive(serde::Serialize, Clone)]
+pub struct InstallPromptPayload {
+    pub id: String,
+    pub name: String,
+    pub creator: Option<String>,
+    pub size_bytes: u64,
+    pub preview_url: String,
+    pub download_url: String,
+}
+
+/// Parse an `animime://install?id=<id>` URL and return the validated id.
+/// Returns `None` if the scheme, host, id characters, or length are invalid.
+pub fn extract_id(raw: &str) -> Option<String> {
+    let url = Url::parse(raw).ok()?;
+    if url.scheme() != "animime" {
+        return None;
+    }
+    if url.host_str() != Some("install") {
+        return None;
+    }
+    let id = url
+        .query_pairs()
+        .find(|(k, _)| k == "id")
+        .map(|(_, v)| v.into_owned())?;
+    if id.is_empty() || id.len() > 64 {
+        return None;
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return None;
+    }
+    Some(id)
+}
+
+/// Fetch package metadata from the marketplace and emit either `install-prompt`
+/// (on success) or `install-error` (on any failure) to the frontend.
+///
+/// This is a **synchronous / blocking** function. T15 must call it via
+/// `tauri::async_runtime::spawn_blocking`:
+///
+/// ```rust
+/// let h = app.clone();
+/// tauri::async_runtime::spawn_blocking(move || crate::deeplink::handle(h, raw_url));
+/// ```
+pub fn handle(app: AppHandle, raw_url: String) {
+    let Some(id) = extract_id(&raw_url) else {
+        return;
+    };
+
+    let meta_url = format!("{MARKETPLACE_BASE}/api/packages/{id}");
+
+    let agent = ureq::Agent::new_with_config(
+        ureq::Agent::config_builder()
+            .timeout_global(Some(std::time::Duration::from_secs(10)))
+            .build(),
+    );
+    let mut response = match agent.get(&meta_url).call() {
+        Ok(r) => r,
+        Err(_) => {
+            let _ = app.emit("install-error", "Marketplace fetch failed");
+            return;
+        }
+    };
+
+    let meta: serde_json::Value = match response.body_mut().read_json() {
+        Ok(v) => v,
+        Err(_) => {
+            let _ = app.emit("install-error", "Malformed marketplace response");
+            return;
+        }
+    };
+
+    // Format check must come before any bundle download.
+    if meta["format"].as_str() != Some("animime") {
+        let _ = app.emit("install-error", "Wrong format — that is a .snoroh package");
+        return;
+    }
+
+    let name = meta["name"].as_str().unwrap_or("");
+    let size_bytes = meta["size_bytes"].as_u64().unwrap_or(0);
+    if name.is_empty() || size_bytes == 0 {
+        let _ = app.emit("install-error", "Incomplete marketplace response");
+        return;
+    }
+
+    let payload = InstallPromptPayload {
+        id: id.clone(),
+        name: name.to_string(),
+        creator: meta["creator"].as_str().map(String::from),
+        size_bytes,
+        preview_url: format!("{MARKETPLACE_BASE}/api/packages/{id}/preview"),
+        download_url: format!("{MARKETPLACE_BASE}/api/packages/{id}/download"),
+    };
+
+    let _ = app.emit("install-prompt", payload);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_id;
+
+    #[test]
+    fn accepts_valid() {
+        assert_eq!(
+            extract_id("animime://install?id=abc-123_X&v=1").as_deref(),
+            Some("abc-123_X")
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_scheme() {
+        assert_eq!(extract_id("snoroh://install?id=abc"), None);
+    }
+
+    #[test]
+    fn rejects_wrong_host() {
+        assert_eq!(extract_id("animime://run?id=abc"), None);
+    }
+
+    #[test]
+    fn rejects_bad_chars() {
+        assert_eq!(extract_id("animime://install?id=a/b"), None);
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let long = "a".repeat(65);
+        assert_eq!(extract_id(&format!("animime://install?id={long}")), None);
+    }
+
+    #[test]
+    fn rejects_empty_id() {
+        assert_eq!(extract_id("animime://install?id="), None);
+    }
+
+    #[test]
+    fn rejects_missing_id_param() {
+        assert_eq!(extract_id("animime://install"), None);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ extern crate objc;
 
 mod broadcast;
 mod claude_config;
+mod deeplink;
 mod discovery;
 mod focus;
 mod helpers;
@@ -422,11 +423,12 @@ pub fn run() {
                 .max_file_size(1_000_000)
                 .build(),
         )
+        .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
-        .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_fs::init())
         .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, get_sessions, focus_terminal, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible, set_tray_visible, request_local_network, claude_config::get_claude_config, claude_config::set_plugin_enabled, claude_config::get_command_content, claude_config::delete_command, claude_config::delete_mcp_server, claude_config::delete_hook_entry])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
@@ -657,6 +659,16 @@ pub fn run() {
                     pet.clone(),
                 );
                 broadcast::start_broadcast(discovery_handle, discovery_state, nickname, pet);
+            });
+
+            use tauri_plugin_deep_link::DeepLinkExt;
+            let handle = app.handle().clone();
+            app.deep_link().on_open_url(move |event| {
+                for url in event.urls() {
+                    let h = handle.clone();
+                    let raw = url.to_string();
+                    tauri::async_runtime::spawn_blocking(move || crate::deeplink::handle(h, raw));
+                }
             });
 
             Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -70,6 +70,13 @@
       "csp": null
     }
   },
+  "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["animime"]
+      }
+    }
+  },
   "bundle": {
     "resources": [
       "script/terminal-mirror.zsh",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,11 @@ import {
   LogicalPosition,
   LogicalSize,
 } from "@tauri-apps/api/window";
+import { useInstallPrompt } from "./hooks/useInstallPrompt";
+import { InstallPromptDialog } from "./components/InstallPromptDialog";
 import "./styles/theme.css";
 import "./styles/app.css";
+import "./styles/install-prompt.css";
 
 // Total window height while the session-list dropdown is open.
 // The dropdown itself is position: fixed so it doesn't inflate the
@@ -50,6 +53,7 @@ const SPRITE_NATIVE_WIDTH = 128;
 const BASELINE_WIDTH = 320;
 
 function App() {
+  const { prompt, error: installError, clear } = useInstallPrompt();
   const { status, scenario } = useStatus();
   const { dragging, onMouseDown } = useDrag();
   const { visible, message, dismiss } = useBubble();
@@ -372,6 +376,7 @@ function App() {
   }, [sessionOpen]);
 
   return (
+    <>
     <div
       ref={containerRef}
       data-testid="app-container"
@@ -433,6 +438,8 @@ function App() {
         </div>
       )}
     </div>
+    <InstallPromptDialog prompt={prompt} error={installError} onDone={clear} />
+    </>
   );
 }
 

--- a/src/__mocks__/tauri-event.ts
+++ b/src/__mocks__/tauri-event.ts
@@ -2,21 +2,53 @@
  * Mock for @tauri-apps/api/event
  *
  * Stores event handlers so tests can fire events with emitMockEvent().
+ *
+ * Supports two modes:
+ *   - "immediate" (default): listen() resolves synchronously via Promise.resolve
+ *   - "deferred": listen() hangs until resolveListen() is called manually
  */
 
 type Handler = (event: { payload: unknown }) => void;
 
 const handlers = new Map<string, Set<Handler>>();
 
+type ListenMode = "immediate" | "deferred";
+let listenMode: ListenMode = "immediate";
+let pendingResolve: (() => void) | null = null;
+
+/** Switch between immediate and deferred resolution for listen(). */
+export function setListenMode(mode: ListenMode): void {
+  listenMode = mode;
+  pendingResolve = null;
+}
+
+/**
+ * When in "deferred" mode, call this to resolve the pending listen() promise.
+ * The unlisten function will be registered and the handler added to `handlers`.
+ */
+export function resolveListen(): void {
+  if (pendingResolve) {
+    pendingResolve();
+    pendingResolve = null;
+  }
+}
+
 export const listen = vi.fn(
-  async (event: string, handler: Handler): Promise<() => void> => {
+  (event: string, handler: Handler): Promise<() => void> => {
     if (!handlers.has(event)) {
       handlers.set(event, new Set());
     }
     handlers.get(event)!.add(handler);
-    return () => {
+    const unlisten = () => {
       handlers.get(event)?.delete(handler);
     };
+
+    if (listenMode === "deferred") {
+      return new Promise<() => void>((resolve) => {
+        pendingResolve = () => resolve(unlisten);
+      });
+    }
+    return Promise.resolve(unlisten);
   }
 );
 
@@ -33,4 +65,11 @@ export function resetMocks() {
   handlers.clear();
   listen.mockClear();
   emit.mockClear();
+  listenMode = "immediate";
+  pendingResolve = null;
+}
+
+/** Returns the number of registered handlers for a given event name. */
+export function listenerCount(event: string): number {
+  return handlers.get(event)?.size ?? 0;
 }

--- a/src/__tests__/components/InstallPromptDialog.test.tsx
+++ b/src/__tests__/components/InstallPromptDialog.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { InstallPromptDialog } from "../../components/InstallPromptDialog";
+import type { InstallPromptPayload } from "../../hooks/useInstallPrompt";
+
+const mockImportFromBytes = vi.fn();
+
+vi.mock("../../hooks/useCustomMimes", () => ({
+  useCustomMimes: () => ({
+    mimes: [],
+    loaded: true,
+    importFromBytes: mockImportFromBytes,
+    pickSpriteFile: vi.fn(),
+    addMime: vi.fn(),
+    addMimeFromBlobs: vi.fn(),
+    updateMime: vi.fn(),
+    updateMimeFromSmartImport: vi.fn(),
+    deleteMime: vi.fn(),
+    exportMime: vi.fn(),
+    importMime: vi.fn(),
+    getSpriteUrl: vi.fn(),
+  }),
+}));
+
+const basePrompt: InstallPromptPayload = {
+  id: "pkg-123",
+  name: "Cool Mime",
+  creator: "Alice",
+  size_bytes: 2048,
+  preview_url: "https://example.com/preview.gif",
+  download_url: "https://example.com/bundle.animime",
+};
+
+describe("InstallPromptDialog", () => {
+  beforeEach(() => {
+    mockImportFromBytes.mockReset();
+  });
+
+  it("renders nothing when prompt is null and error is null", () => {
+    const { container } = render(
+      <InstallPromptDialog prompt={null} error={null} onDone={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders error-only card when prompt is null but error is set", () => {
+    render(
+      <InstallPromptDialog
+        prompt={null}
+        error="Marketplace fetch failed"
+        onDone={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId("install-prompt-dialog")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Marketplace fetch failed"
+    );
+    expect(screen.queryByTestId("install-confirm")).toBeNull();
+  });
+
+  it("Close button fires onDone from error-only state", () => {
+    const onDone = vi.fn();
+    render(
+      <InstallPromptDialog
+        prompt={null}
+        error="Bad format"
+        onDone={onDone}
+      />
+    );
+    fireEvent.click(screen.getByTestId("install-cancel"));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges Rust error prop into error slot when prompt is present", () => {
+    render(
+      <InstallPromptDialog
+        prompt={basePrompt}
+        error="Network failure"
+        onDone={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Network failure");
+    // preview/name still rendered
+    expect(screen.getByText("Cool Mime")).toBeInTheDocument();
+  });
+
+  it("renders name, creator, and size when prompt is provided", () => {
+    render(<InstallPromptDialog prompt={basePrompt} onDone={vi.fn()} />);
+    expect(screen.getByTestId("install-prompt-dialog")).toBeInTheDocument();
+    expect(screen.getByText("Cool Mime")).toBeInTheDocument();
+    expect(screen.getByText("by Alice")).toBeInTheDocument();
+    expect(screen.getByText("2 KB")).toBeInTheDocument();
+  });
+
+  it("shows '< 1 KB' for sub-1024-byte prompt", () => {
+    render(
+      <InstallPromptDialog
+        prompt={{ ...basePrompt, size_bytes: 512 }}
+        onDone={vi.fn()}
+      />
+    );
+    expect(screen.getByText("< 1 KB")).toBeInTheDocument();
+  });
+
+  it("does not render creator line when creator is null", () => {
+    render(
+      <InstallPromptDialog
+        prompt={{ ...basePrompt, creator: null }}
+        onDone={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/^by /)).toBeNull();
+  });
+
+  it("Cancel button fires onDone", () => {
+    const onDone = vi.fn();
+    render(<InstallPromptDialog prompt={basePrompt} onDone={onDone} />);
+    fireEvent.click(screen.getByTestId("install-cancel"));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("Install button fetches bytes, calls importFromBytes, then fires onDone", async () => {
+    const onDone = vi.fn();
+    const fakeBytes = new Uint8Array([1, 2, 3]);
+    const fakeBuffer = fakeBytes.buffer;
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValueOnce(fakeBuffer),
+    } as unknown as Response);
+
+    mockImportFromBytes.mockResolvedValueOnce("custom-999");
+
+    render(<InstallPromptDialog prompt={basePrompt} onDone={onDone} />);
+    fireEvent.click(screen.getByTestId("install-confirm"));
+
+    await waitFor(() => {
+      expect(mockImportFromBytes).toHaveBeenCalledWith(
+        expect.any(Uint8Array),
+        "Cool Mime.animime"
+      );
+    });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error and clears busy when fetch fails", async () => {
+    const onDone = vi.fn();
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    } as unknown as Response);
+
+    render(<InstallPromptDialog prompt={basePrompt} onDone={onDone} />);
+    fireEvent.click(screen.getByTestId("install-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Download failed (HTTP 503)"
+      );
+    });
+
+    expect(onDone).not.toHaveBeenCalled();
+    expect(screen.getByTestId("install-cancel")).not.toBeDisabled();
+  });
+
+  it("shows error when importFromBytes rejects", async () => {
+    const onDone = vi.fn();
+    const fakeBytes = new Uint8Array([1]).buffer;
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValueOnce(fakeBytes),
+    } as unknown as Response);
+
+    mockImportFromBytes.mockRejectedValueOnce(new Error("Invalid .animime file"));
+
+    render(<InstallPromptDialog prompt={basePrompt} onDone={onDone} />);
+    fireEvent.click(screen.getByTestId("install-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Invalid .animime file");
+    });
+
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/hooks/useCustomMimes.test.ts
+++ b/src/__tests__/hooks/useCustomMimes.test.ts
@@ -356,6 +356,78 @@ describe("useCustomMimes", () => {
     expect(sheetRemove).toBeDefined();
   });
 
+  describe("importFromBytes", () => {
+    function makeV1Payload(name: string): Uint8Array {
+      const sprites: Record<string, { frames: number; data: string }> = {};
+      for (const status of ALL_STATUSES) {
+        sprites[status] = { frames: 3, data: btoa("fakepng") };
+      }
+      const payload = JSON.stringify({ version: 1, name, sprites });
+      return new TextEncoder().encode(payload);
+    }
+
+    it("imports a v1 .animime bytes buffer and returns an id", async () => {
+      vi.mocked(exists).mockResolvedValue(true);
+
+      const { result } = renderHook(() => useCustomMimes());
+      await act(async () => {});
+
+      let returnedId: string | null | undefined;
+      await act(async () => {
+        returnedId = await result.current.importFromBytes(
+          makeV1Payload("BytesMime"),
+          "byte-pet.animime"
+        );
+      });
+
+      expect(returnedId).toMatch(/^custom-\d+$/);
+      expect(result.current.mimes).toHaveLength(1);
+      expect(result.current.mimes[0].name).toBe("BytesMime");
+      for (const status of ALL_STATUSES) {
+        expect(result.current.mimes[0].sprites[status]).toBeDefined();
+        expect(result.current.mimes[0].sprites[status].frames).toBe(3);
+      }
+    });
+
+    it("throws on invalid .animime bytes", async () => {
+      vi.mocked(exists).mockResolvedValue(true);
+
+      const { result } = renderHook(() => useCustomMimes());
+      await act(async () => {});
+
+      await expect(
+        act(async () => {
+          await result.current.importFromBytes(
+            new TextEncoder().encode('{"version":99,"name":"x"}'),
+            "bad.animime"
+          );
+        })
+      ).rejects.toThrow("Invalid .animime file");
+    });
+
+    it("importMime delegates to importFromBytes (file picker path still works)", async () => {
+      vi.mocked(exists).mockResolvedValue(true);
+
+      const { readFile: mockReadFile } = await import(
+        "@tauri-apps/plugin-fs"
+      );
+      const { open: mockOpen } = await import("@tauri-apps/plugin-dialog");
+      vi.mocked(mockOpen).mockResolvedValue("/tmp/pet.animime");
+      vi.mocked(mockReadFile).mockResolvedValue(makeV1Payload("FileMime"));
+
+      const { result } = renderHook(() => useCustomMimes());
+      await act(async () => {});
+
+      let returnedId: string | null | undefined;
+      await act(async () => {
+        returnedId = await result.current.importMime();
+      });
+
+      expect(returnedId).toMatch(/^custom-\d+$/);
+      expect(result.current.mimes[0].name).toBe("FileMime");
+    });
+  });
+
   it("cleans up listener on unmount", async () => {
     const { result, unmount } = renderHook(() => useCustomMimes());
     await act(async () => {});

--- a/src/__tests__/hooks/useInstallPrompt.test.ts
+++ b/src/__tests__/hooks/useInstallPrompt.test.ts
@@ -1,0 +1,209 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { useInstallPrompt } from "../../hooks/useInstallPrompt";
+import {
+  emitMockEvent,
+  listenerCount,
+  resetMocks,
+  resolveListen,
+  setListenMode,
+} from "../../__mocks__/tauri-event";
+
+describe("useInstallPrompt", () => {
+  afterEach(() => {
+    resetMocks();
+  });
+
+  it("captures install-prompt event payloads", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+
+    // Wait for useEffect listener registration to settle
+    await act(async () => {});
+
+    act(() => {
+      emitMockEvent("install-prompt", {
+        id: "abc",
+        name: "Cat",
+        creator: "me",
+        size_bytes: 1024,
+        preview_url: "/p",
+        download_url: "/d",
+      });
+    });
+
+    expect(result.current.prompt?.name).toBe("Cat");
+
+    act(() => result.current.clear());
+
+    expect(result.current.prompt).toBeNull();
+  });
+
+  it("handles nullable creator field", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    await act(async () => {});
+
+    act(() => {
+      emitMockEvent("install-prompt", {
+        id: "xyz",
+        name: "Dog",
+        creator: null,
+        size_bytes: 2048,
+        preview_url: "/prev",
+        download_url: "/dl",
+      });
+    });
+
+    expect(result.current.prompt?.creator).toBeNull();
+    expect(result.current.prompt?.id).toBe("xyz");
+  });
+
+  it("starts with null prompt", () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    expect(result.current.prompt).toBeNull();
+  });
+
+  it("cleans up listener on unmount", async () => {
+    const { result, unmount } = renderHook(() => useInstallPrompt());
+    await act(async () => {});
+
+    // Listener must be registered before unmount
+    expect(listenerCount("install-prompt")).toBe(1);
+
+    unmount();
+
+    // After unmount the unlisten callback must have removed the handler
+    expect(listenerCount("install-prompt")).toBe(0);
+
+    // Behavioral confirmation: emitting after unmount must not change state
+    act(() => {
+      emitMockEvent("install-prompt", {
+        id: "abc",
+        name: "Cat",
+        creator: null,
+        size_bytes: 1024,
+        preview_url: "/p",
+        download_url: "/d",
+      });
+    });
+
+    expect(result.current.prompt).toBeNull();
+  });
+
+  it("does not leak listener when unmounted before listen() resolves", async () => {
+    // Switch to deferred mode so the listen() promise won't resolve until we say so.
+    // The mock's pendingResolve slot is last-write-wins: the hook registers two
+    // listeners ("install-prompt" then "install-error"), so resolveListen() resolves
+    // the last-registered one ("install-error").
+    setListenMode("deferred");
+
+    const { unmount } = renderHook(() => useInstallPrompt());
+
+    // Unmount BEFORE either listen() promise has resolved — cleanup runs with
+    // unlistenRef.current still null in the buggy implementation
+    unmount();
+
+    // Now resolve the pending listen() promise — the .then callback fires
+    await act(async () => {
+      resolveListen();
+    });
+
+    // The handler was added to `handlers` inside listen() before the promise
+    // was returned, but the unlisten fn must have been called immediately
+    // because the component was already unmounted. The mock only supports one
+    // pending resolve at a time, so we verify the last-registered event ("install-error").
+    expect(listenerCount("install-error")).toBe(0);
+  });
+
+  it("captures install-error payload in error state", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    await act(async () => {});
+
+    act(() => {
+      emitMockEvent("install-error", "Marketplace fetch failed");
+    });
+
+    expect(result.current.error).toBe("Marketplace fetch failed");
+  });
+
+  it("emit install-error clears prompt", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    await act(async () => {});
+
+    act(() => {
+      emitMockEvent("install-prompt", {
+        id: "abc",
+        name: "Cat",
+        creator: null,
+        size_bytes: 1024,
+        preview_url: "/p",
+        download_url: "/d",
+      });
+    });
+
+    expect(result.current.prompt?.name).toBe("Cat");
+
+    act(() => {
+      emitMockEvent("install-error", "Bad format");
+    });
+
+    expect(result.current.prompt).toBeNull();
+    expect(result.current.error).toBe("Bad format");
+  });
+
+  it("emit install-prompt clears error", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    await act(async () => {});
+
+    act(() => {
+      emitMockEvent("install-error", "Previous error");
+    });
+
+    expect(result.current.error).toBe("Previous error");
+
+    act(() => {
+      emitMockEvent("install-prompt", {
+        id: "abc",
+        name: "Cat",
+        creator: null,
+        size_bytes: 1024,
+        preview_url: "/p",
+        download_url: "/d",
+      });
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.prompt?.name).toBe("Cat");
+  });
+
+  it("clear() resets both prompt and error to null", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    await act(async () => {});
+
+    act(() => {
+      emitMockEvent("install-error", "Some error");
+    });
+
+    expect(result.current.error).toBe("Some error");
+
+    act(() => result.current.clear());
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.prompt).toBeNull();
+  });
+
+  it("starts with null error", () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("unlistens install-error on unmount", async () => {
+    const { unmount } = renderHook(() => useInstallPrompt());
+    await act(async () => {});
+
+    expect(listenerCount("install-error")).toBe(1);
+
+    unmount();
+
+    expect(listenerCount("install-error")).toBe(0);
+  });
+});

--- a/src/components/InstallPromptDialog.tsx
+++ b/src/components/InstallPromptDialog.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from "react";
+import type { InstallPromptPayload } from "../hooks/useInstallPrompt";
+import { useCustomMimes } from "../hooks/useCustomMimes";
+
+interface Props {
+  prompt: InstallPromptPayload | null;
+  error?: string | null;
+  onDone: () => void;
+}
+
+export function InstallPromptDialog({ prompt, error: rustError = null, onDone }: Props) {
+  const { importFromBytes } = useCustomMimes();
+  const [busy, setBusy] = useState(false);
+  const [frontendError, setFrontendError] = useState<string | null>(null);
+  const firstBtn = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => { if (prompt) firstBtn.current?.focus(); }, [prompt]);
+
+  // Neither prompt nor any error — render nothing.
+  if (!prompt && !rustError) return null;
+
+  const displayError = rustError ?? frontendError;
+
+  // Error-only: Rust rejected the install before a payload arrived.
+  if (!prompt) {
+    return (
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="install-title"
+        data-testid="install-prompt-dialog"
+        className="install-prompt"
+      >
+        <div className="install-prompt__card">
+          <h2 id="install-title">Install from marketplace</h2>
+          {displayError && (
+            <div className="install-prompt__error" role="alert">{displayError}</div>
+          )}
+          <div className="install-prompt__actions">
+            <button
+              ref={firstBtn}
+              type="button"
+              onClick={onDone}
+              data-testid="install-cancel"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const kb = Math.round(prompt.size_bytes / 1024);
+  const sizeLabel = prompt.size_bytes < 1024 ? "< 1 KB" : `${kb} KB`;
+
+  const handleInstall = async () => {
+    setBusy(true);
+    setFrontendError(null);
+    try {
+      const res = await fetch(prompt.download_url);
+      if (!res.ok) throw new Error(`Download failed (HTTP ${res.status})`);
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      await importFromBytes(bytes, `${prompt.name}.animime`);
+      onDone();
+    } catch (e) {
+      setFrontendError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="install-title"
+      data-testid="install-prompt-dialog"
+      className="install-prompt"
+    >
+      <div className="install-prompt__card">
+        <h2 id="install-title">Install from marketplace</h2>
+        <img
+          src={prompt.preview_url}
+          alt=""
+          width={128}
+          height={128}
+          className="install-prompt__preview pixel"
+        />
+        <div className="install-prompt__meta">
+          <div className="install-prompt__name">{prompt.name}</div>
+          {prompt.creator && (
+            <div className="install-prompt__creator">by {prompt.creator}</div>
+          )}
+          <div className="install-prompt__size">{sizeLabel}</div>
+        </div>
+        {displayError && (
+          <div className="install-prompt__error" role="alert">{displayError}</div>
+        )}
+        <div className="install-prompt__actions">
+          <button
+            ref={firstBtn}
+            type="button"
+            onClick={onDone}
+            disabled={busy}
+            data-testid="install-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleInstall}
+            disabled={busy}
+            data-testid="install-confirm"
+          >
+            {busy ? "Installing…" : "Install"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useCustomMimes.ts
+++ b/src/hooks/useCustomMimes.ts
@@ -310,14 +310,7 @@ export function useCustomMimes() {
     info(`[custom-mimes] exported "${mime.name}" to ${path} (v${payloadObj.version}, ${payload.length} bytes)`);
   }, [mimes, ensureSpritesDir]);
 
-  const importMime = useCallback(async (): Promise<string | null> => {
-    const result = await open({
-      multiple: false,
-      filters: [{ name: "Ani-Mime Export", extensions: ["animime"] }],
-    });
-    if (!result) return null;
-
-    const bytes = await readFile(result);
+  const importFromBytes = useCallback(async (bytes: Uint8Array, _filename: string): Promise<string> => {
     const decoder = new TextDecoder();
     const payload = JSON.parse(decoder.decode(bytes));
 
@@ -333,7 +326,7 @@ export function useCustomMimes() {
     };
 
     const id = `custom-${Date.now()}`;
-    info(`[custom-mimes] importMime: name="${payload.name}", id=${id}, version=${payload.version}`);
+    info(`[custom-mimes] importFromBytes: name="${payload.name}", id=${id}, version=${payload.version}`);
     const dir = await ensureSpritesDir();
 
     const sprites: Record<string, { fileName: string; frames: number }> = {};
@@ -422,6 +415,17 @@ export function useCustomMimes() {
     return id;
   }, [mimes, saveMimes, ensureSpritesDir]);
 
+  const importMime = useCallback(async (): Promise<string | null> => {
+    const result = await open({
+      multiple: false,
+      filters: [{ name: "Ani-Mime Export", extensions: ["animime"] }],
+    });
+    if (!result) return null;
+
+    const bytes = await readFile(result);
+    return importFromBytes(bytes, result);
+  }, [importFromBytes]);
+
   const getSpriteUrl = useCallback(
     async (fileName: string): Promise<string> => {
       const base = await appDataDir();
@@ -431,5 +435,5 @@ export function useCustomMimes() {
     []
   );
 
-  return { mimes, loaded, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, updateMimeFromSmartImport, deleteMime, exportMime, importMime, getSpriteUrl };
+  return { mimes, loaded, pickSpriteFile, addMime, addMimeFromBlobs, updateMime, updateMimeFromSmartImport, deleteMime, exportMime, importMime, importFromBytes, getSpriteUrl };
 }

--- a/src/hooks/useInstallPrompt.ts
+++ b/src/hooks/useInstallPrompt.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+export interface InstallPromptPayload {
+  id: string;
+  name: string;
+  creator: string | null;
+  size_bytes: number;
+  preview_url: string;
+  download_url: string;
+}
+
+export function useInstallPrompt() {
+  const [prompt, setPrompt] = useState<InstallPromptPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const unlistenPromptRef = useRef<(() => void) | null>(null);
+  const unlistenErrorRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    let unmounted = false;
+
+    listen<InstallPromptPayload>("install-prompt", (e) => {
+      setError(null);
+      setPrompt(e.payload);
+    }).then((fn) => {
+      if (unmounted) {
+        fn();
+      } else {
+        unlistenPromptRef.current = fn;
+      }
+    });
+
+    listen<string>("install-error", (e) => {
+      setPrompt(null);
+      setError(e.payload);
+    }).then((fn) => {
+      if (unmounted) {
+        fn();
+      } else {
+        unlistenErrorRef.current = fn;
+      }
+    });
+
+    return () => {
+      unmounted = true;
+      unlistenPromptRef.current?.();
+      unlistenPromptRef.current = null;
+      unlistenErrorRef.current?.();
+      unlistenErrorRef.current = null;
+    };
+  }, []);
+
+  const clear = useCallback(() => {
+    setPrompt(null);
+    setError(null);
+  }, []);
+
+  return { prompt, error, clear };
+}

--- a/src/styles/install-prompt.css
+++ b/src/styles/install-prompt.css
@@ -1,0 +1,16 @@
+.install-prompt {
+  position: fixed; inset: 0;
+  display: grid; place-items: center;
+  background: rgba(0,0,0,0.4);
+  z-index: 100;
+}
+.install-prompt__card {
+  background: var(--bg-pill);
+  border-radius: 12px;
+  padding: 1.5rem;
+  min-width: 260px;
+  display: grid; gap: 0.75rem; justify-items: center;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+}
+.install-prompt__actions { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+.install-prompt__error { color: #c00; font-size: 0.8rem; }


### PR DESCRIPTION
## Summary

Cross-repo deeplink install feature. Custom URL scheme `animime://install?id=<pkg>&v=1` opens the Tauri app and prompts to install a mime from the snoroh marketplace.

**Scope:**

- **Rust side** (`src-tauri/`) — register `animime://` via `tauri-plugin-deep-link` + `Info.plist` + capabilities + `tauri.conf.json`. `deeplink.rs` parses URL → validates id `[a-zA-Z0-9-_]` ≤64 chars → fetches marketplace meta (10s timeout, ureq) → emits `install-prompt` payload (or `install-error` on failure/wrong format). Wired via `on_open_url` in `lib.rs` with `spawn_blocking` (ureq is sync).
- **Frontend** (`src/`) — `useInstallPrompt` hook (listens `install-prompt` + `install-error`, race-safe unmount via `unmounted` flag), `useCustomMimes.importFromBytes(bytes, filename)` refactored from existing file-import path (no duplicated logic), `InstallPromptDialog` modal (shows preview/name/creator/size, handles Install + Cancel, surfaces Rust errors via new `error` prop), mounted in `App.tsx`.

## Tests (all passing via `npx vitest run <file>`)

- `deeplink.rs` — 7 Rust unit tests (id validation, scheme/host/allowlist boundaries)
- `useInstallPrompt.test.ts` — 11 cases (payload capture, error capture, unmount-before-listen-resolve race, clear() resets both, etc.)
- `useCustomMimes.test.ts` — 16 cases (+3 new for byte path, v1/v2 formats)
- `InstallPromptDialog.test.tsx` — 8 cases (null states, error-only card, merged errors, download failure, busy state)

## Security notes

- `preview_url` / `download_url` derived from compile-time `MARKETPLACE_BASE` + allowlisted id — never from server JSON
- Invalid URLs silently ignored (no `install-error` emitted → spec compliant)
- `spawn_blocking` isolates HTTP from Tauri event loop
- Format gate: rejects non-`.animime` bundles with `install-error`
- ASCII-only id allowlist matches snor-oh Swift side post-tightening

## Test plan (please verify locally — author has NOT manually tested end-to-end)

- [ ] `bun run tauri build && bash src-tauri/script/post-build-sign.sh` builds clean
- [ ] Open the .app once so macOS registers the `animime://` scheme
- [ ] `open 'animime://install?id=<real-pkg-id>'` → dialog appears with preview, name, creator, size (or "< 1 KB" for sub-1024-byte)
- [ ] Click Install → bundle downloads, mime list includes new pet
- [ ] Cancel → dialog closes without side effects
- [ ] `open 'animime://install?id=a/b'` → silent ignore (no dialog, no error)
- [ ] `open 'animime://install?id=<snoroh-id>'` → dialog shows "Wrong format" error via `install-error` path
- [ ] Marketplace Install button → app opens or fallback modal (requires prod marketplace redeploy for end-to-end)

## Note

Plan: `docs/plans/2026-04-21-deeplink-install-marketplace.md` (in companion snor-oh PR). Two release blockers from integration review landed last: ASCII-only id allowlist and frontend `install-error` listener. Since `MARKETPLACE_BASE` is a compile-time constant (`https://snor-oh.vercel.app`), local marketplace testing requires rebuilding with the const swapped.

Companion PR (required for full E2E): [oh-repo/snor-oh — feature/deeplink-install]