### PR TITLE
fix(status-pill): round session list button hover/active state

### DIFF
--- a/src/styles/status-pill.css
+++ b/src/styles/status-pill.css
@@ -104,7 +104,7 @@
 }
 
 .pill-action-btn[data-testid="pill-action-task"] {
-  border-radius: 0;
+  border-radius: 9999px;
 }
 
 .pill-action-icon {


### PR DESCRIPTION
## Summary
- Changed the task button's `border-radius` from `0` → `9999px` so the hover and `is-active` background now follow the surrounding pill's shape language instead of showing a sharp-cornered rectangle.

## Test plan
- [ ] `bun run tauri dev`, hover over the session list button — background highlight should be circular, matching the LAN icon next to it.
- [ ] Click the session list button to open the dropdown — `is-active` background should remain circular while open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)