### PR TITLE
fix: stop re-prompting for Accessibility on every Quick Translate launch (v0.17.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.17.14] - 2026-06-08
+
+### Fixed
+- Quick Translate no longer re-prompts for macOS Accessibility permission on every popup launch. It now asks at most once per app run — grant access, restart the app once, and selection pre-fill works silently thereafter.
+
 ## [0.17.13] - 2026-06-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.13",
+  "version": "0.17.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.13"
+version = "0.17.14"
 dependencies = [
  "arboard",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.13"
+version = "0.17.14"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/plugin/selection.rs
+++ b/src-tauri/src/plugin/selection.rs
@@ -36,7 +36,13 @@ mod imp {
     use core_foundation::string::{CFString, CFStringRef};
     use core_graphics::event::{CGEvent, CGEventFlags, CGEventTapLocation, CGKeyCode};
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
+
+    /// We prompt for Accessibility at most once per app run. A running process
+    /// can't see a freshly-granted permission until it is relaunched, so
+    /// re-prompting on every capture just nags the user with no upside.
+    static PROMPTED_THIS_SESSION: AtomicBool = AtomicBool::new(false);
 
     #[link(name = "ApplicationServices", kind = "framework")]
     extern "C" {
@@ -64,7 +70,10 @@ mod imp {
 
     pub fn capture_selection() -> Option<String> {
         if !accessibility_trusted() {
-            prompt_accessibility();
+            // Prompt only the first time this session; thereafter open empty.
+            if !PROMPTED_THIS_SESSION.swap(true, Ordering::Relaxed) {
+                prompt_accessibility();
+            }
             return None;
         }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.13",
+  "version": "0.17.14",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1490,7 +1490,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.13{devMode && " (Dev Mode)"}
+                  Version 0.17.14{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
## Summary
Quick Translate's selection pre-fill re-fired the macOS Accessibility permission dialog on **every** popup launch. A running process can't see a freshly-granted Accessibility permission until it's relaunched, so calling the prompting API whenever `AXIsProcessTrusted()` is false nagged endlessly.

Now we prompt **at most once per app run**; otherwise the popup opens empty (the existing graceful fallback). After granting + one app restart, capture works silently.

Also bumps the app to **0.17.14**.

## Test Plan
- [x] `cargo test --lib` — 103 passed
- [ ] Manual: open Quick Translate with no permission → prompt appears once → grant → restart app → selection pre-fill works, no further prompts; opening the popup again does not re-prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)