### PR TITLE
chore: release v0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.17.5] - 2026-04-23
+
+### Fixed
+- **Window no longer gets stuck at an oversized 1200×1200 after busy transitions.** The shadow-clone effect expanded the window even when its toggle was off, and rapid busy→idle→busy could corrupt the saved pre-expansion baseline so the next "restore" locked the window at the expanded size. Disabled effects now skip the expand path entirely, and the baseline capture is guarded against reentrant overwrites.
+
 ## [0.17.4] - 2026-04-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.4",
+  "version": "0.17.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.4"
+version = "0.17.5"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1480,7 +1480,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.4{devMode && " (Dev Mode)"}
+                  Version 0.17.5{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>

--- a/src/effects/EffectOverlay.tsx
+++ b/src/effects/EffectOverlay.tsx
@@ -7,7 +7,7 @@ import { usePet } from "../hooks/usePet";
 import { useScale } from "../hooks/useScale";
 import { useCustomMimes } from "../hooks/useCustomMimes";
 import { getSpriteMap } from "../constants/sprites";
-import { useEffectEnabled } from "./useEffectEnabled";
+import { useEffectEnabled, isEffectEnabledAsync } from "./useEffectEnabled";
 import { effects } from "./index";
 import type { EffectDefinition } from "./types";
 
@@ -119,16 +119,25 @@ export function EffectOverlay({ onActiveChange }: EffectOverlayProps) {
   const expandWindow = useCallback(async (size: number) => {
     try {
       const win = getCurrentWindow();
-      const factor = await win.scaleFactor();
-      const physPos = await win.outerPosition();
-      const physSize = await win.outerSize();
 
-      const logX = physPos.x / factor;
-      const logY = physPos.y / factor;
-      const logW = physSize.width / factor;
-      const logH = physSize.height / factor;
+      // Only capture the baseline when we don't already have one. If we
+      // do, the previous stopEffect's restoreWindow is still in flight —
+      // reading win.outerSize() now would capture the expanded size as
+      // "normal" and lock the window at `size` x `size` on the next
+      // restore (rapid busy→idle→busy used to leave the window stuck).
+      if (!savedWindowRef.current) {
+        const factor = await win.scaleFactor();
+        const physPos = await win.outerPosition();
+        const physSize = await win.outerSize();
+        savedWindowRef.current = {
+          x: physPos.x / factor,
+          y: physPos.y / factor,
+          w: physSize.width / factor,
+          h: physSize.height / factor,
+        };
+      }
 
-      savedWindowRef.current = { x: logX, y: logY, w: logW, h: logH };
+      const { x: logX, y: logY, w: logW, h: logH } = savedWindowRef.current;
 
       // Pin content position BEFORE resizing to prevent centering shift
       pinRootContent();
@@ -204,6 +213,15 @@ export function EffectOverlay({ onActiveChange }: EffectOverlayProps) {
     let cancelled = false;
 
     const activate = async () => {
+      // Gate on the persisted toggle BEFORE touching the window. The
+      // enable check inside EffectRunner only suppresses sprite render —
+      // it can't prevent expandWindow from running, so without this
+      // guard a disabled effect still grows the window (then snaps
+      // back), which compounds with the savedWindowRef race above and
+      // can leave the window stuck at the expanded size.
+      if (!(await isEffectEnabledAsync(matchingEffect.id))) return;
+      if (cancelled) return;
+
       let spriteUrl: string;
       let frames: number;
 

--- a/src/effects/useEffectEnabled.ts
+++ b/src/effects/useEffectEnabled.ts
@@ -20,6 +20,21 @@ function eventName(effectId: string) {
  */
 const cache = new Map<string, boolean>();
 
+/**
+ * Async lookup used outside React render (e.g. inside an effect callback)
+ * to gate on the persisted value. Returns the cached value when present,
+ * otherwise reads the store and populates the cache. Defaults to `true`
+ * when no value is persisted, matching the hook's default.
+ */
+export async function isEffectEnabledAsync(effectId: string): Promise<boolean> {
+  if (cache.has(effectId)) return cache.get(effectId)!;
+  const store = await load(STORE_FILE);
+  const val = await store.get<boolean>(storeKey(effectId));
+  const resolved = val !== null && val !== undefined ? val : true;
+  cache.set(effectId, resolved);
+  return resolved;
+}
+
 export function useEffectEnabled(effectId: string) {
   // Initializer function → only runs on first render. Reads from cache if we
   // have it, else falls back to the app-wide default of "on".


### PR DESCRIPTION
## Summary
- Fix shadow-clone effect leaving the Tauri window stuck at 1200×1200 after busy transitions (affects users regardless of whether shadow-clone is enabled in Settings).
- Bump version to 0.17.5 across package.json, Cargo.toml, tauri.conf.json, Settings.tsx; add CHANGELOG entry.

## Root cause
Two bugs in `src/effects/EffectOverlay.tsx`:
1. `expandWindow` ran even for disabled effects — the enable check inside `EffectRunner` only gates sprite render, not the window resize.
2. Rapid busy→idle→busy could fire a second `expandWindow` while `restoreWindow` was still in flight, overwriting `savedWindowRef` with the already-expanded 1200×1200 — the next restore then "restored" to that size.

## Fix
- Gate `activate()` on `isEffectEnabledAsync(matchingEffect.id)` before touching the window.
- Only capture the baseline in `expandWindow` when `savedWindowRef.current` is null (prevents reentrant overwrite).

## Test plan
- [ ] `npx tsc --noEmit` clean (done locally)
- [ ] `cd src-tauri && cargo check` clean (done locally)
- [ ] Manual: with shadow-clone disabled, trigger repeated busy transitions (start/stop claude) — window stays at its natural ~320×250 size.
- [ ] Manual: with shadow-clone enabled, a busy transition still grows to 1200×1200 for 2s and restores cleanly; rapid busy→idle→busy restores correctly too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)