### PR TITLE
improve: ani-mime 2026.05.04

### DIFF
--- a/src/hooks/useLanList.ts
+++ b/src/hooks/useLanList.ts
@@ -3,14 +3,23 @@ import { load } from "@tauri-apps/plugin-store";
 import { emit, listen } from "@tauri-apps/api/event";
 
 const STORAGE_KEY = "lanListEnabled";
+const MIGRATION_KEY = "lanListDefaultFalseMigrated";
 const EVENT_NAME = "lan-list-changed";
 
-/** Whether the LAN (peers) icon in the status pill is shown. Defaults to on. */
+/** Whether the LAN (peers) icon in the status pill is shown. Defaults to off. */
 export function useLanList() {
-  const [enabled, setEnabledState] = useState(true);
+  const [enabled, setEnabledState] = useState(false);
 
   useLayoutEffect(() => {
     load("settings.json").then(async (store) => {
+      const migrated = await store.get<boolean>(MIGRATION_KEY);
+      if (!migrated) {
+        await store.set(STORAGE_KEY, false);
+        await store.set(MIGRATION_KEY, true);
+        await store.save();
+        setEnabledState(false);
+        return;
+      }
       const val = await store.get<boolean>(STORAGE_KEY);
       if (val !== null && val !== undefined) {
         setEnabledState(val);

--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -103,6 +103,10 @@
   border-color: rgba(52, 199, 89, 0.5);
 }
 
+.pill-action-btn[data-testid="pill-action-task"] {
+  border-radius: 0;
+}
+
 .pill-action-icon {
   opacity: 0.75;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Default `lanListEnabled` to `false` for new installs.
- One-time migration: on first launch after this update, force `lanListEnabled` to `false` for every existing user (gated by a new `lanListDefaultFalseMigrated` flag in `settings.json`), then the toggle behaves normally.
- Remove the circular `border-radius` from the session list icon button on the status pill (LAN button keeps its rounded shape).

## Test plan
- [ ] Fresh install: LAN peer list toggle in Settings is **off** by default; status pill hides the LAN icon.
- [ ] Upgrade path: existing user with the LAN list previously enabled launches the new build once and lands on **off**; flipping it back to **on** persists across restarts (migration does not re-fire).
- [ ] Status pill: session list icon renders with square corners; LAN icon remains a circle.
- [ ] `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)