### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.18.0] - 2026-04-22
+
+### Added
+- **Sound effects** — Ani-Mime now reacts audibly to meaningful events: a kalimba chime on status transitions (searching, idle, service, disconnected, visiting), an optional working loop while a task runs, a "Done" chime when it finishes, a doorbell when a peer's mime visits, and a tap when you click the session or LAN peer icon.
+- **Sound tab in Settings** — master toggle, per-category toggles (Status / Visit), and a collapsible card per status case so each transition's sound can be swapped, silenced, or previewed with ▶.
+- **Sound Library** — import your own audio files (MP3/WAV/OGG/M4A/AAC/FLAC up to 2 MB), delete customs you don't want, and pick them in any case dropdown. Bundled defaults are read-only.
+- **Loop While Busy** toggle in the Working case (default off) — choose between a looped working sound or a single tap at task start.
+- **Multi-image Smart Import** — the Import Sheet flow now accepts multiple images at once (Cmd+click in the picker). Each imported image shows as a removable tag; adding more preserves your existing frame assignments, removing one drops only that image's frames.
+- **Duplicate frame (+)** — each frame chip in Smart Import has a + button that inserts a copy of that frame right after itself, handy for repeated frames in an animation.
+- **Deep-link install** (`animime://`) — install marketplace mimes by clicking an `animime://` URL. Thanks @cuongtranba (#114)
+
+### Changed
+- **Working sound default** — now Kalimba, matching the other status defaults.
+
 ## [0.17.2] - 2026-04-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.2",
+  "version": "0.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.2"
+version = "0.18.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1480,7 +1480,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.2{devMode && " (Dev Mode)"}
+                  Version 0.18.0{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
Bumps version to **0.18.0** across `package.json`, `Cargo.toml`, `tauri.conf.json`, and `Settings.tsx` (About section). Regenerates `Cargo.lock`. Adds a CHANGELOG entry.

### Highlights since v0.17.2
- **Sound effects** — kalimba on status changes, working loop (opt-in), done chime, doorbell on visits, tap on pill clicks
- **Sound tab in Settings** — master + category toggles, collapsible per-case cards, per-case dropdown with preview
- **Sound Library** — import/delete custom audio (≤ 2 MB; MP3/WAV/OGG/M4A/AAC/FLAC)
- **Multi-image Smart Import** — file tag list, remove drops only that image's frames, + duplicate button on frame chips
- **Deep-link install** (`animime://`) via PR #114

## Test plan
- [ ] Fresh install shows "Version 0.18.0" in Settings → About
- [ ] Settings → Sound tab: master off silences all; status toggle silences case sounds; working loop default off plays once on busy
- [ ] Sound Library: import an MP3, pick it in the Working dropdown, busy transition plays the custom sound
- [ ] Sound Library: import > 2 MB shows the size error inline
- [ ] Mime → Import Sheet: Cmd+click picks several PNGs; all appear as tags; × on a tag removes it and drops its frames
- [ ] Click session pill / LAN peer icon → single tap sound
- [ ] `animime://install?...` URL opens the install prompt (#114)

After merge: tag `v0.18.0` on main to trigger CI release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)