### PR TITLE
feat: event-driven sessions + session count badge + tooltip & shell polish

### DIFF
--- a/src-tauri/script/terminal-mirror.bash
+++ b/src-tauri/script/terminal-mirror.bash
@@ -18,7 +18,7 @@ _tm_is_claude() {
 # --- Command categorization ---
 _tm_classify() {
   local cmd="$1"
-  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|docker-compose|docker\ compose|up|ssh) ]]; then
+  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|expo|docker-compose|docker\ compose|up|run\ dev|run\ start|run\ serve|run\ ios|run\ android|ssh)([[:space:]]|$) ]]; then
     echo "service"
   else
     echo "task"

--- a/src-tauri/script/terminal-mirror.fish
+++ b/src-tauri/script/terminal-mirror.fish
@@ -16,7 +16,7 @@ end
 # --- Command categorization ---
 function _tm_classify
     set -l cmd "$argv[1]"
-    if string match -rq '(^|\s|/)(start|dev|serve|watch|metro|docker-compose|docker compose|up|ssh)(\s|$)' -- "$cmd"
+    if string match -rq '(^|\s|/)(start|dev|serve|watch|metro|expo|docker-compose|docker compose|up|run dev|run start|run serve|run ios|run android|ssh)(\s|$)' -- "$cmd"
         echo "service"
     else
         echo "task"

--- a/src-tauri/script/terminal-mirror.zsh
+++ b/src-tauri/script/terminal-mirror.zsh
@@ -21,7 +21,7 @@ _tm_is_claude() {
 # "task"    = normal command, stay busy until done
 _tm_classify() {
   local cmd="$1"
-  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|docker-compose|docker\ compose|up|run\ dev|run\ start|run\ serve|ssh)([[:space:]]|$) ]]; then
+  if [[ "$cmd" =~ (^|[[:space:]/])(start|dev|serve|watch|metro|expo|docker-compose|docker\ compose|up|run\ dev|run\ start|run\ serve|run\ ios|run\ android|ssh)([[:space:]]|$) ]]; then
     echo "service"
   else
     echo "task"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ use tauri::{Emitter, Manager};
 use tauri::menu::{MenuBuilder, SubmenuBuilder, PredefinedMenuItem, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
 
-use crate::state::{AppState, SessionInfo};
+use crate::state::{AppState, PeerInfo, SessionInfo};
 
 const VISIT_DURATION_SECS: u64 = 8;
 /// Visit duration when the sender attached a message. Currently equal
@@ -84,6 +84,12 @@ fn get_sessions(state: tauri::State<'_, Arc<Mutex<AppState>>>) -> Vec<SessionInf
         is_claude_proc: s.is_claude_proc,
         fg_cmd: s.fg_cmd.clone(),
     }).collect()
+}
+
+#[tauri::command]
+fn get_peers(state: tauri::State<'_, Arc<Mutex<AppState>>>) -> Vec<PeerInfo> {
+    let st = state.lock().unwrap();
+    st.peers.values().cloned().collect()
 }
 
 #[tauri::command]
@@ -429,7 +435,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
-        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, get_sessions, focus_terminal, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible, set_tray_visible, request_local_network, claude_config::get_claude_config, claude_config::set_plugin_enabled, claude_config::get_command_content, claude_config::delete_command, claude_config::delete_mcp_server, claude_config::delete_hook_entry])
+        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, get_sessions, get_peers, focus_terminal, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible, set_tray_visible, request_local_network, claude_config::get_claude_config, claude_config::set_plugin_enabled, claude_config::get_command_content, claude_config::delete_command, claude_config::delete_mcp_server, claude_config::delete_hook_entry])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
 
@@ -600,6 +606,7 @@ pub fn run() {
                 longest_task_today_secs: 0,
                 last_task_duration_secs: 0,
                 usage_day: crate::helpers::now_secs() / 86400,
+                last_sessions_fingerprint: 0,
             }));
 
             app.manage(app_state.clone());
@@ -607,7 +614,7 @@ pub fn run() {
 
             server::start_http_server(app.handle().clone(), app_state.clone());
             watchdog::start_watchdog(app.handle().clone(), app_state.clone());
-            proc_scan::start_proc_scanner(app_state.clone());
+            proc_scan::start_proc_scanner(app.handle().clone(), app_state.clone());
 
             // Start mDNS peer discovery
             let discovery_handle = app.handle().clone();

--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -547,7 +547,7 @@ fn title_from_pwd(pwd: &str) -> String {
     pwd.rsplit('/').next().unwrap_or("").to_string()
 }
 
-fn reconcile(app_state: &Arc<Mutex<AppState>>) {
+fn reconcile(app_handle: &tauri::AppHandle, app_state: &Arc<Mutex<AppState>>) {
     let procs = scan_processes();
     if procs.is_empty() {
         return;
@@ -650,9 +650,14 @@ fn reconcile(app_state: &Arc<Mutex<AppState>>) {
     for (pid, session) in st.sessions.iter_mut() {
         session.is_claude_proc = claude_pids.contains(pid);
     }
+
+    // Fire `status-changed` / `sessions-changed` if this pass actually
+    // mutated anything the UI cares about. Before this, proc_scan mutated
+    // silently and the frontend had to poll.
+    crate::state::emit_if_changed(app_handle, &mut st);
 }
 
-pub fn start_proc_scanner(app_state: Arc<Mutex<AppState>>) {
+pub fn start_proc_scanner(app_handle: tauri::AppHandle, app_state: Arc<Mutex<AppState>>) {
     crate::app_log!(
         "[proc_scan] starting (interval={}s)",
         SCAN_INTERVAL_SECS
@@ -660,6 +665,6 @@ pub fn start_proc_scanner(app_state: Arc<Mutex<AppState>>) {
 
     std::thread::spawn(move || loop {
         std::thread::sleep(std::time::Duration::from_secs(SCAN_INTERVAL_SECS));
-        reconcile(&app_state);
+        reconcile(&app_handle, &app_state);
     });
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use serde::Serialize;
 use tauri::Emitter;
 
@@ -128,6 +130,33 @@ pub struct AppState {
     pub longest_task_today_secs: u64,
     pub last_task_duration_secs: u64,
     pub usage_day: u64,
+    /// Hash of the session fields exposed to the UI. `emit_if_changed` emits
+    /// `sessions-changed` only when this value shifts, so the frontend can
+    /// stay event-driven instead of polling.
+    pub last_sessions_fingerprint: u64,
+}
+
+/// Deterministic hash of the session fields the UI renders. Pids are sorted so
+/// the result doesn't depend on `HashMap` iteration order.
+fn sessions_fingerprint(sessions: &HashMap<u32, Session>) -> u64 {
+    let mut pids: Vec<u32> = sessions.keys().copied().collect();
+    pids.sort_unstable();
+
+    let mut h = DefaultHasher::new();
+    for pid in pids {
+        let s = &sessions[&pid];
+        pid.hash(&mut h);
+        s.ui_state.hash(&mut h);
+        s.busy_type.hash(&mut h);
+        s.pwd.hash(&mut h);
+        s.title.hash(&mut h);
+        s.tty.hash(&mut h);
+        s.has_claude.hash(&mut h);
+        s.claude_pid.hash(&mut h);
+        s.is_claude_proc.hash(&mut h);
+        s.fg_cmd.hash(&mut h);
+    }
+    h.finish()
 }
 
 /// Picks the "winning" UI state across all sessions.
@@ -163,6 +192,10 @@ pub fn emit_if_changed(app: &tauri::AppHandle, state: &mut AppState) {
             crate::app_log!("[state] waking from sleep for {}", new_ui);
             state.sleeping = false;
         } else {
+            // Still check for session-set changes even while sleeping, so the
+            // session-list UI updates (e.g. a shell exiting shouldn't wait for
+            // the next global transition).
+            maybe_emit_sessions_changed(app, state);
             return;
         }
     }
@@ -180,5 +213,17 @@ pub fn emit_if_changed(app: &tauri::AppHandle, state: &mut AppState) {
             crate::app_error!("[state] failed to emit status-changed: {}", e);
         }
         state.current_ui = new_ui.to_string();
+    }
+
+    maybe_emit_sessions_changed(app, state);
+}
+
+fn maybe_emit_sessions_changed(app: &tauri::AppHandle, state: &mut AppState) {
+    let fp = sessions_fingerprint(&state.sessions);
+    if fp != state.last_sessions_fingerprint {
+        state.last_sessions_fingerprint = fp;
+        if let Err(e) = app.emit("sessions-changed", ()) {
+            crate::app_error!("[state] failed to emit sessions-changed: {}", e);
+        }
     }
 }

--- a/src/SessionListApp.tsx
+++ b/src/SessionListApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -154,14 +154,17 @@ export function SessionListApp() {
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
   const [pathTooltip, setPathTooltip] = useState<{
     text: string;
-    x: number;
-    y: number;
+    anchorX: number;
+    anchorTop: number;
+    anchorBottom: number;
   } | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
 
   useTheme();
   useWindowAutoSize(rootRef);
 
-  // Refresh sessions on mount, on status-changed, and every 3s while shown.
+  // Refresh sessions on mount and whenever the backend fires
+  // `sessions-changed` (fingerprint-gated emit). No polling.
   useEffect(() => {
     let cancelled = false;
 
@@ -174,14 +177,12 @@ export function SessionListApp() {
 
     void refresh();
 
-    const unlistenP = listen("status-changed", () => {
+    const unlistenP = listen("sessions-changed", () => {
       void refresh();
     });
-    const id = setInterval(refresh, 3000);
 
     return () => {
       cancelled = true;
-      clearInterval(id);
       unlistenP.then((fn) => fn());
     };
   }, []);
@@ -206,11 +207,40 @@ export function SessionListApp() {
     const rect = el.getBoundingClientRect();
     setPathTooltip({
       text,
-      x: Math.round(rect.left + rect.width / 2),
-      y: Math.round(rect.top),
+      anchorX: rect.left + rect.width / 2,
+      anchorTop: rect.top,
+      anchorBottom: rect.bottom,
     });
   };
   const hidePathTooltip = () => setPathTooltip(null);
+
+  // Measure the tooltip after render and clamp to the viewport so the full
+  // path stays visible regardless of window width.
+  useLayoutEffect(() => {
+    if (!pathTooltip) return;
+    const el = tooltipRef.current;
+    if (!el) return;
+
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const MARGIN = 8;
+    const GAP = 6;
+    const vw = window.innerWidth;
+
+    const placeAbove = pathTooltip.anchorTop >= h + GAP + MARGIN;
+    const y = placeAbove
+      ? pathTooltip.anchorTop - h - GAP
+      : pathTooltip.anchorBottom + GAP;
+
+    let x = pathTooltip.anchorX - w / 2;
+    x = Math.max(MARGIN, Math.min(x, vw - w - MARGIN));
+
+    el.style.left = `${Math.round(x)}px`;
+    el.style.top = `${Math.round(y)}px`;
+    el.style.setProperty("--arrow-x", `${Math.round(pathTooltip.anchorX - x)}px`);
+    el.classList.toggle("below", !placeAbove);
+    el.style.visibility = "visible";
+  }, [pathTooltip]);
 
   const onItemClick = (s: SessionInfo) => {
     invoke("focus_terminal", { pid: s.pid, tty: s.tty || null }).catch((err) =>
@@ -252,10 +282,7 @@ export function SessionListApp() {
                     </span>
                   )}
                 </span>
-                {g.sessions.length > 1 && (
-                  <span className="session-count">{g.sessions.length}</span>
-                )}
-              </>
+                </>
             );
             return (
               <div
@@ -321,8 +348,9 @@ export function SessionListApp() {
       {pathTooltip &&
         createPortal(
           <div
+            ref={tooltipRef}
             className="session-path-tooltip"
-            style={{ left: pathTooltip.x, top: pathTooltip.y }}
+            style={{ visibility: "hidden" }}
             role="tooltip"
           >
             {pathTooltip.text}

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -11,6 +11,7 @@ import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { Status } from "../types/status";
 import { fetchSessions, type SessionInfo } from "../hooks/useSessions";
 import { useSessionList } from "../hooks/useSessionList";
+import { useSessionGroupCount } from "../hooks/useSessionGroupCount";
 import { useLanList } from "../hooks/useLanList";
 import { useOpacity } from "../hooks/useOpacity";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
@@ -232,6 +233,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
   const [dropdownMaxHeight, setDropdownMaxHeight] = useState(280);
   const wrapRef = useRef<HTMLDivElement>(null);
   const { enabled: sessionListEnabled } = useSessionList();
+  const sessionCount = useSessionGroupCount(sessionListEnabled);
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
 
   // --- Peer popover state ---
@@ -252,19 +254,51 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
   // overflow:auto doesn't clip it when it renders above the first row). ---
   const [pathTooltip, setPathTooltip] = useState<{
     text: string;
-    x: number;
-    y: number;
+    anchorX: number;
+    anchorTop: number;
+    anchorBottom: number;
   } | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
 
   const showPathTooltip = (el: HTMLElement, text: string) => {
     const rect = el.getBoundingClientRect();
     setPathTooltip({
       text,
-      x: Math.round(rect.left + rect.width / 2),
-      y: Math.round(rect.top),
+      anchorX: rect.left + rect.width / 2,
+      anchorTop: rect.top,
+      anchorBottom: rect.bottom,
     });
   };
   const hidePathTooltip = () => setPathTooltip(null);
+
+  // Position the tooltip after render so we can measure its actual size and
+  // clamp it inside the window — paths are often wider than the dropdown,
+  // which would otherwise leave the tooltip clipped by the window edge.
+  useLayoutEffect(() => {
+    if (!pathTooltip) return;
+    const el = tooltipRef.current;
+    if (!el) return;
+
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const MARGIN = 8;
+    const GAP = 6;
+    const vw = window.innerWidth;
+
+    const placeAbove = pathTooltip.anchorTop >= h + GAP + MARGIN;
+    const y = placeAbove
+      ? pathTooltip.anchorTop - h - GAP
+      : pathTooltip.anchorBottom + GAP;
+
+    let x = pathTooltip.anchorX - w / 2;
+    x = Math.max(MARGIN, Math.min(x, vw - w - MARGIN));
+
+    el.style.left = `${Math.round(x)}px`;
+    el.style.top = `${Math.round(y)}px`;
+    el.style.setProperty("--arrow-x", `${Math.round(pathTooltip.anchorX - x)}px`);
+    el.classList.toggle("below", !placeAbove);
+    el.style.visibility = "visible";
+  }, [pathTooltip]);
 
   useEffect(() => {
     onOpenChange?.(sessionOpen);
@@ -314,7 +348,9 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
     if (!sessionListEnabled && sessionOpen) setSessionOpen(false);
   }, [sessionListEnabled, sessionOpen]);
 
-  // Live session refresh while dropdown is open.
+  // Live session refresh while dropdown is open. Event-driven via
+  // `sessions-changed` (emitted by the backend only when the session set or
+  // any UI-relevant field changes) — no polling.
   useEffect(() => {
     if (!sessionOpen) return;
     let cancelled = false;
@@ -326,14 +362,12 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
       setGroups(groupSessions(overlaid, detectHome(overlaid)));
     };
 
-    const unlistenP = listen("status-changed", () => {
+    const unlistenP = listen("sessions-changed", () => {
       void refresh();
     });
-    const id = setInterval(refresh, 3000);
 
     return () => {
       cancelled = true;
-      clearInterval(id);
       unlistenP.then((fn) => fn());
     };
   }, [sessionOpen]);
@@ -453,7 +487,7 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
               data-testid="pill-action-task"
               className={`pill-action-btn ${sessionOpen ? "is-active" : ""}`}
               onClick={toggleSession}
-              aria-label="Show sessions list"
+              aria-label={`Show sessions list (${sessionCount})`}
               aria-expanded={sessionOpen}
               title="Session list"
             >
@@ -467,6 +501,11 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
               >
                 <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM7 9h10v2H7V9zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" />
               </svg>
+              {sessionCount > 0 && (
+                <span className="pill-action-badge" data-testid="pill-action-task-badge">
+                  {sessionCount}
+                </span>
+              )}
             </button>
           )}
 
@@ -540,9 +579,6 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
                       </span>
                     )}
                   </span>
-                  {g.sessions.length > 1 && (
-                    <span className="session-count">{g.sessions.length}</span>
-                  )}
                 </>
               );
               return (
@@ -612,8 +648,9 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
       {pathTooltip &&
         createPortal(
           <div
+            ref={tooltipRef}
             className="session-path-tooltip"
-            style={{ left: pathTooltip.x, top: pathTooltip.y }}
+            style={{ visibility: "hidden" }}
             role="tooltip"
           >
             {pathTooltip.text}

--- a/src/hooks/usePeers.ts
+++ b/src/hooks/usePeers.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
 export interface PeerInfo {
@@ -13,11 +14,21 @@ export function usePeers() {
   const [peers, setPeers] = useState<PeerInfo[]>([]);
 
   useEffect(() => {
+    let cancelled = false;
+
+    // `peers-changed` only fires on add/expire — seed initial state from
+    // the backend so the count shows up after reload/HMR without waiting
+    // for a peer join or leave.
+    invoke<PeerInfo[]>("get_peers").then((list) => {
+      if (!cancelled) setPeers(list);
+    });
+
     const unlisten = listen<PeerInfo[]>("peers-changed", (e) => {
       setPeers(e.payload);
     });
 
     return () => {
+      cancelled = true;
       unlisten.then((fn) => fn());
     };
   }, []);

--- a/src/hooks/useSessionGroupCount.ts
+++ b/src/hooks/useSessionGroupCount.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { fetchSessions } from "./useSessions";
+
+/**
+ * Live count of session groups — same grouping rule as the session dropdown:
+ * shells grouped by pwd, plus the Claude Code virtual row if no shell owns it.
+ * Event-driven: fetches once on mount, then refreshes only when the backend
+ * emits `sessions-changed` (fingerprint-gated — no refresh unless something
+ * the UI cares about actually changed).
+ */
+export function useSessionGroupCount(enabled: boolean = true): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      setCount(0);
+      return;
+    }
+
+    let cancelled = false;
+
+    const refresh = async () => {
+      const list = await fetchSessions();
+      if (cancelled) return;
+
+      const keys = new Set<string>();
+      let hasClaudeVirtual = false;
+      let anyShellHasClaude = false;
+
+      for (const s of list) {
+        if (s.pid === 0) {
+          hasClaudeVirtual = true;
+          continue;
+        }
+        if (s.is_claude_proc) continue;
+        if (s.has_claude) anyShellHasClaude = true;
+        keys.add(s.pwd || s.title || String(s.pid));
+      }
+
+      let n = keys.size;
+      if (hasClaudeVirtual && !anyShellHasClaude) n += 1;
+      setCount(n);
+    };
+
+    void refresh();
+    const unlistenP = listen("sessions-changed", () => void refresh());
+
+    return () => {
+      cancelled = true;
+      unlistenP.then((fn) => fn());
+    };
+  }, [enabled]);
+
+  return count;
+}

--- a/src/styles/session-list-window.css
+++ b/src/styles/session-list-window.css
@@ -123,19 +123,6 @@ button.session-group-head:hover {
   opacity: 0.9;
 }
 
-.session-count {
-  flex-shrink: 0;
-  min-width: 16px;
-  padding: 1px 5px;
-  border-radius: 9999px;
-  background: var(--bg-pill-hover);
-  border: 1px solid var(--border-pill);
-  font-size: 10px;
-  font-weight: 600;
-  text-align: center;
-  opacity: 0.75;
-}
-
 .session-group-info {
   position: relative;
   display: inline-flex;
@@ -166,7 +153,6 @@ button.session-group-head:hover {
    ? icon's getBoundingClientRect. */
 .session-path-tooltip {
   position: fixed;
-  transform: translate(-50%, calc(-100% - 6px));
   padding: 5px 8px;
   background: rgba(0, 0, 0, 0.9);
   color: rgba(255, 255, 255, 0.95);
@@ -174,21 +160,32 @@ button.session-group-head:hover {
   font-family: "SF Mono", "Menlo", "Monaco", monospace;
   font-size: 10px;
   font-weight: 400;
-  white-space: nowrap;
+  max-width: calc(100vw - 16px);
+  overflow-wrap: anywhere;
   pointer-events: none;
   z-index: 10000;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   animation: path-tooltip-in 0.08s ease-out;
 }
 
+/* Arrow pointing at the ? icon. `--arrow-x` is set in JS relative to the
+   tooltip's left edge so the arrow tracks the icon even after clamping. */
 .session-path-tooltip::after {
   content: "";
   position: absolute;
   top: 100%;
-  left: 50%;
+  left: var(--arrow-x, 50%);
   transform: translateX(-50%);
   border: 4px solid transparent;
   border-top-color: rgba(0, 0, 0, 0.9);
+}
+
+/* Flipped: tooltip sits *below* the ? icon when there isn't room above. */
+.session-path-tooltip.below::after {
+  top: auto;
+  bottom: 100%;
+  border-top-color: transparent;
+  border-bottom-color: rgba(0, 0, 0, 0.9);
 }
 
 @keyframes path-tooltip-in {

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -278,19 +278,6 @@ button.session-group-head:hover {
   opacity: 0.9;
 }
 
-.session-count {
-  flex-shrink: 0;
-  min-width: 16px;
-  padding: 1px 5px;
-  border-radius: 9999px;
-  background: var(--bg-pill-hover);
-  border: 1px solid var(--border-pill);
-  font-size: 10px;
-  font-weight: 600;
-  text-align: center;
-  opacity: 0.75;
-}
-
 /* Little ? circle next to the basename that reveals full path on hover. */
 .session-group-info {
   position: relative;
@@ -324,7 +311,6 @@ button.session-group-head:hover {
    transform parks the tooltip just above the icon. */
 .session-path-tooltip {
   position: fixed;
-  transform: translate(-50%, calc(-100% - 6px));
   padding: 5px 8px;
   background: rgba(0, 0, 0, 0.9);
   color: rgba(255, 255, 255, 0.95);
@@ -332,22 +318,33 @@ button.session-group-head:hover {
   font-family: "SF Mono", "Menlo", "Monaco", monospace;
   font-size: 10px;
   font-weight: 400;
-  white-space: nowrap;
+  max-width: calc(100vw - 16px);
+  overflow-wrap: anywhere;
   pointer-events: none;
   z-index: 10000;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   animation: path-tooltip-in 0.08s ease-out;
 }
 
-/* Arrow pointing down from the tooltip toward the ? icon. */
+/* Arrow pointing down at the ? icon. `--arrow-x` is set in JS relative to
+   the tooltip's left edge so the arrow stays on the icon even when the
+   tooltip is shifted horizontally to avoid clipping the viewport. */
 .session-path-tooltip::after {
   content: "";
   position: absolute;
   top: 100%;
-  left: 50%;
+  left: var(--arrow-x, 50%);
   transform: translateX(-50%);
   border: 4px solid transparent;
   border-top-color: rgba(0, 0, 0, 0.9);
+}
+
+/* Flipped: tooltip sits *below* the ? icon when there isn't room above. */
+.session-path-tooltip.below::after {
+  top: auto;
+  bottom: 100%;
+  border-top-color: transparent;
+  border-bottom-color: rgba(0, 0, 0, 0.9);
 }
 
 @keyframes path-tooltip-in {


### PR DESCRIPTION
## Summary
- **Perf / architecture:** Moved session state updates from polling to events. Backend now emits a `sessions-changed` event via a fingerprint diff in `emit_if_changed` whenever session state mutates. Wired `proc_scan::reconcile` to flow through the same emit path — previously it mutated sessions silently every 2s, which is why the frontend had to poll. All three consumers (`useSessionGroupCount`, `StatusPill` dropdown, `SessionListApp`) now listen to the event and drop their 3s polls.
- **Peer badge after reload:** added `get_peers` Tauri command. `usePeers` now seeds initial state on mount instead of waiting for a `peers-changed` event that only fires on add/expire — fixes the missing peer count after HMR/window reload.
- **Session count badge:** the pill task icon now shows the number of session groups (grouped by pwd, same rule as the dropdown), matching the peer badge style. Also removed the redundant per-group child count inside the dropdown rows.
- **Path tooltip viewport clamping:** tooltip now measures itself in `useLayoutEffect` and clamps `left` / `top` to the window. Long paths wrap (`overflow-wrap: anywhere`, `max-width: calc(100vw - 16px)`) instead of overflowing past the window's left edge. Arrow follows the icon via a `--arrow-x` CSS var after clamping. Auto-flips below when there's no room above.
- **Shell classification:** `bun run ios`, `bun run android`, `expo run:*`, `npx expo …` now classify as `service` across zsh / bash / fish. Synced the three regexes and added a trailing anchor in bash so `expo` doesn't accidentally match `export` (also fixes the pre-existing `dev` vs. `devtool` issue).

## Test plan
- [ ] Open 3+ shells across 2+ pwds — dropdown groups correctly, pill task-icon badge shows the group count.
- [ ] Run `bun run ios` / `expo start` — pill flashes blue, session row stays labelled `service` until the command exits.
- [ ] Kill a shell — dropdown + badge update within the next proc_scan pass (~2s), no manual refresh.
- [ ] Reload the main window (HMR or fresh open) while peers are active — peer count badge reappears immediately (via `get_peers`).
- [ ] Hover the `?` on the first dropdown row with a very long path — tooltip flips below the icon, stays inside the window.
- [ ] Hover `?` on a row with a long path that would center outside the window — tooltip clamps to the window edge, arrow still points at the icon.
- [ ] Confirm no frontend 3s polls remain on session state (grep `setInterval` — only `SuperpowerTool` log tail should remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)