### PR TITLE
chore: release v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.18.0] - 2026-04-22
+## [0.17.3] - 2026-04-22
 
 ### Added
 - **Sound effects** — Ani-Mime now reacts audibly to meaningful events: a kalimba chime on status transitions (searching, idle, service, disconnected, visiting), an optional working loop while a task runs, a "Done" chime when it finishes, a doorbell when a peer's mime visits, and a tap when you click the session or LAN peer icon.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.17.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.18.0"
+version = "0.17.3"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.18.0"
+version = "0.17.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.18.0",
+  "version": "0.17.3",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/__tests__/components/InstallPromptDialog.test.tsx
+++ b/src/__tests__/components/InstallPromptDialog.test.tsx
@@ -123,7 +123,7 @@ describe("InstallPromptDialog", () => {
     const fakeBytes = new Uint8Array([1, 2, 3]);
     const fakeBuffer = fakeBytes.buffer;
 
-    global.fetch = vi.fn().mockResolvedValueOnce({
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
       arrayBuffer: vi.fn().mockResolvedValueOnce(fakeBuffer),
     } as unknown as Response);
@@ -145,7 +145,7 @@ describe("InstallPromptDialog", () => {
   it("shows error and clears busy when fetch fails", async () => {
     const onDone = vi.fn();
 
-    global.fetch = vi.fn().mockResolvedValueOnce({
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
       ok: false,
       status: 503,
     } as unknown as Response);
@@ -167,7 +167,7 @@ describe("InstallPromptDialog", () => {
     const onDone = vi.fn();
     const fakeBytes = new Uint8Array([1]).buffer;
 
-    global.fetch = vi.fn().mockResolvedValueOnce({
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
       arrayBuffer: vi.fn().mockResolvedValueOnce(fakeBytes),
     } as unknown as Response);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1480,7 +1480,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.18.0{devMode && " (Dev Mode)"}
+                  Version 0.17.3{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
Rolls back the stillborn 0.18.0 (CI builds failed on a pre-existing typecheck error) and releases the same content as **v0.17.3** instead.

- All 4 version files bumped to `0.17.3` (package.json, Cargo.toml, tauri.conf.json, Settings.tsx)
- `Cargo.lock` regenerated
- CHANGELOG entry heading changed `[0.18.0]` → `[0.17.3]`; body unchanged
- **Build fix**: `src/__tests__/components/InstallPromptDialog.test.tsx` used `global.fetch` (Node-only); swapped to `globalThis.fetch` so `tsc` — which tauri's `beforeBuildCommand` invokes via `bun run build` — stops failing the release build

### Content since v0.17.2 (unchanged from what 0.18.0 would have shipped)
- Sound effects, Sound tab, Sound Library, Loop While Busy (#115)
- Multi-image Smart Import + duplicate frame button (#115)
- Deep-link install `animime://` (#114)

## Test plan
- [ ] `bun run build` passes locally (verified)
- [ ] After merge + tag push, all 4 CI build jobs succeed and DMGs are attached to the v0.17.3 release
- [ ] Settings → About shows Version 0.17.3
- [ ] Install a fresh v0.17.3 DMG on aarch64 macOS — app launches, sounds play, SmartImport multi-select works, `animime://` deep-link opens install prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)