### PR TITLE
chore: release v0.17.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.17.7] - 2026-05-05
+
+### Fixed
+- **Claude Code mirror no longer flickers between Working… and Free during auto-compaction.** Recent Claude Code versions fire `SessionStart(source="compact")` mid-turn; the inline curl hooks couldn't read stdin JSON to distinguish that from `startup`/`resume`/`clear`, so the pill flipped to Free and back. Replaced the inline curl with a single stdin-aware Node hook script (`~/.ani-mime/hooks/ani-mime-hook.mjs`) that ignores `compact` and routes the rest correctly.
+- **Pill no longer sticks at Working… when Claude is waiting on the user.** Subscribed to `Notification(permission_prompt|idle_prompt)` → idle, so the mirror flips to Free during permission dialogs and back to Working… when you approve.
+- **Pill no longer sticks at Working… after a turn fails.** Subscribed to `StopFailure` → idle, mirroring the existing `Stop` mapping.
+- Existing settings.json migrates automatically on launch — legacy curl hooks are rewritten in place; unrelated hooks (e.g. masko-desktop) are untouched.
+
+### Changed
+- **LAN peer list defaults to off** for new users; square icon in the session list dropdown for visual consistency with the peer-count badge.
+
 ## [0.17.6] - 2026-04-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.6",
+  "version": "0.17.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.6"
+version = "0.17.7"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1481,7 +1481,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.6{devMode && " (Dev Mode)"}
+                  Version 0.17.7{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary

Release v0.17.7. Highlights:

- **Claude Code mirror correctness fix** — replaces inline curl hooks with a stdin-aware Node script so the pill no longer flickers between Working… and Free during auto-compaction, no longer sticks at Working… while Claude waits on a permission prompt, and no longer sticks at Working… after a turn fails. Existing settings.json migrates automatically. (#125)
- **LAN peer list defaults to off** for new users; square session-list dropdown icon. (#124)

## Test plan

- [x] \`cargo check\` passes (Cargo.lock regenerated for the new version)
- [x] \`npx tsc --noEmit\` passes
- [ ] CI matrix builds aarch64 + x64 DMGs after merge + tag push
- [ ] Homebrew cask updated post-CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)