### PR TITLE
fix(claude-hooks): mirror busy/idle via stdin-aware Node hook

### DIFF
--- a/docs/superpowers/specs/2026-05-05-claude-hook-mirror-fix-design.md
+++ b/docs/superpowers/specs/2026-05-05-claude-hook-mirror-fix-design.md
@@ -1,0 +1,166 @@
+# Claude Code Hook Mirror Fix — Stdin-Aware Wrapper Script
+
+**Date:** 2026-05-05
+**Branch (suggested):** `fix/claude-hook-mirror`
+**Status:** Approved (design)
+
+## Problem
+
+ani-mime mirrors Claude Code's working/idle status by registering inline `curl` hooks in `~/.claude/settings.json`. With recent Claude Code versions, the mirror is incorrect:
+
+1. **False idle / flicker during long sessions.** `SessionStart` now fires mid-turn with `source="compact"` whenever Claude auto-compacts. The current hook calls `state=idle` on every `SessionStart`, regardless of source — so the pill flips to **Free** while Claude is still **Working…**, then flicks back when the next `PreToolUse` fires.
+2. **Stuck busy after a failed turn.** `StopFailure` (turn ends in error) is not subscribed; `Stop` doesn't fire on failure → busy stays.
+3. **Stuck busy when Claude is waiting on the user.** `Notification` with `notification_type=permission_prompt` or `idle_prompt` is not subscribed → mirror stays **Working…** while Claude is actually idle waiting for input.
+
+Inline curl one-liners cannot read the stdin JSON payload, so they cannot distinguish `SessionStart(startup)` from `SessionStart(compact)`, nor `Notification(permission_prompt)` from `Notification(auth_success)`.
+
+## Goal
+
+Mirror Claude Code's working/idle state correctly through every hook event the latest Claude Code emits, with low ongoing maintenance as Claude continues to add events.
+
+## Non-Goals
+
+- New UI states (no new "waiting-for-permission" pill — `permission_prompt` maps to existing **Free**).
+- Changing the shell terminal-mirror scripts (`terminal-mirror.{zsh,bash,fish}`).
+- Replacing the HTTP wire format (`/status?pid=&state=&type=`) — that contract stays.
+
+## Approach — Stdin-aware Node hook script
+
+Replace the inline curl commands with a single Node script that reads the stdin JSON payload Claude Code sends to every hook, then routes to the existing `:1234/status` endpoint with the right state.
+
+Node is guaranteed available wherever Claude Code is installed (Claude Code itself runs on Node), so no new dependency.
+
+### Architecture
+
+```
+src-tauri/script/ani-mime-hook.mjs   ← bundled resource (new)
+        │ copied at every startup, like server.mjs
+        ▼
+~/.ani-mime/hooks/ani-mime-hook.mjs  ← installed location
+        │ invoked by Claude Code per hook event
+        ▼
+~/.claude/settings.json hooks → "node ~/.ani-mime/hooks/ani-mime-hook.mjs"
+        │ HTTP POST
+        ▼
+127.0.0.1:1234/status?pid=<claude_pid>&state=busy|idle&type=task
+```
+
+### Components
+
+| File | Responsibility |
+|---|---|
+| `src-tauri/script/ani-mime-hook.mjs` (new) | Reads stdin JSON, decides state, posts to `:1234`. Zero dependencies. |
+| `src-tauri/src/setup/hooks.rs` (new) | Installs the script to `~/.ani-mime/hooks/`. Mirrors `setup/mcp.rs`. Owns the canonical hook command string. |
+| `src-tauri/src/setup/claude.rs` (modified) | Uses `setup::hooks::HOOK_COMMAND` instead of inline curl. Hook event list updated to include `StopFailure` and `Notification`. |
+| `src-tauri/src/claude_config.rs` (modified) | `migrate_claude_hooks` upgrades existing users: replaces inline curl commands with the script command. |
+| `src-tauri/tauri.conf.json` (modified) | Add `script/ani-mime-hook.mjs` to bundle resources. |
+| `src-tauri/src/setup/mod.rs` (modified) | Call `hooks::install_hook_script(&home)` before `claude::setup_claude_hooks(&home)`. |
+
+### Hook Script Behavior
+
+`ani-mime-hook.mjs` reads stdin to EOF, parses JSON, and selects an action:
+
+| `hook_event_name` | Condition | POST | UI label after |
+|---|---|---|---|
+| `PreToolUse` | always | `state=busy&type=task` | **Working…** |
+| `UserPromptSubmit` | always | `state=busy&type=task` | **Working…** |
+| `Stop` | always | `state=idle` | **Free** |
+| `StopFailure` | always | `state=idle` | **Free** |
+| `SessionStart` | `source` ∈ {`startup`, `resume`, `clear`} | `state=idle` | **Free** |
+| `SessionStart` | `source == "compact"` | no-op | unchanged |
+| `SessionEnd` | always | `state=idle` | **Free** |
+| `Notification` | `notification_type` ∈ {`permission_prompt`, `idle_prompt`} | `state=idle` | **Free** |
+| `Notification` | other types | no-op | unchanged |
+| any other event | unknown | no-op (forward-compatible) | unchanged |
+
+PID: `process.ppid` (the `node` process is a direct child of the `claude` binary — same semantics as today's `$PPID`).
+
+### Error Handling
+
+- All logic wrapped in try/catch. Any error → `process.exit(0)`. Hooks must never block Claude.
+- HTTP request uses `AbortController` with 1000 ms timeout — matches today's `--max-time 1`.
+- Stdout silent on success. Errors → `console.error` (Claude logs first stderr line in debug log).
+- If stdin is empty or not JSON → exit 0 silently.
+- If `hook_event_name` is missing or unknown → exit 0 silently.
+
+### settings.json Layout (after install)
+
+```json
+{
+  "hooks": {
+    "PreToolUse":       [{ "matcher": "", "hooks": [{ "type": "command", "command": "node \"$HOME/.ani-mime/hooks/ani-mime-hook.mjs\" || true" }] }],
+    "UserPromptSubmit": [{ "matcher": "", "hooks": [{ "type": "command", "command": "node \"$HOME/.ani-mime/hooks/ani-mime-hook.mjs\" || true" }] }],
+    "Stop":             [...same...],
+    "StopFailure":      [...same...],
+    "SessionStart":     [...same...],
+    "SessionEnd":       [...same...],
+    "Notification":     [...same...]
+  }
+}
+```
+
+The `|| true` is kept so a missing/broken script never blocks Claude — same defense-in-depth as today.
+
+The marker used to detect "this is an ani-mime hook" changes from `127.0.0.1:1234` to a stable token. Use `ani-mime-hook.mjs` as the new marker — it appears in every command line we own, never in commands we don't.
+
+### Migration for Existing Users
+
+`claude_config.rs::migrate_claude_hooks` runs on every startup. New behavior:
+
+1. Walk every hook event in `~/.claude/settings.json`.
+2. For each hook command containing `127.0.0.1:1234` (the legacy curl marker), **replace** it with the new node command string.
+3. Remove the legacy hook entries entirely if duplicates exist (don't keep both).
+4. Add hooks for any of the seven events that aren't already configured (handled by `setup_claude_hooks`).
+5. Log applied migrations once per startup, deduped.
+
+The migration is idempotent — safe on every startup. Already-migrated installations are no-ops.
+
+### Setup Flow
+
+`setup/mod.rs` orchestrator gains one step:
+
+```
+1. Install MCP server (existing)
+2. Install hook script (new — copy from bundle to ~/.ani-mime/hooks/)
+3. Configure Claude hooks (existing — now uses node command)
+4. Migrate legacy hooks (existing — now also rewrites old curl commands)
+5. Setup shell integration (existing)
+```
+
+### Logging
+
+- `[setup] installed hook script to ~/.ani-mime/hooks/ani-mime-hook.mjs`
+- `[setup] migrated claude hooks: legacy curl → node script (3 events)`
+- Hook script itself is silent (no logs) — its work shows up as `[http] pid=N -> busy/idle` in the existing server log.
+
+## Testing
+
+**Manual smoke test (primary acceptance):**
+
+1. Start Claude Code in a terminal where ani-mime is running.
+2. Submit a long prompt that triggers tools. Pill should be **Working…** for the duration, never flicker.
+3. Continue past the auto-compact threshold. When TUI shows "Compacted", pill must stay **Working…** (never flip to Free).
+4. End turn. Pill goes **Free**.
+5. Trigger a permission prompt (e.g., a tool needing approval). Pill should go **Free** while waiting.
+6. Approve. Pill goes back to **Working…** for the next tool call.
+7. Force a turn error (e.g., kill the API mid-response). Pill should still go **Free** (via StopFailure).
+
+**Build check:**
+- `cd src-tauri && cargo check` — must pass
+- `npx tsc --noEmit` — must pass (no frontend type changes expected)
+
+**Unit-test scope (none added):**
+- The hook script is small and exercised by manual integration. Adding a test harness for stdin/HTTP would be larger than the script itself.
+
+## Risks / Open Questions
+
+- **Node startup latency.** A `node` cold start is ~50–80 ms vs. ~5 ms for curl. Hook fires per-tool-call. Acceptable budget — Claude Code's hook timeout default is 60 s. Will monitor; if it ever matters, a single long-running daemon could replace the per-invocation script (out of scope here).
+- **`process.ppid` vs `$PPID`.** Should be identical for the `node` child of `claude`. If Claude Code ever wraps hook invocations in an extra `sh -c`, both `$PPID` and `process.ppid` would shift to the `sh` (which has `claude` as its parent). Both break the same way; no regression.
+- **`Notification(idle_prompt)` semantics.** The docs label this as "Claude Code is idle and prompting user for input" — mapping to **Free** is correct. If a future variant of `idle_prompt` actually means something else, the table can be tightened.
+- **`SessionStart(source=compact)` no-op.** If Claude ever fires this without an active session (corner case), the pill would stay at whatever state it was — including `disconnected`. The watchdog would then resolve it on the next `proc_scan` cycle (≤2 s). Acceptable.
+
+## Out of Scope
+
+- Adding a "waiting-for-permission" sub-state with its own sprite/label (could be a follow-up; the table above only uses existing states).
+- Subscribing to richer events (`SubagentStart/Stop`, `PreCompact`, `PostToolBatch`) for analytics — not needed for mirror correctness.
+- Replacing the HTTP wire format with a Unix socket — performance is fine.

--- a/src-tauri/script/ani-mime-hook.mjs
+++ b/src-tauri/script/ani-mime-hook.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// ani-mime hook — invoked by Claude Code on every hook event.
+// Reads a JSON payload from stdin, decides whether the mirror should be
+// busy/idle, and POSTs to the local ani-mime HTTP server. Silent on success.
+
+const PORT = 1234;
+const HOST = "127.0.0.1";
+const TIMEOUT_MS = 1000;
+
+async function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(""));
+  });
+}
+
+function decide(payload) {
+  const event = payload.hook_event_name;
+  switch (event) {
+    case "PreToolUse":
+    case "UserPromptSubmit":
+      return { state: "busy", type: "task" };
+
+    case "Stop":
+    case "StopFailure":
+    case "SessionEnd":
+      return { state: "idle" };
+
+    case "SessionStart": {
+      const src = payload.source;
+      if (src === "compact") return null;
+      return { state: "idle" };
+    }
+
+    case "Notification": {
+      const t = payload.notification_type;
+      if (t === "permission_prompt" || t === "idle_prompt") {
+        return { state: "idle" };
+      }
+      return null;
+    }
+
+    default:
+      return null;
+  }
+}
+
+async function post({ state, type }) {
+  const params = new URLSearchParams({ pid: String(process.ppid), state });
+  if (type) params.set("type", type);
+  const url = `http://${HOST}:${PORT}/status?${params.toString()}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+(async () => {
+  try {
+    const raw = (await readStdin()).trim();
+    if (!raw) return;
+    const payload = JSON.parse(raw);
+    const action = decide(payload);
+    if (!action) return;
+    await post(action);
+  } catch (err) {
+    console.error(`[ani-mime-hook] ${err && err.message ? err.message : err}`);
+  } finally {
+    process.exit(0);
+  }
+})();

--- a/src-tauri/src/setup/claude.rs
+++ b/src-tauri/src/setup/claude.rs
@@ -1,12 +1,40 @@
 use std::path::Path;
 
-/// Patch existing ani-mime hooks for compatibility with newer behaviors.
-/// Safe to run on every startup — only modifies hooks that actually need fixing.
-///
-/// Migrations applied (idempotently):
-///   1. Add `|| true` so a missing app doesn't error in claude
-///   2. Replace `pid=0` (shared session) with `pid=$PPID` (per-claude session)
-///      and switch single quotes to double so the shell expands $PPID
+use super::hooks::{HOOK_COMMAND, HOOK_MARKER};
+
+/// Legacy marker for inline curl hooks installed by older ani-mime versions.
+const LEGACY_MARKER: &str = "127.0.0.1:1234";
+
+/// Every hook event ani-mime subscribes to. The same `HOOK_COMMAND` is
+/// registered for all of them — the script reads the JSON payload from
+/// stdin and decides what to do.
+const HOOK_EVENTS: &[&str] = &[
+    "PreToolUse",
+    "UserPromptSubmit",
+    "Stop",
+    "StopFailure",
+    "SessionStart",
+    "SessionEnd",
+    "Notification",
+];
+
+/// Returns true if `~/.claude/settings.json` already contains any
+/// ani-mime-owned hook (legacy curl or new script).
+pub fn claude_hooks_configured(home: &Path) -> bool {
+    let path = home.join(".claude/settings.json");
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    content.contains(LEGACY_MARKER) || content.contains(HOOK_MARKER)
+}
+
+/// Run on every startup. Two responsibilities:
+///   1. Rewrite legacy inline-curl hooks (containing 127.0.0.1:1234) to the
+///      new node script command.
+///   2. Add any of the seven hook events that aren't yet configured — so
+///      existing users automatically pick up StopFailure and Notification
+///      without re-running first-launch setup.
 pub fn migrate_claude_hooks(home: &Path) {
     let settings_path = home.join(".claude/settings.json");
     if !settings_path.exists() {
@@ -18,7 +46,11 @@ pub fn migrate_claude_hooks(home: &Path) {
         Err(_) => return,
     };
 
-    if !content.contains("127.0.0.1:1234") {
+    let has_legacy = content.contains(LEGACY_MARKER);
+    let has_new = content.contains(HOOK_MARKER);
+
+    // User never set up claude hooks — nothing to migrate.
+    if !has_legacy && !has_new {
         return;
     }
 
@@ -27,75 +59,86 @@ pub fn migrate_claude_hooks(home: &Path) {
         Err(_) => return,
     };
 
+    let mut migrations: Vec<String> = Vec::new();
     let mut patched = false;
-    let mut migrations_applied: Vec<&str> = Vec::new();
 
-    if let Some(hooks) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) {
-        for (_event, entries) in hooks.iter_mut() {
-            if let Some(entries) = entries.as_array_mut() {
+    // --- Step 1: rewrite legacy curl commands to the new script command ---
+    if has_legacy {
+        if let Some(hooks) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) {
+            for (_event, entries) in hooks.iter_mut() {
+                let Some(entries) = entries.as_array_mut() else { continue };
                 for entry in entries.iter_mut() {
-                    if let Some(hks) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
-                        for hook in hks.iter_mut() {
-                            let Some(cmd) = hook
-                                .get_mut("command")
-                                .and_then(|c| c.as_str().map(String::from))
-                            else {
-                                continue;
-                            };
-                            if !cmd.contains("127.0.0.1:1234") {
-                                continue;
-                            }
-
-                            let mut new_cmd = cmd.clone();
-
-                            // Migration 2: pid=0 → pid=$PPID. Replace the
-                            // single-quoted URL wrapping (which prevents $PPID
-                            // expansion) with double quotes.
-                            if new_cmd.contains("pid=0") {
-                                new_cmd = new_cmd.replace("pid=0", "pid=$PPID");
-                                // Convert any single-quoted URL into a double-quoted one
-                                // so the shell actually expands $PPID at runtime.
-                                if let Some(start) = new_cmd.find("'http://127.0.0.1:1234") {
-                                    if let Some(end_rel) = new_cmd[start + 1..].find('\'') {
-                                        let end = start + 1 + end_rel;
-                                        new_cmd.replace_range(start..start + 1, "\"");
-                                        new_cmd.replace_range(end..end + 1, "\"");
-                                    }
-                                }
-                                migrations_applied.push("pid=0 → pid=$PPID");
-                            }
-
-                            // Migration 1: append `|| true` if missing.
-                            if !new_cmd.contains("|| true") {
-                                new_cmd = format!("{} || true", new_cmd);
-                                migrations_applied.push("added || true");
-                            }
-
-                            if new_cmd != cmd {
-                                hook["command"] = serde_json::Value::String(new_cmd);
-                                patched = true;
-                            }
+                    let Some(hks) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+                        continue;
+                    };
+                    for hook in hks.iter_mut() {
+                        let Some(cmd) = hook
+                            .get_mut("command")
+                            .and_then(|c| c.as_str().map(String::from))
+                        else {
+                            continue;
+                        };
+                        if cmd.contains(LEGACY_MARKER) && !cmd.contains(HOOK_MARKER) {
+                            hook["command"] = serde_json::Value::String(HOOK_COMMAND.to_string());
+                            patched = true;
                         }
                     }
                 }
             }
         }
+        if patched {
+            migrations.push("legacy curl → node script".into());
+        }
     }
 
-    if patched {
-        if let Ok(json_str) = serde_json::to_string_pretty(&settings) {
-            if std::fs::write(&settings_path, json_str).is_ok() {
-                migrations_applied.sort();
-                migrations_applied.dedup();
-                crate::app_log!(
-                    "[setup] migrated claude hooks: {}",
-                    migrations_applied.join(", ")
-                );
+    // --- Step 2: dedupe ani-mime hooks within each entry ---
+    if let Some(hooks) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) {
+        for (_event, entries) in hooks.iter_mut() {
+            let Some(entries) = entries.as_array_mut() else { continue };
+            for entry in entries.iter_mut() {
+                let Some(hks) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+                    continue;
+                };
+                let before = hks.len();
+                let mut seen_ours = false;
+                hks.retain(|h| {
+                    let cmd = h["command"].as_str().unwrap_or("");
+                    let is_ours = cmd.contains(HOOK_MARKER);
+                    if is_ours {
+                        if seen_ours {
+                            return false;
+                        }
+                        seen_ours = true;
+                    }
+                    true
+                });
+                if hks.len() != before {
+                    patched = true;
+                }
             }
+        }
+    }
+
+    // --- Step 3: add any missing events from HOOK_EVENTS ---
+    let added = ensure_hook_events(&mut settings);
+    if !added.is_empty() {
+        migrations.push(format!("added events: {}", added.join(", ")));
+        patched = true;
+    }
+
+    if !patched {
+        return;
+    }
+
+    if let Ok(json_str) = serde_json::to_string_pretty(&settings) {
+        if std::fs::write(&settings_path, json_str).is_ok() {
+            crate::app_log!("[setup] migrated claude hooks: {}", migrations.join("; "));
         }
     }
 }
 
+/// First-launch hook setup. Adds every event in `HOOK_EVENTS` to
+/// ~/.claude/settings.json with the canonical `HOOK_COMMAND`.
 pub fn setup_claude_hooks(home: &Path) {
     crate::app_log!("[setup] configuring Claude Code hooks");
 
@@ -104,16 +147,10 @@ pub fn setup_claude_hooks(home: &Path) {
 
     let mut settings: serde_json::Value = if settings_path.exists() {
         match std::fs::read_to_string(&settings_path) {
-            Ok(content) => match serde_json::from_str(&content) {
-                Ok(json) => {
-                    crate::app_log!("[setup] loaded existing claude settings");
-                    json
-                }
-                Err(e) => {
-                    crate::app_error!("[setup] failed to parse claude settings: {}", e);
-                    serde_json::json!({})
-                }
-            },
+            Ok(content) => serde_json::from_str(&content).unwrap_or_else(|e| {
+                crate::app_error!("[setup] failed to parse claude settings: {}", e);
+                serde_json::json!({})
+            }),
             Err(e) => {
                 crate::app_error!("[setup] failed to read claude settings: {}", e);
                 serde_json::json!({})
@@ -127,80 +164,76 @@ pub fn setup_claude_hooks(home: &Path) {
         serde_json::json!({})
     };
 
-    let hooks = settings
-        .as_object_mut()
-        .unwrap()
-        .entry("hooks")
-        .or_insert(serde_json::json!({}));
-
-    // Use $PPID instead of a hardcoded 0: each running `claude` binary becomes
-    // its own session (so two concurrent Claude tabs don't share the same dot).
-    // $PPID inside the hook subshell is the parent process — i.e. the claude
-    // binary that spawned the hook.
-    let busy_cmd = "curl -s --max-time 1 \"http://127.0.0.1:1234/status?pid=$PPID&state=busy&type=task\" > /dev/null 2>&1 || true";
-    let idle_cmd = "curl -s --max-time 1 \"http://127.0.0.1:1234/status?pid=$PPID&state=idle\" > /dev/null 2>&1 || true";
-    let ani_marker = "127.0.0.1:1234";
-
-    let has_ani_hook = |arr: &serde_json::Value| -> bool {
-        arr.as_array().map_or(false, |entries| {
-            entries.iter().any(|entry| {
-                entry["hooks"].as_array().map_or(false, |hks| {
-                    hks.iter().any(|h| {
-                        h["command"]
-                            .as_str()
-                            .map_or(false, |c| c.contains(ani_marker))
-                    })
-                })
-            })
-        })
-    };
-
-    let add_hook = |hooks_obj: &mut serde_json::Value, event: &str, cmd: &str| {
-        let arr = hooks_obj
-            .as_object_mut()
-            .unwrap()
-            .entry(event)
-            .or_insert(serde_json::json!([]));
-
-        if has_ani_hook(arr) {
-            crate::app_log!("[setup] claude hook for {} already exists", event);
-            return;
-        }
-
-        if let Some(entries) = arr.as_array_mut() {
-            if entries.is_empty() {
-                entries.push(serde_json::json!({
-                    "matcher": "",
-                    "hooks": [{ "type": "command", "command": cmd }]
-                }));
-            } else if let Some(first) = entries.first_mut() {
-                if let Some(hks) = first["hooks"].as_array_mut() {
-                    hks.push(serde_json::json!({
-                        "type": "command",
-                        "command": cmd
-                    }));
-                }
-            }
-        }
-        crate::app_log!("[setup] added claude hook for {}", event);
-    };
-
-    add_hook(hooks, "PreToolUse", busy_cmd);
-    add_hook(hooks, "UserPromptSubmit", busy_cmd);
-    add_hook(hooks, "Stop", idle_cmd);
-    add_hook(hooks, "SessionStart", idle_cmd);
-    add_hook(hooks, "SessionEnd", idle_cmd);
+    let added = ensure_hook_events(&mut settings);
+    if added.is_empty() {
+        crate::app_log!("[setup] all claude hooks already configured");
+    } else {
+        crate::app_log!("[setup] added claude hooks for: {}", added.join(", "));
+    }
 
     match serde_json::to_string_pretty(&settings) {
         Ok(json_str) => {
             if let Err(e) = std::fs::write(&settings_path, json_str) {
                 crate::app_error!("[setup] failed to write claude settings: {}", e);
             } else {
-                crate::app_log!("[setup] claude hooks written to {}", settings_path.display());
+                crate::app_log!(
+                    "[setup] claude hooks written to {}",
+                    settings_path.display()
+                );
             }
         }
-        Err(e) => {
-            crate::app_error!("[setup] failed to serialize claude settings: {}", e);
+        Err(e) => crate::app_error!("[setup] failed to serialize claude settings: {}", e),
+    }
+}
+
+/// Adds an ani-mime hook entry for every event in `HOOK_EVENTS` that
+/// doesn't already have one. Returns the list of events that were added.
+fn ensure_hook_events(settings: &mut serde_json::Value) -> Vec<String> {
+    let hooks = settings
+        .as_object_mut()
+        .expect("settings must be a JSON object")
+        .entry("hooks")
+        .or_insert(serde_json::json!({}));
+
+    let mut added = Vec::new();
+    for event in HOOK_EVENTS {
+        let arr = hooks
+            .as_object_mut()
+            .unwrap()
+            .entry((*event).to_string())
+            .or_insert(serde_json::json!([]));
+
+        if entry_array_has_marker(arr, HOOK_MARKER) {
+            continue;
+        }
+
+        if let Some(entries) = arr.as_array_mut() {
+            if entries.is_empty() {
+                entries.push(serde_json::json!({
+                    "matcher": "",
+                    "hooks": [{ "type": "command", "command": HOOK_COMMAND }]
+                }));
+            } else if let Some(first) = entries.first_mut() {
+                if let Some(hks) = first["hooks"].as_array_mut() {
+                    hks.push(serde_json::json!({
+                        "type": "command",
+                        "command": HOOK_COMMAND
+                    }));
+                }
+            }
+            added.push((*event).to_string());
         }
     }
+    added
+}
+
+fn entry_array_has_marker(arr: &serde_json::Value, marker: &str) -> bool {
+    arr.as_array().map_or(false, |entries| {
+        entries.iter().any(|entry| {
+            entry["hooks"].as_array().map_or(false, |hks| {
+                hks.iter()
+                    .any(|h| h["command"].as_str().map_or(false, |c| c.contains(marker)))
+            })
+        })
+    })
 }

--- a/src-tauri/src/setup/hooks.rs
+++ b/src-tauri/src/setup/hooks.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+
+/// Marker token used to identify ani-mime-owned hook commands in
+/// ~/.claude/settings.json — must be unique to commands we own.
+pub const HOOK_MARKER: &str = "ani-mime-hook.mjs";
+
+/// Canonical hook command Claude Code runs for every event we subscribe to.
+/// Uses $HOME so the path expands inside the shell Claude Code spawns,
+/// and `|| true` so a missing/broken script never blocks Claude.
+pub const HOOK_COMMAND: &str =
+    "node \"$HOME/.ani-mime/hooks/ani-mime-hook.mjs\" || true";
+
+/// Copy the hook script to ~/.ani-mime/hooks/ so Claude Code can run it.
+/// Called on every startup to keep the script up-to-date with the bundle.
+pub fn install_hook_script(resource_dir: &Path, home: &Path) {
+    let hooks_dir = home.join(".ani-mime/hooks");
+    if let Err(e) = std::fs::create_dir_all(&hooks_dir) {
+        crate::app_error!(
+            "[hooks] failed to create {}: {}",
+            hooks_dir.display(),
+            e
+        );
+        return;
+    }
+
+    let source = resource_dir.join("script/ani-mime-hook.mjs");
+    let dest = hooks_dir.join("ani-mime-hook.mjs");
+
+    if !source.exists() {
+        crate::app_warn!("[hooks] source not found: {}", source.display());
+        return;
+    }
+
+    match std::fs::copy(&source, &dest) {
+        Ok(_) => crate::app_log!("[hooks] installed script to {}", dest.display()),
+        Err(e) => crate::app_error!("[hooks] failed to copy script: {}", e),
+    }
+}

--- a/src-tauri/src/setup/mod.rs
+++ b/src-tauri/src/setup/mod.rs
@@ -1,11 +1,13 @@
 mod claude;
+mod hooks;
 mod mcp;
 pub(crate) mod shell;
 
 use std::path::PathBuf;
 use tauri::Emitter;
 
-use self::claude::{migrate_claude_hooks, setup_claude_hooks};
+use self::claude::{claude_hooks_configured, migrate_claude_hooks, setup_claude_hooks};
+use self::hooks::install_hook_script;
 use self::mcp::{install_mcp_server, register_mcp_server};
 use self::shell::{detect_shells, install_shell_hooks, ShellInfo};
 use crate::platform;
@@ -25,6 +27,11 @@ pub fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
                 return;
             }
         };
+        // Always install/update the hook script before migrating settings.json
+        // — migration rewrites legacy curl commands to point at this script,
+        // so the script must already be on disk.
+        install_hook_script(&resource_dir, &home);
+
         // Always run migrations for existing users
         migrate_claude_hooks(&home);
 
@@ -41,8 +48,6 @@ pub fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
 
         crate::app_log!("[setup] first launch detected, starting setup");
 
-        let settings_path = home.join(".claude/settings.json");
-
         // Detect shells and determine what needs setup
         let shells = detect_shells(&home);
         let available: Vec<&ShellInfo> = shells.iter().filter(|s| s.is_installed()).collect();
@@ -58,10 +63,7 @@ pub fn auto_setup(resource_dir: PathBuf, app_handle: tauri::AppHandle) {
             crate::app_log!("[setup]   {} (installed={}, configured={})", s.name, s.is_installed(), s.is_configured());
         }
 
-        let claude_done = {
-            let content = std::fs::read_to_string(&settings_path).unwrap_or_default();
-            content.contains("127.0.0.1:1234")
-        };
+        let claude_done = claude_hooks_configured(&home);
         crate::app_log!("[setup] claude hooks already configured: {}", claude_done);
 
         // Nothing to do — skip silently

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -83,6 +83,7 @@
       "script/terminal-mirror.bash",
       "script/terminal-mirror.fish",
       "script/tauri-hook.sh",
+      "script/ani-mime-hook.mjs",
       "docs/custom-mime-guide.pdf",
       "mcp-server/server.mjs"
     ],


### PR DESCRIPTION
## Summary

- Replaces inline curl hooks in \`~/.claude/settings.json\` with a single stdin-aware Node script (\`~/.ani-mime/hooks/ani-mime-hook.mjs\`) that reads each hook event's JSON payload and decides the right mirror state.
- Fixes the false-idle / flicker users see when Claude Code auto-compacts mid-turn — \`SessionStart(source="compact")\` is now a no-op instead of flipping the pill to **Free**.
- Adds coverage for \`StopFailure\` (turn ends in error → idle) and \`Notification\` types \`permission_prompt\` / \`idle_prompt\` (Claude waiting on user → idle), so the pill no longer sticks at **Working...** when Claude is actually idle.
- Existing users migrate automatically on next launch: legacy curl commands are rewritten in-place, missing events are added, and any unrelated hooks (e.g. \`masko-desktop\`) are left untouched.

## Why

Claude Code's hook event surface has grown. Inline curl one-liners can't read the stdin JSON, so they can't distinguish \`SessionStart(startup)\` from \`SessionStart(compact)\`, or \`Notification(permission_prompt)\` from \`Notification(auth_success)\`. The script-based approach centralises hook logic in one file and is forward-compatible: unknown events are silent no-ops.

## Behavior table

| Event | Condition | POST | UI label |
|---|---|---|---|
| \`PreToolUse\`, \`UserPromptSubmit\` | always | \`state=busy&type=task\` | **Working...** |
| \`Stop\`, \`StopFailure\`, \`SessionEnd\` | always | \`state=idle\` | **Free** |
| \`SessionStart\` | source ∈ {startup, resume, clear} | \`state=idle\` | **Free** |
| \`SessionStart\` | source == \`compact\` | no-op | unchanged |
| \`Notification\` | type ∈ {permission_prompt, idle_prompt} | \`state=idle\` | **Free** |
| \`Notification\` | other types | no-op | unchanged |
| anything else | unknown event | no-op | unchanged |

## Test plan

- [x] \`cargo check\` passes
- [x] \`npx tsc --noEmit\` passes
- [x] Smoke-test \`ani-mime-hook.mjs\` for: \`PreToolUse\`, \`StopFailure\`, \`Notification(permission_prompt)\`, \`Notification(auth_success)\`, \`SessionStart(compact)\`, malformed JSON, empty stdin — all exit 0
- [ ] \`bun run tauri dev\`, run a long Claude turn that triggers auto-compaction → pill stays **Working...** through compact (no flick to Free)
- [ ] Trigger a permission prompt → pill goes **Free** while waiting, **Working...** after approve
- [ ] Force a turn error → pill returns to **Free** via \`StopFailure\`
- [ ] Verify existing \`masko-desktop\` (or other) hooks in \`~/.claude/settings.json\` are untouched after migration

## Design doc

\`docs/superpowers/specs/2026-05-05-claude-hook-mirror-fix-design.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)