### PR TITLE
chore: release v0.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.17.4] - 2026-04-23
+
+### Added
+- **Session-count badge** on the pill task icon, showing the number of active session groups (grouped by pwd) — matches the peer-count badge style.
+- **Expo / React Native command classification** — `bun run ios`, `bun run android`, `expo run:*`, `npx expo …` now classify as `service` across zsh / bash / fish. Previously stayed busy indefinitely.
+
+### Changed
+- **Event-driven session updates** — backend emits a fingerprint-gated `sessions-changed` event whenever session state mutates (including `proc_scan` passes, which used to mutate silently). `useSessionGroupCount`, the `StatusPill` dropdown, and the `SessionListApp` window all drop their 3-second polls and listen to the event instead.
+- Removed the redundant per-group child-count pill inside dropdown rows.
+
+### Fixed
+- **Peer-count badge** now survives window reload / HMR — added a `get_peers` Tauri command; `usePeers` seeds from it on mount instead of waiting for a `peers-changed` event that only fires on add/expire.
+- **Path tooltip** no longer gets clipped by the window edge — it measures itself after render and clamps both axes to the viewport, wrapping long paths instead of overflowing. Arrow tracks the `?` icon after clamping and flips automatically when placed below.
+
 ## [0.17.3] - 2026-04-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.3",
+  "version": "0.17.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.3"
+version = "0.17.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1480,7 +1480,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.3{devMode && " (Dev Mode)"}
+                  Version 0.17.4{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
Release v0.17.4.

## Highlights
- Session-count badge on pill task icon
- Event-driven session updates (drops 3s polls across the app)
- Expo / RN commands (`bun run ios/android`, `expo run:*`) classified as service
- Peer-count badge survives window reload (new `get_peers` command)
- Path tooltip viewport clamping — long paths wrap, arrow tracks the icon

See CHANGELOG.md for full details.

## Test plan
- [x] `cargo check` clean (regenerates Cargo.lock with new version)
- [x] `tsc --noEmit` clean
- [ ] Merge, tag `v0.17.4`, push → CI builds DMGs
- [ ] Update Homebrew cask after DMGs publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)