### PR TITLE
perf(proc_scan): drop ~80% of per-PID syscalls in 2s scan loop

### DIFF
--- a/docs/superpowers/plans/2026-05-06-proc-scan-perf.md
+++ b/docs/superpowers/plans/2026-05-06-proc-scan-perf.md
@@ -1,0 +1,474 @@
+# proc_scan Performance Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drop steady-state CPU of the `proc_scan` thread from ~5–10% to ~1–2% by eliminating wasted per-PID syscalls, without changing observable behavior.
+
+**Architecture:** Three stacking changes inside a single file (`src-tauri/src/proc_scan.rs`): (1) gate the `PROC_PIDVNODEPATHINFO` cwd lookup on `is_shell(name)`, (2) filter `listpids` by current effective UID, (3) drop the redundant `proc_pid::name()` call by reading `pbi_comm` from the existing `BSDInfo` result. No public API or behavior change; covered by spec `docs/superpowers/specs/2026-05-06-proc-scan-perf-design.md`.
+
+**Tech Stack:** Rust 1.x, `libproc 0.14`, macOS-only code paths gated by `#[cfg(target_os = "macos")]`. Existing project conventions: tests inside `#[cfg(test)] mod tests` blocks at the bottom of the same file, FFI declared via inline `extern "C"` (no direct `libc` crate dep).
+
+---
+
+## File Structure
+
+Only one source file is modified.
+
+| File | Responsibility |
+|---|---|
+| `src-tauri/src/proc_scan.rs` (modify) | Process enumeration + reconciliation. All three changes happen here. |
+
+The file already mixes pure helpers, FFI shims, and the polling loop. The plan keeps that shape: the new helper (`pbi_comm_to_string`) is added next to the existing pure helpers (`argv0_basename`, `looks_like_version_string`, etc.) and the new `geteuid_safe()` FFI shim sits with the other inline `extern "C"` blocks (`sysctl`, `devname`).
+
+---
+
+## Task ordering rationale
+
+Task order is **biggest-win-first, lowest-risk-first**. After Task 1, the user already has the dominant performance win even if Tasks 2–4 are deferred. Each task ends with a green `cargo check` and a commit. Functional verification is consolidated into Task 5 (manual smoke + perf measurement) because `scan_processes` is libproc-dependent and not unit-testable without significant scaffolding.
+
+---
+
+## Task 1: Gate `get_cwd_macos` on `is_shell(name)`
+
+**Why first:** This is the dominant cost (one ~2 KB syscall per PID, ~830 of which are wasted per scan). Single-line gate. Zero risk of breaking behavior — `cwd` is read in `reconcile()` only inside the `for t in &live_terminals` loop, and `is_user_terminal()` already requires `is_shell(&name)`, so non-shell PIDs never consume the field today.
+
+**Files:**
+- Modify: `src-tauri/src/proc_scan.rs`
+
+- [ ] **Step 1: Read the current `scan_processes()` body and locate the cwd line**
+
+Run: `grep -n "let cwd = get_cwd_macos" src-tauri/src/proc_scan.rs`
+Expected output: two matches — one inside `get_proc_info()` (~line 368), one inside `scan_processes()` (~line 473).
+
+- [ ] **Step 2: Replace the cwd line in `scan_processes()`**
+
+Anchor the edit by surrounding context. In the loop inside `scan_processes()`, find the unconditional cwd fetch:
+
+```rust
+        let cwd = get_cwd_macos(pid as i32);
+
+        // Only spend a sysctl roundtrip on processes that might be Claude
+```
+
+Replace with:
+
+```rust
+        // Only fetch cwd for shells — it's the only type of process whose
+        // cwd we consume (in reconcile() via is_user_terminal -> is_shell).
+        // PROC_PIDVNODEPATHINFO copies a ~2 KB struct per call, so doing it
+        // unconditionally for every PID on the system was the dominant
+        // cost of this scan loop.
+        let cwd = if is_shell(&name) {
+            get_cwd_macos(pid as i32)
+        } else {
+            None
+        };
+
+        // Only spend a sysctl roundtrip on processes that might be Claude
+```
+
+- [ ] **Step 3: Apply the same gate inside `get_proc_info()`**
+
+`get_proc_info()` is the single-PID diagnostic helper (used outside the hot loop). Gate it for consistency. Find:
+
+```rust
+    let cwd = get_cwd_macos(pid as i32);
+    let argv0 = if name == "node" || is_shell(&name) {
+```
+
+Replace with:
+
+```rust
+    let cwd = if is_shell(&name) {
+        get_cwd_macos(pid as i32)
+    } else {
+        None
+    };
+    let argv0 = if name == "node" || is_shell(&name) {
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd src-tauri && cargo check`
+Expected: `Finished` with no errors. (Warnings about unused imports etc. are unrelated.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/proc_scan.rs
+git commit -m "$(cat <<'EOF'
+perf(proc_scan): gate cwd lookup on is_shell
+
+PROC_PIDVNODEPATHINFO copies a ~2 KB struct per call. The cwd field is
+only consumed by reconcile() inside the live_terminals loop, which
+already requires is_shell(&name). Fetching it for every PID on the
+system was ~99% wasted work — the dominant cost of the 2 s scan.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Filter `listpids` by current effective UID
+
+**Why second:** Drops kernel and root-owned daemons before they enter the loop (typically halves PID count). Uses the supported, non-deprecated `processes::pids_by_type(ProcFilter::ByUID { uid })` API in `libproc 0.14`. UID is fetched via an inline `extern "C"` shim, matching the file's existing FFI style (no new Cargo dep).
+
+**Files:**
+- Modify: `src-tauri/src/proc_scan.rs`
+
+- [ ] **Step 1: Add an inline `extern "C"` shim for `geteuid` near the top of the macOS-only code**
+
+Find the existing FFI block for `sysctl` (inside `read_argv0`). Right above the `#[cfg(target_os = "macos")] fn scan_processes()` function definition, add:
+
+```rust
+/// Effective UID of the running process. Used to filter `proc_listpids`
+/// down to user-owned PIDs and skip kernel/root daemons that we will
+/// never care about.
+#[cfg(target_os = "macos")]
+fn geteuid_safe() -> u32 {
+    extern "C" {
+        fn geteuid() -> u32;
+    }
+    unsafe { geteuid() }
+}
+```
+
+- [ ] **Step 2: Replace the `listpids` call inside `scan_processes()`**
+
+Add this import near the top of the file, alongside the existing `libproc` imports:
+
+```rust
+#[cfg(target_os = "macos")]
+use libproc::processes::{pids_by_type, ProcFilter};
+```
+
+Then in `scan_processes()`, find:
+
+```rust
+    let pids = match proc_pid::listpids(proc_pid::ProcType::ProcAllPIDS) {
+        Ok(p) => p,
+        Err(e) => {
+            crate::app_warn!("[proc_scan] listpids failed: {}", e);
+            return Vec::new();
+        }
+    };
+```
+
+Replace with:
+
+```rust
+    // Filter to the current user's processes at the OS level. Drops
+    // kernel_task and root-owned daemons (~half the system's PIDs on a
+    // typical Mac) before we pay the per-PID syscall cost. Shells and
+    // claude both run as the user, so nothing we care about is excluded.
+    // sudo'd processes are intentionally not tracked — same as before.
+    let uid = geteuid_safe();
+    let pids = match pids_by_type(ProcFilter::ByUID { uid }) {
+        Ok(p) => p,
+        Err(e) => {
+            crate::app_warn!("[proc_scan] pids_by_type(ByUID {{uid={}}}) failed: {}", uid, e);
+            return Vec::new();
+        }
+    };
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd src-tauri && cargo check`
+Expected: `Finished` with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/proc_scan.rs
+git commit -m "$(cat <<'EOF'
+perf(proc_scan): filter listpids by current UID
+
+Use the supported pids_by_type(ProcFilter::ByUID) API instead of the
+deprecated listpids(ProcAllPIDS). Drops kernel/root daemons at the OS
+level — typically halves the PID count we then iterate. User shells
+and claude both run as the user, so nothing we track is excluded.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `pbi_comm_to_string` helper (TDD)
+
+**Why third:** Pure function, can be properly unit-tested. Prepares for Task 4. Done before Task 4 so the helper is in place when we drop `proc_pid::name()`.
+
+**Files:**
+- Modify: `src-tauri/src/proc_scan.rs`
+
+- [ ] **Step 1: Locate the existing `#[cfg(test)] mod tests` block — it does not exist in this file**
+
+Run: `grep -n "^#\[cfg(test)\]" src-tauri/src/proc_scan.rs`
+Expected: no matches. We will add a new `tests` module at the bottom of the file.
+
+- [ ] **Step 2: Write the failing tests at the bottom of `proc_scan.rs`**
+
+Append to the end of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::raw::c_char;
+
+    fn make_comm(s: &str) -> [c_char; 17] {
+        let mut buf = [0 as c_char; 17];
+        for (i, b) in s.bytes().enumerate() {
+            if i >= 16 { break; } // leave the trailing NUL
+            buf[i] = b as c_char;
+        }
+        buf
+    }
+
+    #[test]
+    fn pbi_comm_to_string_reads_until_first_nul() {
+        let comm = make_comm("zsh");
+        assert_eq!(pbi_comm_to_string(&comm), "zsh");
+    }
+
+    #[test]
+    fn pbi_comm_to_string_returns_empty_for_all_zero_buffer() {
+        let comm = [0 as c_char; 17];
+        assert_eq!(pbi_comm_to_string(&comm), "");
+    }
+
+    #[test]
+    fn pbi_comm_to_string_handles_full_16_byte_name_without_nul_in_first_16() {
+        // p_comm is 16 chars + NUL at index 16. A 16-char process name fills
+        // indices 0..15 and the NUL sits at index 16. We must read all 16
+        // bytes, not stop early.
+        let comm = make_comm("abcdefghijklmnop"); // exactly 16 chars
+        assert_eq!(pbi_comm_to_string(&comm), "abcdefghijklmnop");
+    }
+
+    #[test]
+    fn pbi_comm_to_string_returns_empty_for_invalid_utf8() {
+        let mut comm = [0 as c_char; 17];
+        comm[0] = 0xFFu8 as c_char; // invalid utf-8 start byte
+        comm[1] = 0xFEu8 as c_char;
+        assert_eq!(pbi_comm_to_string(&comm), "");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail with "function not defined"**
+
+Run: `cd src-tauri && cargo test -p ani-mime-lib --lib proc_scan::tests::`
+Expected: compile error — `cannot find function pbi_comm_to_string in this scope`.
+
+- [ ] **Step 4: Add the helper function near the other pure helpers**
+
+In `proc_scan.rs`, find the existing helper:
+
+```rust
+/// Just the basename of argv[0] (strip any leading dirs).
+fn argv0_basename(s: &str) -> &str {
+    s.rsplit('/').next().unwrap_or(s)
+}
+```
+
+Right above it, add:
+
+```rust
+/// Convert the C-string `pbi_comm` field of a `BSDInfo` (16 chars + NUL)
+/// to a Rust `String`. Stops at the first NUL byte; returns an empty
+/// string if the bytes are not valid UTF-8 (matches the lossy behavior
+/// of `proc_pid::name()` on garbage input).
+fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String {
+    let bytes: Vec<u8> = comm.iter()
+        .take_while(|&&b| b != 0)
+        .map(|&b| b as u8)
+        .collect();
+    String::from_utf8(bytes).unwrap_or_default()
+}
+```
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+Run: `cd src-tauri && cargo test -p ani-mime-lib --lib proc_scan::tests::`
+Expected: 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/proc_scan.rs
+git commit -m "$(cat <<'EOF'
+proc_scan: add pbi_comm_to_string helper with tests
+
+Pure function that converts a BSDInfo pbi_comm C buffer to a Rust
+String. Will replace the redundant proc_pid::name() syscall in the
+next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Use `pbi_comm` from BSDInfo, drop `proc_pid::name()`
+
+**Why fourth:** With the helper in place, we can remove the redundant `name()` syscall (one less syscall per surviving PID). Order matters — the BSDInfo call must happen before we know the name, so the loop body needs a small reshuffle.
+
+**Files:**
+- Modify: `src-tauri/src/proc_scan.rs`
+
+- [ ] **Step 1: Replace the loop body inside `scan_processes()`**
+
+Find the existing block:
+
+```rust
+    let mut out = Vec::new();
+    for pid in pids {
+        let name = match proc_pid::name(pid as i32) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+
+        let (ppid, pgid, tpgid, tdev) = match proc_pid::pidinfo::<BSDInfo>(pid as i32, 0) {
+            Ok(info) => (info.pbi_ppid, info.pbi_pgid, info.e_tpgid, info.e_tdev),
+            Err(_) => (0, 0, 0, 0),
+        };
+```
+
+Replace with:
+
+```rust
+    let mut out = Vec::new();
+    for pid in pids {
+        // pidinfo<BSDInfo> gives us name (pbi_comm), ppid, pgid, tpgid,
+        // tdev in a single syscall. Skip the PID if it can't be read —
+        // post-UID-filter this is rare (the PID either exited between
+        // listpids and pidinfo, or we somehow lack permission).
+        let info = match proc_pid::pidinfo::<BSDInfo>(pid as i32, 0) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        let name = pbi_comm_to_string(&info.pbi_comm);
+        if name.is_empty() {
+            continue;
+        }
+        let (ppid, pgid, tpgid, tdev) =
+            (info.pbi_ppid, info.pbi_pgid, info.e_tpgid, info.e_tdev);
+```
+
+Note: the previous code returned `(0, 0, 0, 0)` if pidinfo failed but kept the entry (using a name-only ProcInfo). After this change a pidinfo failure causes the PID to be skipped, which is consistent with the previous behavior on a `name()` failure (also `continue`). Keeping zombie/dead PIDs in `out` with bogus zeroed fields was already a hazard for `is_user_terminal` (`tdev == 0` → not a terminal anyway), so dropping them is strictly safer.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd src-tauri && cargo check`
+Expected: `Finished` with no errors.
+
+- [ ] **Step 3: Run the full test suite to make sure helper tests still pass**
+
+Run: `cd src-tauri && cargo test -p ani-mime-lib --lib proc_scan::tests::`
+Expected: 4 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/proc_scan.rs
+git commit -m "$(cat <<'EOF'
+perf(proc_scan): read name from BSDInfo, drop separate name() syscall
+
+BSDInfo.pbi_comm is the same 16-char p_comm field that proc_pid::name()
+returns, so calling both was redundant. Folding them into one syscall
+saves ~one call per surviving PID per scan (~400/scan on a typical Mac).
+PIDs whose pidinfo fails are now skipped (was: kept with zeroed fields,
+which is_user_terminal already filtered out via tdev==0).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Manual smoke test and perf verification
+
+No commits in this task — verification only. Records the before/after CPU numbers in your head (or in a follow-up note) so the perf claim in the spec is grounded.
+
+- [ ] **Step 1: Build a release binary**
+
+Run: `cd /Users/vietnguyenw.silentium/Desktop/vietnguyenw/dev/ani-mime && bun run tauri build`
+Expected: produces a fresh `.app` under `src-tauri/target/release/bundle/macos/`.
+
+(If you'd rather iterate in dev mode, use `bun run tauri dev` instead — but CPU numbers from the dev build are not representative.)
+
+- [ ] **Step 2: Functional smoke test — multi-shell pwd refresh**
+
+  1. Quit any running Ani-Mime instance.
+  2. Launch the freshly built app.
+  3. Open three terminal tabs. In each, `cd` to a different directory.
+  4. Click the mascot status pill → expand the session list.
+  5. Verify each tab shows its actual current directory within ~2 s of `cd`.
+
+Expected: pwd values match.
+
+- [ ] **Step 3: Functional smoke test — claude attachment**
+
+  1. In one tab, run `claude` and start a session.
+  2. In the session list, verify that tab shows the Claude logo on its row.
+  3. Quit `claude` (Ctrl-D twice).
+  4. Verify the logo disappears from that row within ~2 s.
+
+Expected: logo appears and disappears as described.
+
+- [ ] **Step 4: Functional smoke test — fg_cmd**
+
+  1. In one tab, run `bun run tauri dev` (or any long-running command, e.g. `sleep 30`).
+  2. Verify the session list shows the foreground command in the relevant row.
+  3. Stop the command (Ctrl-C).
+  4. Verify the foreground command clears within ~2 s.
+
+Expected: fg_cmd updates as described.
+
+- [ ] **Step 5: Functional smoke test — zombie cleanup**
+
+  1. In one tab, note its PID (`echo $$`).
+  2. Close the tab.
+  3. Verify the session disappears from the list within ~2 s.
+
+Expected: session is removed.
+
+- [ ] **Step 6: CPU before/after measurement**
+
+  1. Quit Ani-Mime. Launch the **previous** release version (or `git stash` the changes, run `bun run tauri dev`, and observe).
+  2. With no terminals doing anything, observe CPU% for the Ani-Mime process in Activity Monitor for 60 s. Record the rough average.
+  3. Quit. Launch the **new** build. Repeat the 60 s observation.
+  4. Compare. Expectation per spec: ~5–10% → ~1–2%.
+
+Expected: a clear, qualitative drop. Exact numbers depend on the Mac and number of running processes.
+
+- [ ] **Step 7: If anything in steps 2–5 regressed**
+
+Bisect commits with `git bisect` between this branch's tip and `main` to identify which task broke behavior. The four commits should be independently bisectable because each one ends with a green `cargo check`.
+
+If functional behavior is fine but CPU did not drop noticeably, capture a 30 s sample of the Ani-Mime process for analysis:
+
+```bash
+# Get pid:
+pgrep -x "Ani-Mime"
+# Sample for 30 seconds:
+sample <pid> 30 -file /tmp/ani-mime-sample.txt
+```
+
+Look for time spent inside `proc_scan` / `scan_processes` / `pidinfo`. If most cost is elsewhere (e.g., `tiny_http`, `webview`), the assumption that proc_scan was the dominant cost was wrong and we need to rebrainstorm.
+
+---
+
+## Self-review (filled in by plan author)
+
+- **Spec coverage:** Every change in the spec maps to a task — Task 1 covers spec §1.3 (gate cwd), Task 2 covers spec §1.1 (UID filter), Tasks 3+4 cover spec §1.2 (drop redundant name call). Spec verification section maps to Task 5. Risks section maps to Task 5 step 7 (the "if it didn't drop" branch).
+- **Placeholder scan:** No TBD/TODO/"add error handling" left. Every code-touching step contains the exact code. Test code is complete and runnable.
+- **Type consistency:** Helper signature is consistent across Task 3 (definition + tests) and Task 4 (call site): `pbi_comm_to_string(&info.pbi_comm)` against `fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String`.
+- **No dead refs:** `pids_by_type` and `ProcFilter` imports are added in Task 2. `pbi_comm_to_string` is added in Task 3 and used in Task 4. `geteuid_safe` is added and used in Task 2.

--- a/docs/superpowers/plans/2026-05-06-proc-scan-perf.md
+++ b/docs/superpowers/plans/2026-05-06-proc-scan-perf.md
@@ -216,14 +216,15 @@ Append to the end of the file:
 
 ```rust
 #[cfg(test)]
+#[cfg(target_os = "macos")]
 mod tests {
     use super::*;
     use std::os::raw::c_char;
 
-    fn make_comm(s: &str) -> [c_char; 17] {
-        let mut buf = [0 as c_char; 17];
+    fn make_comm(s: &str) -> [c_char; 16] {
+        let mut buf = [0 as c_char; 16];
         for (i, b) in s.bytes().enumerate() {
-            if i >= 16 { break; } // leave the trailing NUL
+            if i >= 16 { break; }
             buf[i] = b as c_char;
         }
         buf
@@ -237,23 +238,24 @@ mod tests {
 
     #[test]
     fn pbi_comm_to_string_returns_empty_for_all_zero_buffer() {
-        let comm = [0 as c_char; 17];
+        let comm = [0 as c_char; 16];
         assert_eq!(pbi_comm_to_string(&comm), "");
     }
 
     #[test]
-    fn pbi_comm_to_string_handles_full_16_byte_name_without_nul_in_first_16() {
-        // p_comm is 16 chars + NUL at index 16. A 16-char process name fills
-        // indices 0..15 and the NUL sits at index 16. We must read all 16
-        // bytes, not stop early.
+    fn pbi_comm_to_string_reads_full_buffer_when_no_nul_present() {
+        // pbi_comm is 16 bytes (MAXCOMLEN). When the process name is
+        // exactly 16 bytes, the buffer has NO trailing NUL — the take_while
+        // simply hits the end of the array. Verify the helper returns the
+        // full 16 chars in that case rather than stopping early.
         let comm = make_comm("abcdefghijklmnop"); // exactly 16 chars
         assert_eq!(pbi_comm_to_string(&comm), "abcdefghijklmnop");
     }
 
     #[test]
     fn pbi_comm_to_string_returns_empty_for_invalid_utf8() {
-        let mut comm = [0 as c_char; 17];
-        comm[0] = 0xFFu8 as c_char; // invalid utf-8 start byte
+        let mut comm = [0 as c_char; 16];
+        comm[0] = 0xFFu8 as c_char;
         comm[1] = 0xFEu8 as c_char;
         assert_eq!(pbi_comm_to_string(&comm), "");
     }
@@ -279,11 +281,14 @@ fn argv0_basename(s: &str) -> &str {
 Right above it, add:
 
 ```rust
-/// Convert the C-string `pbi_comm` field of a `BSDInfo` (16 chars + NUL)
-/// to a Rust `String`. Stops at the first NUL byte; returns an empty
-/// string if the bytes are not valid UTF-8 (matches the lossy behavior
-/// of `proc_pid::name()` on garbage input).
-fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String {
+/// Convert the C-string `pbi_comm` field of a `BSDInfo` (16 bytes —
+/// `MAXCOMLEN`, may not have a trailing NUL when the name is exactly
+/// 16 bytes) to a Rust `String`. Stops at the first NUL byte; returns
+/// an empty string if the bytes are not valid UTF-8. Callers should
+/// skip the PID when an empty string is returned, matching the current
+/// behavior where `proc_pid::name()` failure causes `continue`.
+#[cfg(target_os = "macos")]
+fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 16]) -> String {
     let bytes: Vec<u8> = comm.iter()
         .take_while(|&&b| b != 0)
         .map(|&b| b as u8)
@@ -470,5 +475,5 @@ Look for time spent inside `proc_scan` / `scan_processes` / `pidinfo`. If most c
 
 - **Spec coverage:** Every change in the spec maps to a task — Task 1 covers spec §1.3 (gate cwd), Task 2 covers spec §1.1 (UID filter), Tasks 3+4 cover spec §1.2 (drop redundant name call). Spec verification section maps to Task 5. Risks section maps to Task 5 step 7 (the "if it didn't drop" branch).
 - **Placeholder scan:** No TBD/TODO/"add error handling" left. Every code-touching step contains the exact code. Test code is complete and runnable.
-- **Type consistency:** Helper signature is consistent across Task 3 (definition + tests) and Task 4 (call site): `pbi_comm_to_string(&info.pbi_comm)` against `fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String`.
+- **Type consistency:** Helper signature is consistent across Task 3 (definition + tests) and Task 4 (call site): `pbi_comm_to_string(&info.pbi_comm)` against `fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 16]) -> String`. (Original draft of this plan used `; 17` based on a misreading of the kernel `p_comm` size; corrected to `; 16` — `MAXCOMLEN` — once the libproc binding was inspected during T3 review.)
 - **No dead refs:** `pids_by_type` and `ProcFilter` imports are added in Task 2. `pbi_comm_to_string` is added in Task 3 and used in Task 4. `geteuid_safe` is added and used in Task 2.

--- a/docs/superpowers/specs/2026-05-06-proc-scan-perf-design.md
+++ b/docs/superpowers/specs/2026-05-06-proc-scan-perf-design.md
@@ -1,0 +1,121 @@
+# proc_scan performance fix
+
+**Date:** 2026-05-06
+**Status:** Approved (pending implementation plan)
+**Owner:** vietnguyenhoangw
+
+## Problem
+
+The Ani-Mime app idles at ~5–10% CPU. Investigation pinned the cost to `proc_scan::scan_processes()` (`src-tauri/src/proc_scan.rs`), which runs every 2 seconds.
+
+On a typical Mac (~837 PIDs in this user's environment) one scan executes:
+
+| Per PID | Cost | Used by |
+|---|---|---|
+| `proc_pid::name()` | 1 syscall | filter + claude detection |
+| `pidinfo::<BSDInfo>` | 1 syscall (~152 B copy) | filter + claude parent walk |
+| `get_cwd_macos()` (`PROC_PIDVNODEPATHINFO`) | 1 syscall (~2 KB copy) | **only used for shells** |
+| `read_argv0()` | 1 sysctl | only when `is_shell` / `node` / version-string (already gated) |
+
+That is ~2,500 syscalls every 2 s and ~840 KB/s of kernel→user memcpy, ~99% of which is thrown away because cwd is consumed only for the ~5 PIDs that survive `is_user_terminal()`.
+
+Discovery, broadcast, and the frontend rAF loop have already been ruled out — the user's `LAN Peer List` is disabled, and `Mascot.tsx` short-circuits its rAF loop while frozen.
+
+## Goals
+
+- Reduce steady-state CPU of the proc_scan thread by ≥80% without changing observable behavior.
+- Keep the change small enough to review in one PR.
+- Preserve correctness for the existing manual smoke flow (multi-tab pwd refresh, claude attachment, zombie cleanup).
+
+## Non-goals
+
+- Adaptive polling interval.
+- Bulk `sysctl(KERN_PROC_ALL)` rewrite.
+- Event-driven scanning (`kqueue(EVFILT_PROC)`, EndpointSecurity).
+- Changes to the click-to-focus path (`focus.rs`) or to `get_proc_info()` callers outside the hot loop.
+
+Each non-goal is a separate, larger design and is intentionally deferred.
+
+## Design
+
+Three stacking changes, all in `src-tauri/src/proc_scan.rs`:
+
+### 1. Filter PIDs at the OS by current UID
+
+Replace the deprecated `listpids(ProcType::ProcAllPIDS)` call with `processes::pids_by_type(ProcFilter::ByUID { uid })`, where `uid` is `libc::geteuid()`. This drops kernel and root-owned daemons before they enter the loop — roughly 50% of the PID list on a normal user Mac.
+
+### 2. Drop the redundant `proc_pid::name()` call
+
+`BSDInfo` already carries the same short name in `pbi_comm` (16 chars + NUL). Read the name from the BSDInfo result instead of issuing a separate `name()` syscall. Saves one syscall per surviving PID.
+
+A small helper converts the C buffer to a Rust `String`:
+
+```rust
+fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String {
+    let bytes: Vec<u8> = comm.iter()
+        .take_while(|&&b| b != 0)
+        .map(|&b| b as u8)
+        .collect();
+    String::from_utf8(bytes).unwrap_or_default()
+}
+```
+
+The truncation behavior is identical to `proc_pid::name()` (both expose `p_comm`), so `is_shell()` and `looks_like_version_string()` continue to work unchanged.
+
+### 3. Gate `get_cwd_macos()` on `is_shell(name)`
+
+Mirror the existing argv0 gating (`proc_scan.rs:480`) for cwd:
+
+```rust
+let cwd = if is_shell(&name) {
+    get_cwd_macos(pid as i32)
+} else {
+    None
+};
+```
+
+cwd is consumed only inside `reconcile()` for entries that pass `is_user_terminal()` — which already requires `is_shell(&name)`. Fetching cwd for non-shell PIDs is dead work.
+
+Apply the same gating to `get_proc_info()` (single-PID diagnostic helper) for consistency, even though it is not on the hot path.
+
+## Expected impact
+
+| Metric | Before | After |
+|---|---|---|
+| Syscalls / scan | ~2,500 | ~415 |
+| Syscalls / sec | ~1,250 | ~210 |
+| Kernel→user memcpy / sec | ~840 KB | ~35 KB |
+
+CPU expectation on the user's machine: ~5–10% → ~1–2% steady-state for the Ani-Mime process. Verification is manual (Activity Monitor / `sample`) since no perf-regression test harness exists.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| UID filter excludes a PID we care about (e.g., `sudo claude`) | Documented as unsupported. `focus_terminal` does not depend on `scan_processes()` — it uses `proc_pid::pidpath()` + a `ps`-built ppid map, which already handles cross-UID. |
+| `pbi_comm` truncated to 16 chars changes filtering behavior | Same buffer `proc_pid::name()` returns. Identical truncation. |
+| `pidinfo<BSDInfo>` fails for a listed PID | Skip the PID (`continue`). Post-UID-filter, denials are rare. Matches current behavior on `name()` failure. |
+| Library crate API drift | `pids_by_type` and `ProcFilter::ByUID` are the supported, non-deprecated API in `libproc 0.14` (the version pinned in `Cargo.toml`). |
+
+## Verification
+
+- `cd src-tauri && cargo check` — passes.
+- Manual smoke test:
+  1. Open 2–3 terminal tabs; `cd` into different directories — pwd updates in mascot session list within 2 s.
+  2. Run `claude` in one tab — Claude logo appears on that tab's session row.
+  3. Run `bun run tauri dev` in another — `fg_cmd` resolves to `bun` (or `node`).
+  4. Close a shell tab — session disappears within 2 s.
+- CPU before/after via Activity Monitor while idle (no terminals active).
+
+No automated tests are added. `scan_processes` depends on libproc and is not unit-testable without significant scaffolding; existing code has no test coverage for it. Behavior coverage stays at the smoke-test level.
+
+## Files touched
+
+- `src-tauri/src/proc_scan.rs` — the only file modified.
+
+## Out of scope (recorded for later)
+
+- Adaptive polling: slow the scan to 5–10 s when no shells are alive.
+- Bulk `sysctl(KERN_PROC_ALL)` to drop the per-PID loop entirely.
+- Event-driven process lifecycle (`kqueue(EVFILT_PROC)` per tracked PID; EndpointSecurity for global). The latter requires Apple-issued entitlements.
+- Frontend rAF loop tuning (verified not the bottleneck this round).

--- a/docs/superpowers/specs/2026-05-06-proc-scan-perf-design.md
+++ b/docs/superpowers/specs/2026-05-06-proc-scan-perf-design.md
@@ -51,7 +51,7 @@ Replace the deprecated `listpids(ProcType::ProcAllPIDS)` call with `processes::p
 A small helper converts the C buffer to a Rust `String`:
 
 ```rust
-fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String {
+fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 16]) -> String {
     let bytes: Vec<u8> = comm.iter()
         .take_while(|&&b| b != 0)
         .map(|&b| b as u8)
@@ -60,7 +60,7 @@ fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String {
 }
 ```
 
-The truncation behavior is identical to `proc_pid::name()` (both expose `p_comm`), so `is_shell()` and `looks_like_version_string()` continue to work unchanged.
+`BSDInfo.pbi_comm` is `[c_char; MAXCOMLEN]` where `MAXCOMLEN = 16` — the kernel does not include a trailing NUL slot in the libproc binding, so `take_while` simply consumes the whole array when the name is exactly 16 bytes. The truncation/empty-on-bad-utf8 behavior matches `proc_pid::name()`, so `is_shell()` and `looks_like_version_string()` continue to work unchanged.
 
 ### 3. Gate `get_cwd_macos()` on `is_shell(name)`
 

--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -24,6 +24,8 @@ use crate::state::AppState;
 use libproc::libproc::bsd_info::BSDInfo;
 #[cfg(target_os = "macos")]
 use libproc::libproc::proc_pid;
+#[cfg(target_os = "macos")]
+use libproc::processes::{pids_by_type, ProcFilter};
 
 // `libproc::proc_pid::pidcwd` is unimplemented on macOS (returns Err). We work
 // around it by calling `proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, ...)` via the
@@ -452,12 +454,29 @@ fn is_claude(proc: &ProcInfo) -> bool {
     is_claude_name(&proc.name) || is_claude_name(argv0_basename(&proc.argv0))
 }
 
+/// Effective UID of the running process. Used to filter `proc_listpids`
+/// down to user-owned PIDs and skip kernel/root daemons that we will
+/// never care about.
+#[cfg(target_os = "macos")]
+fn geteuid_safe() -> u32 {
+    extern "C" {
+        fn geteuid() -> u32;
+    }
+    unsafe { geteuid() }
+}
+
 #[cfg(target_os = "macos")]
 pub fn scan_processes() -> Vec<ProcInfo> {
-    let pids = match proc_pid::listpids(proc_pid::ProcType::ProcAllPIDS) {
+    // Filter to the current user's processes at the OS level. Drops
+    // kernel_task and root-owned daemons (~half the system's PIDs on a
+    // typical Mac) before we pay the per-PID syscall cost. Shells and
+    // claude both run as the user, so nothing we care about is excluded.
+    // sudo'd processes are intentionally not tracked — same as before.
+    let uid = geteuid_safe();
+    let pids = match pids_by_type(ProcFilter::ByUID { uid }) {
         Ok(p) => p,
         Err(e) => {
-            crate::app_warn!("[proc_scan] listpids failed: {}", e);
+            crate::app_warn!("[proc_scan] pids_by_type(ByUID {{uid={}}}) failed: {}", uid, e);
             return Vec::new();
         }
     };

--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -365,7 +365,11 @@ pub fn get_proc_info(pid: u32) -> Option<ProcInfo> {
     let (ppid, pgid, tpgid, tdev) = proc_pid::pidinfo::<BSDInfo>(pid as i32, 0)
         .map(|info| (info.pbi_ppid, info.pbi_pgid, info.e_tpgid, info.e_tdev))
         .unwrap_or((0, 0, 0, 0));
-    let cwd = get_cwd_macos(pid as i32);
+    let cwd = if is_shell(&name) {
+        get_cwd_macos(pid as i32)
+    } else {
+        None
+    };
     let argv0 = if name == "node" || is_shell(&name) {
         read_argv0(pid as i32).unwrap_or_default()
     } else {
@@ -470,7 +474,16 @@ pub fn scan_processes() -> Vec<ProcInfo> {
             Err(_) => (0, 0, 0, 0),
         };
 
-        let cwd = get_cwd_macos(pid as i32);
+        // Only fetch cwd for shells — it's the only type of process whose
+        // cwd we consume (in reconcile() via is_user_terminal -> is_shell).
+        // PROC_PIDVNODEPATHINFO copies a ~2 KB struct per call, so doing it
+        // unconditionally for every PID on the system was the dominant
+        // cost of this scan loop.
+        let cwd = if is_shell(&name) {
+            get_cwd_macos(pid as i32)
+        } else {
+            None
+        };
 
         // Only spend a sysctl roundtrip on processes that might be Claude
         // Code: node-shipped CLI, shells (we read argv0 for shell detection

--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -193,7 +193,6 @@ fn read_argv0(pid: i32) -> Option<String> {
 /// skip the PID when an empty string is returned, matching the current
 /// behavior where `proc_pid::name()` failure causes `continue`.
 #[cfg(target_os = "macos")]
-#[allow(dead_code)]
 fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 16]) -> String {
     let bytes: Vec<u8> = comm.iter()
         .take_while(|&&b| b != 0)
@@ -499,15 +498,20 @@ pub fn scan_processes() -> Vec<ProcInfo> {
 
     let mut out = Vec::new();
     for pid in pids {
-        let name = match proc_pid::name(pid as i32) {
-            Ok(n) => n,
+        // pidinfo<BSDInfo> gives us name (pbi_comm), ppid, pgid, tpgid,
+        // tdev in a single syscall. Skip the PID if it can't be read —
+        // post-UID-filter this is rare (the PID either exited between
+        // listpids and pidinfo, or we somehow lack permission).
+        let info = match proc_pid::pidinfo::<BSDInfo>(pid as i32, 0) {
+            Ok(i) => i,
             Err(_) => continue,
         };
-
-        let (ppid, pgid, tpgid, tdev) = match proc_pid::pidinfo::<BSDInfo>(pid as i32, 0) {
-            Ok(info) => (info.pbi_ppid, info.pbi_pgid, info.e_tpgid, info.e_tdev),
-            Err(_) => (0, 0, 0, 0),
-        };
+        let name = pbi_comm_to_string(&info.pbi_comm);
+        if name.is_empty() {
+            continue;
+        }
+        let (ppid, pgid, tpgid, tdev) =
+            (info.pbi_ppid, info.pbi_pgid, info.e_tpgid, info.e_tdev);
 
         // Only fetch cwd for shells — it's the only type of process whose
         // cwd we consume (in reconcile() via is_user_terminal -> is_shell).

--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -458,7 +458,7 @@ fn is_claude(proc: &ProcInfo) -> bool {
 /// down to user-owned PIDs and skip kernel/root daemons that we will
 /// never care about.
 #[cfg(target_os = "macos")]
-fn geteuid_safe() -> u32 {
+fn current_euid() -> u32 {
     extern "C" {
         fn geteuid() -> u32;
     }
@@ -472,7 +472,7 @@ pub fn scan_processes() -> Vec<ProcInfo> {
     // typical Mac) before we pay the per-PID syscall cost. Shells and
     // claude both run as the user, so nothing we care about is excluded.
     // sudo'd processes are intentionally not tracked — same as before.
-    let uid = geteuid_safe();
+    let uid = current_euid();
     let pids = match pids_by_type(ProcFilter::ByUID { uid }) {
         Ok(p) => p,
         Err(e) => {

--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -186,11 +186,15 @@ fn read_argv0(pid: i32) -> Option<String> {
     String::from_utf8(buf[start..pos].to_vec()).ok()
 }
 
-/// Convert the C-string `pbi_comm` field of a `BSDInfo` (16 chars + NUL)
-/// to a Rust `String`. Stops at the first NUL byte; returns an empty
-/// string if the bytes are not valid UTF-8 (matches the lossy behavior
-/// of `proc_pid::name()` on garbage input).
-fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String {
+/// Convert the C-string `pbi_comm` field of a `BSDInfo` (16 bytes —
+/// `MAXCOMLEN`, may not have a trailing NUL when the name is exactly
+/// 16 bytes) to a Rust `String`. Stops at the first NUL byte; returns
+/// an empty string if the bytes are not valid UTF-8. Callers should
+/// skip the PID when an empty string is returned, matching the current
+/// behavior where `proc_pid::name()` failure causes `continue`.
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 16]) -> String {
     let bytes: Vec<u8> = comm.iter()
         .take_while(|&&b| b != 0)
         .map(|&b| b as u8)
@@ -737,14 +741,15 @@ pub fn start_proc_scanner(app_handle: tauri::AppHandle, app_state: Arc<Mutex<App
 }
 
 #[cfg(test)]
+#[cfg(target_os = "macos")]
 mod tests {
     use super::*;
     use std::os::raw::c_char;
 
-    fn make_comm(s: &str) -> [c_char; 17] {
-        let mut buf = [0 as c_char; 17];
+    fn make_comm(s: &str) -> [c_char; 16] {
+        let mut buf = [0 as c_char; 16];
         for (i, b) in s.bytes().enumerate() {
-            if i >= 16 { break; } // leave the trailing NUL
+            if i >= 16 { break; }
             buf[i] = b as c_char;
         }
         buf
@@ -758,23 +763,24 @@ mod tests {
 
     #[test]
     fn pbi_comm_to_string_returns_empty_for_all_zero_buffer() {
-        let comm = [0 as c_char; 17];
+        let comm = [0 as c_char; 16];
         assert_eq!(pbi_comm_to_string(&comm), "");
     }
 
     #[test]
-    fn pbi_comm_to_string_handles_full_16_byte_name_without_nul_in_first_16() {
-        // p_comm is 16 chars + NUL at index 16. A 16-char process name fills
-        // indices 0..15 and the NUL sits at index 16. We must read all 16
-        // bytes, not stop early.
+    fn pbi_comm_to_string_reads_full_buffer_when_no_nul_present() {
+        // pbi_comm is 16 bytes (MAXCOMLEN). When the process name is
+        // exactly 16 bytes, the buffer has NO trailing NUL — the take_while
+        // simply hits the end of the array. Verify the helper returns the
+        // full 16 chars in that case rather than stopping early.
         let comm = make_comm("abcdefghijklmnop"); // exactly 16 chars
         assert_eq!(pbi_comm_to_string(&comm), "abcdefghijklmnop");
     }
 
     #[test]
     fn pbi_comm_to_string_returns_empty_for_invalid_utf8() {
-        let mut comm = [0 as c_char; 17];
-        comm[0] = 0xFFu8 as c_char; // invalid utf-8 start byte
+        let mut comm = [0 as c_char; 16];
+        comm[0] = 0xFFu8 as c_char;
         comm[1] = 0xFEu8 as c_char;
         assert_eq!(pbi_comm_to_string(&comm), "");
     }

--- a/src-tauri/src/proc_scan.rs
+++ b/src-tauri/src/proc_scan.rs
@@ -186,6 +186,18 @@ fn read_argv0(pid: i32) -> Option<String> {
     String::from_utf8(buf[start..pos].to_vec()).ok()
 }
 
+/// Convert the C-string `pbi_comm` field of a `BSDInfo` (16 chars + NUL)
+/// to a Rust `String`. Stops at the first NUL byte; returns an empty
+/// string if the bytes are not valid UTF-8 (matches the lossy behavior
+/// of `proc_pid::name()` on garbage input).
+fn pbi_comm_to_string(comm: &[std::os::raw::c_char; 17]) -> String {
+    let bytes: Vec<u8> = comm.iter()
+        .take_while(|&&b| b != 0)
+        .map(|&b| b as u8)
+        .collect();
+    String::from_utf8(bytes).unwrap_or_default()
+}
+
 /// Just the basename of argv[0] (strip any leading dirs).
 fn argv0_basename(s: &str) -> &str {
     s.rsplit('/').next().unwrap_or(s)
@@ -722,4 +734,48 @@ pub fn start_proc_scanner(app_handle: tauri::AppHandle, app_state: Arc<Mutex<App
         std::thread::sleep(std::time::Duration::from_secs(SCAN_INTERVAL_SECS));
         reconcile(&app_handle, &app_state);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::raw::c_char;
+
+    fn make_comm(s: &str) -> [c_char; 17] {
+        let mut buf = [0 as c_char; 17];
+        for (i, b) in s.bytes().enumerate() {
+            if i >= 16 { break; } // leave the trailing NUL
+            buf[i] = b as c_char;
+        }
+        buf
+    }
+
+    #[test]
+    fn pbi_comm_to_string_reads_until_first_nul() {
+        let comm = make_comm("zsh");
+        assert_eq!(pbi_comm_to_string(&comm), "zsh");
+    }
+
+    #[test]
+    fn pbi_comm_to_string_returns_empty_for_all_zero_buffer() {
+        let comm = [0 as c_char; 17];
+        assert_eq!(pbi_comm_to_string(&comm), "");
+    }
+
+    #[test]
+    fn pbi_comm_to_string_handles_full_16_byte_name_without_nul_in_first_16() {
+        // p_comm is 16 chars + NUL at index 16. A 16-char process name fills
+        // indices 0..15 and the NUL sits at index 16. We must read all 16
+        // bytes, not stop early.
+        let comm = make_comm("abcdefghijklmnop"); // exactly 16 chars
+        assert_eq!(pbi_comm_to_string(&comm), "abcdefghijklmnop");
+    }
+
+    #[test]
+    fn pbi_comm_to_string_returns_empty_for_invalid_utf8() {
+        let mut comm = [0 as c_char; 17];
+        comm[0] = 0xFFu8 as c_char; // invalid utf-8 start byte
+        comm[1] = 0xFEu8 as c_char;
+        assert_eq!(pbi_comm_to_string(&comm), "");
+    }
 }


### PR DESCRIPTION
## Summary

Eliminates the wasted-syscall hot path in the 2-second `proc_scan` thread that was costing ~5–10% steady-state CPU. Three stacking changes inside `src-tauri/src/proc_scan.rs`:

1. **Gate `get_cwd_macos` on `is_shell(name)`** — `PROC_PIDVNODEPATHINFO` copies a ~2 KB struct per call. cwd is consumed only inside `reconcile()` for entries that pass `is_user_terminal()` (which already requires `is_shell`), so fetching it for every PID was ~99% wasted work.
2. **Filter `listpids` by current effective UID** — switches the deprecated `listpids(ProcAllPIDS)` to `pids_by_type(ProcFilter::ByUID { uid })` (the supported libproc 0.14 API). Drops kernel/root daemons before the per-PID loop pays any cost. Adds a small `current_euid()` helper using inline `extern "C"` to match the file's existing FFI style — no new Cargo dependency.
3. **Read name from `BSDInfo.pbi_comm`** instead of a separate `proc_pid::name()` call — they return the same 16-char `p_comm` field, so calling both was redundant. New pure helper `pbi_comm_to_string` with 4 unit tests.

Expected impact: **~2,500 → ~415 syscalls per scan**, **~840 KB/s → ~35 KB/s** of kernel→user memcpy; CPU should drop from ~5–10% to ~1–2% steady-state.

Spec at `docs/superpowers/specs/2026-05-06-proc-scan-perf-design.md`; plan at `docs/superpowers/plans/2026-05-06-proc-scan-perf.md`.

## Behavioral note

PIDs whose `pidinfo<BSDInfo>` call fails are now `continue`d (skipped) instead of being kept with zeroed `(ppid, pgid, tpgid, tdev)`. This is strictly safer — `is_user_terminal()` already filtered such zombies out via `tdev == 0`, so they were never useful entries anyway.

## Out of scope (potential follow-ups)

- Apply `pbi_comm_to_string` to `get_proc_info()` for internal consistency (called only on click, not in hot path)
- Linux `pid_exists()` could use `kill(pid, 0)` so the HTTP 410 path works on Linux/WSL2 builds
- Adaptive polling interval (slow scan when no shells active)

## Test Plan

- [ ] `cd src-tauri && cargo check` — clean
- [ ] `cd src-tauri && cargo test --lib proc_scan::tests::` — 4 tests pass
- [ ] Build the app (`bun run tauri build && bash src-tauri/script/post-build-sign.sh`) and launch the new binary
- [ ] **Multi-shell pwd refresh:** open 2–3 terminal tabs, `cd` to different dirs in each, verify each row in the mascot session list shows the correct directory within ~2 s
- [ ] **Claude attachment:** run `claude` in one tab, verify the Claude logo appears on that row; quit `claude`, verify the logo clears within ~2 s
- [ ] **Foreground command:** run `bun run tauri dev` (or `sleep 30`) in a tab; verify `fg_cmd` shows in the row; Ctrl-C; verify it clears within ~2 s
- [ ] **Zombie cleanup:** close a shell tab; verify the session disappears within ~2 s
- [ ] **CPU before/after:** observe Ani-Mime process CPU% in Activity Monitor for 60 s on the previous build, then on the new build, with no terminals doing anything. Expect a clear drop (~5–10% → ~1–2%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)