### PR TITLE
chore: release v0.17.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.17.8] - 2026-05-05
+
+### Changed
+- **LAN Peer List toggle now fully gates the LAN feature.** Turning it off skips mDNS discovery, UDP multicast/unicast announces, and the periodic discovery heartbeat at startup — previously these all kept running even with the toggle off, only the status-pill icon was hidden. The "No friends nearby! Check Privacy → Local Network" speech bubble is also suppressed live when the toggle is off. Toggling the setting requires a restart for the LAN scanner to start or stop.
+
+### Fixed
+- **Session list dropdown no longer cancels in-flight window drags.** Closing the dropdown mid-drag preserves the dragged window position instead of snapping back.
+- **Session list button hover/active state is now rounded** to match the pill, no more sharp-cornered hover artifact.
+
 ## [0.17.7] - 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.7",
+  "version": "0.17.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "cocoa",
  "dirs 6.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.7"
+version = "0.17.8"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1481,7 +1481,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.7{devMode && " (Dev Mode)"}
+                  Version 0.17.8{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary

Bump to **v0.17.8** — bundles four merged PRs since v0.17.7:

- **#127** — Claude Code mirror no longer flickers during auto-compaction (`SessionStart(source="compact")` handling)
- **#128** — Session list pill button hover/active state now rounded
- **#129** — Session list dropdown preserves window drag position when it closes mid-drag
- **#130** — LAN Peer List toggle fully disables mDNS + UDP broadcast + Local Network privacy bubble

Files bumped to 0.17.8 per `CLAUDE.md` release checklist:
- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/tauri.conf.json`
- `src/components/Settings.tsx` (About hardcoded string)
- `src-tauri/Cargo.lock` (regenerated via `cargo check`)
- `CHANGELOG.md` header

## Test Plan

- [x] All 4 version strings + Cargo.lock pin to 0.17.8
- [x] `cargo check` clean
- [ ] Merge → tag `v0.17.8` on main → CI builds DMGs and publishes the GitHub release
- [ ] Update `vietnguyenhoangw/homebrew-ani-mime` cask after CI publishes the DMGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)