### PR TITLE
chore: release v0.17.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.17.6] - 2026-04-29
+
+### Changed
+- **Fixed-default pet window with explicit size triggers** — the main window now starts at a single fixed default and only grows when a named trigger fires (session list, visitors, speech bubble), shrinking back when the trigger clears. Removes the cascade of auto-size effects that could leave the window in inconsistent states.
+
+### Fixed
+- **DEV Tag toggle no longer kills the bounds outlines.** Toggling DEV Tag off in the Superpower tool used to call `set_dev_mode(false)`, which dropped the App / Container / Root bounds visuals along with the tag. The toggle now emits a dedicated `dev-tag-changed` event and only hides the DEV tag.
+- **Auto-open Superpower on dev unlock** — clicking the version label 10 times now opens the Superpower window automatically, not just enables dev mode silently.
+
 ## [0.17.5] - 2026-04-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.5",
+  "version": "0.17.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.5"
+version = "0.17.6"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1481,7 +1481,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.5{devMode && " (Dev Mode)"}
+                  Version 0.17.6{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
- Bump version to 0.17.6 across `package.json`, `Cargo.toml`, `tauri.conf.json`, and the Settings about-page string.
- Adds CHANGELOG entry covering the window-sizing refactor (#122) and the DEV Tag toggle decoupling.

## Test plan
- [ ] Verify Settings about page shows `Version 0.17.6`
- [ ] Tag `v0.17.6` on `main` once merged so CI publishes the DMGs
- [ ] After release, update Homebrew cask with new SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)