### PR TITLE
feat: mini bar mode (edge-docked status bar)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-mini-bar-mode.md
+++ b/docs/superpowers/plans/2026-06-15-mini-bar-mode.md
@@ -1,0 +1,1715 @@
+# Mini Bar Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimize button that collapses the floating pet into a thin status bar that snaps to any of the four screen edges, glows with the current status color, and exposes the session + peer tools plus a restore button.
+
+**Architecture:** Reuse the single main window (no new Tauri window). A `useMiniMode` hook owns a `mode: 'pet' | 'mini'` state and the window resize/snap mechanics. `App` renders either the existing pet column or a new `<MiniBar>`. Edge/corner snapping is a pure `computeSnap()` function so it is unit-testable without Tauri. Session-grouping logic is extracted into a shared util and a `<SessionDropdown>` component so both the pet pill and the mini bar reuse it.
+
+**Tech Stack:** React 19, TypeScript, Tauri 2 (`@tauri-apps/api/window`), Vitest + React Testing Library, Playwright (e2e). Package manager: **Bun**.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/utils/snap.ts` — pure edge/corner snap math + bar constants. No Tauri imports.
+- `src/utils/popoverPos.ts` — pure inward-popover position math for mini mode.
+- `src/utils/sessionGroups.ts` — session grouping helpers extracted from `StatusPill.tsx`.
+- `src/components/SessionDropdown.tsx` — presentational session-list dropdown, shared by pill + mini.
+- `src/components/MiniBar.tsx` — the bar UI (dot, session, peer, restore) + glow + orientation.
+- `src/hooks/useMiniMode.ts` — `mode` state + enter/exit/snap window mechanics.
+- `src/styles/mini-bar.css` — bar layout + status glow.
+- `src/__tests__/utils/snap.test.ts`
+- `src/__tests__/utils/popoverPos.test.ts`
+- `src/__tests__/components/MiniBar.test.tsx`
+
+**Modify:**
+- `src/__mocks__/tauri-window.ts` — add `currentMonitor`, `LogicalPosition`, `LogicalSize`, `outerSize`, `scaleFactor`, `toLogical`.
+- `src/hooks/useDrag.ts` — accept an `onDragEnd` callback; ignore drags that start on a `<button>`.
+- `src/components/StatusPill.tsx` — add the minimize button; import grouping from `sessionGroups.ts`; render `<SessionDropdown>`.
+- `src/App.tsx` — branch render on `mode`; gate pet-mode resize effects while in mini mode.
+- `e2e/mini-bar.spec.ts` — new e2e (create).
+
+---
+
+## Task Group 1: Snap math (pure, no Tauri)
+
+### Task 1: `computeSnap()` and bar constants
+
+**Files:**
+- Create: `src/utils/snap.ts`
+- Test: `src/__tests__/utils/snap.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/__tests__/utils/snap.test.ts
+import { describe, it, expect } from "vitest";
+import { computeSnap, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS } from "../../utils/snap";
+
+const MON = { x: 0, y: 0, width: 1000, height: 800 };
+const LONG = 168;
+const SHORT = 40;
+
+describe("computeSnap", () => {
+  it("snaps to the LEFT edge, TOP corner (vertical bar)", () => {
+    // window center at (50, 100) -> nearest edge is left, top half
+    const r = computeSnap({ x: 30, y: 16, width: 40, height: 168 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("left");
+    expect(r.orientation).toBe("vertical");
+    expect(r.width).toBe(SHORT);
+    expect(r.height).toBe(LONG);
+    expect(r.x).toBe(8);          // monitor.x + edge margin
+    expect(r.y).toBe(30);         // monitor.y + menuBar margin (top corner)
+  });
+
+  it("snaps to the RIGHT edge, BOTTOM corner (vertical bar)", () => {
+    // center (950, 700)
+    const r = computeSnap({ x: 930, y: 616, width: 40, height: 168 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("right");
+    expect(r.orientation).toBe("vertical");
+    expect(r.x).toBe(1000 - SHORT - 8); // 952
+    expect(r.y).toBe(800 - LONG - 8);   // 624 (bottom corner)
+  });
+
+  it("snaps to the TOP edge, RIGHT corner (horizontal bar)", () => {
+    // center (900, 50)
+    const r = computeSnap({ x: 816, y: 30, width: 168, height: 40 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("top");
+    expect(r.orientation).toBe("horizontal");
+    expect(r.width).toBe(LONG);
+    expect(r.height).toBe(SHORT);
+    expect(r.y).toBe(30);                 // menuBar margin
+    expect(r.x).toBe(1000 - LONG - 8);    // 824 (right corner)
+  });
+
+  it("snaps to the BOTTOM edge, LEFT corner (horizontal bar)", () => {
+    // center (100, 750)
+    const r = computeSnap({ x: 16, y: 730, width: 168, height: 40 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("bottom");
+    expect(r.orientation).toBe("horizontal");
+    expect(r.y).toBe(800 - SHORT - 8);    // 752
+    expect(r.x).toBe(8);                   // left corner
+  });
+
+  it("exports sane default bar constants", () => {
+    expect(BAR_LONG).toBeGreaterThan(BAR_SHORT);
+    expect(DEFAULT_MARGINS.menuBar).toBeGreaterThanOrEqual(DEFAULT_MARGINS.edge);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest run src/__tests__/utils/snap.test.ts`
+Expected: FAIL — `Cannot find module '../../utils/snap'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/utils/snap.ts
+export type Orientation = "horizontal" | "vertical";
+export type Edge = "left" | "right" | "top" | "bottom";
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SnapMargins {
+  /** Gap from screen edges, in logical px. */
+  edge: number;
+  /** Extra gap from the top edge to clear the macOS menu bar, in logical px. */
+  menuBar: number;
+}
+
+export interface SnapResult {
+  x: number;
+  y: number;
+  edge: Edge;
+  orientation: Orientation;
+  /** Bar window width at this orientation (logical px). */
+  width: number;
+  /** Bar window height at this orientation (logical px). */
+  height: number;
+}
+
+/** Bar dimensions in logical px (before display scale). Long = along the edge. */
+export const BAR_LONG = 168;
+export const BAR_SHORT = 40;
+
+export const DEFAULT_MARGINS: SnapMargins = { edge: 8, menuBar: 30 };
+
+/**
+ * Given the current window rect and the monitor rect (both logical px),
+ * pick the nearest of the four edges, then the nearest corner on that edge,
+ * and return the snapped top-left position + the bar orientation/size.
+ *
+ * Pure: no Tauri calls, plain numbers in and out, so it is unit-testable.
+ */
+export function computeSnap(
+  win: Rect,
+  monitor: Rect,
+  barLong: number,
+  barShort: number,
+  margins: SnapMargins = DEFAULT_MARGINS
+): SnapResult {
+  const cx = win.x + win.width / 2;
+  const cy = win.y + win.height / 2;
+
+  const distLeft = cx - monitor.x;
+  const distRight = monitor.x + monitor.width - cx;
+  const distTop = cy - monitor.y;
+  const distBottom = monitor.y + monitor.height - cy;
+
+  const min = Math.min(distLeft, distRight, distTop, distBottom);
+
+  let edge: Edge;
+  if (min === distLeft) edge = "left";
+  else if (min === distRight) edge = "right";
+  else if (min === distTop) edge = "top";
+  else edge = "bottom";
+
+  const vertical = edge === "left" || edge === "right";
+  const width = vertical ? barShort : barLong;
+  const height = vertical ? barLong : barShort;
+
+  let x: number;
+  let y: number;
+
+  if (vertical) {
+    x =
+      edge === "left"
+        ? monitor.x + margins.edge
+        : monitor.x + monitor.width - width - margins.edge;
+    const topHalf = cy < monitor.y + monitor.height / 2;
+    y = topHalf
+      ? monitor.y + margins.menuBar
+      : monitor.y + monitor.height - height - margins.edge;
+  } else {
+    y =
+      edge === "top"
+        ? monitor.y + margins.menuBar
+        : monitor.y + monitor.height - height - margins.edge;
+    const leftHalf = cx < monitor.x + monitor.width / 2;
+    x = leftHalf
+      ? monitor.x + margins.edge
+      : monitor.x + monitor.width - width - margins.edge;
+  }
+
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    edge,
+    orientation: vertical ? "vertical" : "horizontal",
+    width,
+    height,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest run src/__tests__/utils/snap.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/snap.ts src/__tests__/utils/snap.test.ts
+git commit -m "feat(mini-bar): pure edge/corner snap math"
+```
+
+---
+
+## Task Group 2: Tauri window mock additions
+
+### Task 2: Extend the window mock for monitor + logical types
+
+**Files:**
+- Modify: `src/__mocks__/tauri-window.ts`
+
+- [ ] **Step 1: Replace the mock with the extended version**
+
+Replace the entire contents of `src/__mocks__/tauri-window.ts` with:
+
+```ts
+/**
+ * Mock for @tauri-apps/api/window
+ */
+
+export class LogicalPosition {
+  type = "Logical" as const;
+  constructor(public x: number, public y: number) {}
+}
+
+export class LogicalSize {
+  type = "Logical" as const;
+  constructor(public width: number, public height: number) {}
+}
+
+export class PhysicalPosition {
+  type = "Physical" as const;
+  constructor(public x: number, public y: number) {}
+  toLogical(_sf: number) {
+    return new LogicalPosition(this.x, this.y);
+  }
+}
+
+export class PhysicalSize {
+  type = "Physical" as const;
+  constructor(public width: number, public height: number) {}
+  toLogical(_sf: number) {
+    return new LogicalSize(this.width, this.height);
+  }
+}
+
+const mockWindow = {
+  label: "main",
+  startDragging: vi.fn(async () => {}),
+  setPosition: vi.fn(async () => {}),
+  outerPosition: vi.fn(async () => new PhysicalPosition(0, 0)),
+  outerSize: vi.fn(async () => new PhysicalSize(160, 240)),
+  setSize: vi.fn(async () => {}),
+  scaleFactor: vi.fn(async () => 1),
+  hide: vi.fn(async () => {}),
+  close: vi.fn(async () => {}),
+};
+
+export function getCurrentWindow() {
+  return mockWindow;
+}
+
+export const currentMonitor = vi.fn(async () => ({
+  name: "mock",
+  scaleFactor: 1,
+  position: new PhysicalPosition(0, 0),
+  size: new PhysicalSize(1000, 800),
+}));
+
+export function resetMocks() {
+  mockWindow.startDragging.mockClear();
+  mockWindow.setPosition.mockClear();
+  mockWindow.outerPosition.mockClear();
+  mockWindow.outerSize.mockClear();
+  mockWindow.setSize.mockClear();
+  mockWindow.scaleFactor.mockClear();
+  mockWindow.hide.mockClear();
+  mockWindow.close.mockClear();
+  currentMonitor.mockClear();
+}
+```
+
+- [ ] **Step 2: Run the existing suite to verify nothing broke**
+
+Run: `bunx vitest run`
+Expected: PASS — the full existing suite still green (the mock is a superset of the old one).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__mocks__/tauri-window.ts
+git commit -m "test(mini-bar): extend tauri-window mock with monitor + logical types"
+```
+
+---
+
+## Task Group 3: MiniBar component (core: dot + restore + glow)
+
+### Task 3: MiniBar renders dot + restore, with orientation + status classes
+
+**Files:**
+- Create: `src/components/MiniBar.tsx`
+- Create: `src/styles/mini-bar.css`
+- Test: `src/__tests__/components/MiniBar.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/__tests__/components/MiniBar.test.tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MiniBar } from "../../components/MiniBar";
+
+describe("MiniBar", () => {
+  it("renders the status dot with the status class", () => {
+    render(<MiniBar status="busy" orientation="horizontal" onRestore={() => {}} />);
+    const dot = screen.getByTestId("mini-bar-dot");
+    expect(dot).toHaveClass("dot");
+    expect(dot).toHaveClass("busy");
+  });
+
+  it("reflects orientation via data-orientation + class", () => {
+    render(<MiniBar status="idle" orientation="vertical" onRestore={() => {}} />);
+    const bar = screen.getByTestId("mini-bar");
+    expect(bar).toHaveAttribute("data-orientation", "vertical");
+    expect(bar).toHaveClass("vertical");
+    expect(bar).toHaveClass("idle");
+  });
+
+  it("calls onRestore when the restore button is clicked", () => {
+    const onRestore = vi.fn();
+    render(<MiniBar status="idle" orientation="horizontal" onRestore={onRestore} />);
+    fireEvent.click(screen.getByTestId("mini-bar-restore"));
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest run src/__tests__/components/MiniBar.test.tsx`
+Expected: FAIL — `Cannot find module '../../components/MiniBar'`.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+// src/components/MiniBar.tsx
+import type { Status } from "../types/status";
+import type { Orientation } from "../utils/snap";
+import "../styles/mini-bar.css";
+
+interface MiniBarProps {
+  status: Status;
+  orientation: Orientation;
+  onRestore: () => void;
+}
+
+/**
+ * The collapsed "mini bar" view. Reuses the `.dot` status classes from
+ * status-pill.css (loaded globally because StatusPill is imported by App).
+ * The status class on the root drives the glow color (see mini-bar.css).
+ */
+export function MiniBar({ status, orientation, onRestore }: MiniBarProps) {
+  return (
+    <div
+      data-testid="mini-bar"
+      data-orientation={orientation}
+      className={`mini-bar ${orientation} ${status}`}
+    >
+      <span data-testid="mini-bar-dot" className={`dot ${status}`} />
+      <button
+        type="button"
+        data-testid="mini-bar-restore"
+        className="mini-bar-btn"
+        aria-label="Restore pet"
+        title="Restore"
+        onClick={onRestore}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M4 4h7v2H6v5H4V4zm9 0h7v7h-2V6h-5V4zM4 13h2v5h5v2H4v-7zm14 0h2v7h-7v-2h5v-5z" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write the stylesheet**
+
+```css
+/* src/styles/mini-bar.css */
+
+/* Collapse the pet container's pet-size minimums while in mini mode. */
+.container.mini-mode {
+  min-width: 0 !important;
+  min-height: 0 !important;
+  padding: 0;
+}
+
+.mini-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 0 10px;
+  border-radius: 20px;
+  background: var(--bg-pill);
+  border: 1px solid var(--border-pill);
+  transition: box-shadow 0.3s, border-color 0.2s;
+}
+
+.mini-bar.vertical {
+  flex-direction: column;
+  padding: 10px 0;
+}
+
+.mini-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 6px;
+  background: var(--bg-pill-hover);
+  border: 1px solid var(--border-pill);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.mini-bar-btn:hover {
+  border-color: var(--border-pill-hover);
+}
+
+/* Status glow — colors mirror the .dot.* values in status-pill.css. */
+.mini-bar.idle         { box-shadow: 0 0 8px rgba(52, 199, 89, 0.5),  0 0 18px rgba(52, 199, 89, 0.3); }
+.mini-bar.busy         { box-shadow: 0 0 8px rgba(255, 59, 48, 0.5),  0 0 18px rgba(255, 59, 48, 0.3); }
+.mini-bar.service      { box-shadow: 0 0 8px rgba(94, 92, 230, 0.5),  0 0 18px rgba(94, 92, 230, 0.3); }
+.mini-bar.searching    { box-shadow: 0 0 8px rgba(255, 204, 0, 0.5),  0 0 18px rgba(255, 204, 0, 0.3); }
+.mini-bar.initializing { box-shadow: 0 0 8px rgba(255, 159, 10, 0.5), 0 0 18px rgba(255, 159, 10, 0.3); }
+.mini-bar.visiting     { box-shadow: 0 0 8px rgba(175, 82, 222, 0.5), 0 0 18px rgba(175, 82, 222, 0.3); }
+.mini-bar.disconnected { box-shadow: 0 0 8px rgba(99, 99, 102, 0.4); }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bunx vitest run src/__tests__/components/MiniBar.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MiniBar.tsx src/styles/mini-bar.css src/__tests__/components/MiniBar.test.tsx
+git commit -m "feat(mini-bar): MiniBar component with status glow + orientation"
+```
+
+---
+
+## Task Group 4: useMiniMode hook (window mechanics)
+
+### Task 4: enter/exit/snap window transitions
+
+**Files:**
+- Create: `src/hooks/useMiniMode.ts`
+- Test: `src/__tests__/hooks/useMiniMode.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/__tests__/hooks/useMiniMode.test.tsx
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { useMiniMode } from "../../hooks/useMiniMode";
+import { getCurrentWindow, resetMocks } from "../../__mocks__/tauri-window";
+
+describe("useMiniMode", () => {
+  beforeEach(() => resetMocks());
+
+  it("starts in pet mode", () => {
+    const { result } = renderHook(() => useMiniMode(1));
+    expect(result.current.mode).toBe("pet");
+  });
+
+  it("enterMini flips to mini and resizes + positions the window", async () => {
+    const { result } = renderHook(() => useMiniMode(1));
+    await act(async () => {
+      await result.current.enterMini();
+    });
+    await waitFor(() => expect(result.current.mode).toBe("mini"));
+    const win = getCurrentWindow();
+    expect(win.setSize).toHaveBeenCalled();
+    expect(win.setPosition).toHaveBeenCalled();
+  });
+
+  it("exitMini flips back to pet and restores pet size", async () => {
+    const { result } = renderHook(() => useMiniMode(1));
+    await act(async () => {
+      await result.current.enterMini();
+    });
+    const win = getCurrentWindow();
+    win.setSize.mockClear();
+    await act(async () => {
+      await result.current.exitMini();
+    });
+    await waitFor(() => expect(result.current.mode).toBe("pet"));
+    expect(win.setSize).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest run src/__tests__/hooks/useMiniMode.test.tsx`
+Expected: FAIL — `Cannot find module '../../hooks/useMiniMode'`.
+
+- [ ] **Step 3: Write the hook**
+
+```ts
+// src/hooks/useMiniMode.ts
+import { useCallback, useRef, useState } from "react";
+import {
+  getCurrentWindow,
+  currentMonitor,
+  LogicalPosition,
+  LogicalSize,
+} from "@tauri-apps/api/window";
+import { getDefaultPetSize } from "./useWindowDefaultSize";
+import {
+  computeSnap,
+  BAR_LONG,
+  BAR_SHORT,
+  DEFAULT_MARGINS,
+  type Orientation,
+  type Rect,
+} from "../utils/snap";
+
+export type Mode = "pet" | "mini";
+
+/** Read the current monitor as a logical-pixel rect, or null if unavailable. */
+async function monitorLogicalRect(): Promise<Rect | null> {
+  const m = await currentMonitor();
+  if (!m) return null;
+  const sf = m.scaleFactor || 1;
+  return {
+    x: m.position.x / sf,
+    y: m.position.y / sf,
+    width: m.size.width / sf,
+    height: m.size.height / sf,
+  };
+}
+
+/**
+ * Owns the pet <-> mini transition and the window resize/snap mechanics.
+ * No persistence (the app always launches in pet mode).
+ */
+export function useMiniMode(scale: number) {
+  const [mode, setMode] = useState<Mode>("pet");
+  const [orientation, setOrientation] = useState<Orientation>("horizontal");
+  const savedPetPosRef = useRef<LogicalPosition | null>(null);
+
+  const snapToNearest = useCallback(async () => {
+    const win = getCurrentWindow();
+    try {
+      const monitor = await monitorLogicalRect();
+      if (!monitor) {
+        console.warn("[mini-bar] no monitor; leaving bar where dropped");
+        return;
+      }
+      const sf = await win.scaleFactor();
+      const pos = (await win.outerPosition()).toLogical(sf);
+      const size = (await win.outerSize()).toLogical(sf);
+      const barLong = Math.round(BAR_LONG * scale);
+      const barShort = Math.round(BAR_SHORT * scale);
+      const snap = computeSnap(
+        { x: pos.x, y: pos.y, width: size.width, height: size.height },
+        monitor,
+        barLong,
+        barShort,
+        DEFAULT_MARGINS
+      );
+      setOrientation(snap.orientation);
+      await win.setSize(new LogicalSize(snap.width, snap.height));
+      await win.setPosition(new LogicalPosition(snap.x, snap.y));
+    } catch (err) {
+      console.error("[mini-bar] snap failed:", err);
+    }
+  }, [scale]);
+
+  const enterMini = useCallback(async () => {
+    const win = getCurrentWindow();
+    try {
+      const sf = await win.scaleFactor();
+      const pos = (await win.outerPosition()).toLogical(sf);
+      savedPetPosRef.current = new LogicalPosition(
+        Math.round(pos.x),
+        Math.round(pos.y)
+      );
+    } catch (err) {
+      console.error("[mini-bar] capture pet position failed:", err);
+    }
+    setMode("mini");
+    await snapToNearest();
+  }, [snapToNearest]);
+
+  const exitMini = useCallback(async () => {
+    const win = getCurrentWindow();
+    setMode("pet");
+    try {
+      const def = getDefaultPetSize(scale);
+      await win.setSize(new LogicalSize(def.width, def.height));
+      const saved = savedPetPosRef.current;
+      if (saved) await win.setPosition(saved);
+    } catch (err) {
+      console.error("[mini-bar] restore failed:", err);
+    }
+  }, [scale]);
+
+  return { mode, orientation, enterMini, exitMini, snapToNearest };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest run src/__tests__/hooks/useMiniMode.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useMiniMode.ts src/__tests__/hooks/useMiniMode.test.tsx
+git commit -m "feat(mini-bar): useMiniMode hook for window enter/exit/snap"
+```
+
+---
+
+## Task Group 5: Wire into App (minimize button, render branch, effect gating, drag-snap)
+
+### Task 5: useDrag accepts an onDragEnd + ignores button drags
+
+**Files:**
+- Modify: `src/hooks/useDrag.ts`
+- Test: `src/__tests__/hooks/useDrag.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/__tests__/hooks/useDrag.test.tsx
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useDrag } from "../../hooks/useDrag";
+import { getCurrentWindow, resetMocks } from "../../__mocks__/tauri-window";
+
+function mouseEvent(target: HTMLElement, button = 0) {
+  return { button, target } as unknown as React.MouseEvent;
+}
+
+describe("useDrag", () => {
+  beforeEach(() => resetMocks());
+
+  it("calls onDragEnd after a drag completes", async () => {
+    const onDragEnd = vi.fn();
+    const { result } = renderHook(() => useDrag(onDragEnd));
+    const div = document.createElement("div");
+    await act(async () => {
+      await result.current.onMouseDown(mouseEvent(div));
+    });
+    expect(getCurrentWindow().startDragging).toHaveBeenCalled();
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a drag when the target is a button", async () => {
+    const { result } = renderHook(() => useDrag());
+    const btn = document.createElement("button");
+    await act(async () => {
+      await result.current.onMouseDown(mouseEvent(btn));
+    });
+    expect(getCurrentWindow().startDragging).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest run src/__tests__/hooks/useDrag.test.tsx`
+Expected: FAIL — `onDragEnd` is not called / button drag still starts.
+
+- [ ] **Step 3: Update the hook**
+
+Replace the contents of `src/hooks/useDrag.ts` with:
+
+```ts
+import { useState, useCallback } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export function useDrag(onDragEnd?: () => void) {
+  const [dragging, setDragging] = useState(false);
+
+  const onMouseDown = useCallback(
+    async (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      // Don't start a window drag when interacting with the pill dropdown.
+      if (target.closest('[data-testid="status-pill-wrap"]')) return;
+      // Don't drag when pressing a button (minimize/restore/tools/session).
+      if (target.closest("button")) return;
+      setDragging(true);
+      await getCurrentWindow().startDragging();
+      setDragging(false);
+      onDragEnd?.();
+    },
+    [onDragEnd]
+  );
+
+  return { dragging, onMouseDown };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest run src/__tests__/hooks/useDrag.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useDrag.ts src/__tests__/hooks/useDrag.test.tsx
+git commit -m "feat(mini-bar): useDrag onDragEnd callback + ignore button drags"
+```
+
+### Task 6: Add the minimize button to StatusPill
+
+**Files:**
+- Modify: `src/components/StatusPill.tsx`
+- Test: `src/__tests__/components/StatusPill.test.tsx`
+
+- [ ] **Step 1: Write the failing test (append to the existing describe block)**
+
+Add inside the existing `describe("StatusPill", ...)` in `src/__tests__/components/StatusPill.test.tsx`:
+
+```tsx
+  it("renders a minimize button and calls onMinimize when clicked", () => {
+    const onMinimize = vi.fn();
+    render(<StatusPill status="idle" onMinimize={onMinimize} />);
+    const btn = screen.getByTestId("pill-action-minimize");
+    fireEvent.click(btn);
+    expect(onMinimize).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render a minimize button when onMinimize is omitted", () => {
+    render(<StatusPill status="idle" />);
+    expect(screen.queryByTestId("pill-action-minimize")).toBeNull();
+  });
+```
+
+Ensure the test file imports `fireEvent` and `vi`:
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest run src/__tests__/components/StatusPill.test.tsx`
+Expected: FAIL — no element with testid `pill-action-minimize`.
+
+- [ ] **Step 3: Add the prop**
+
+In `src/components/StatusPill.tsx`, extend the props interface (after `onOpenChange?`):
+
+```tsx
+  /**
+   * When provided, renders a minimize button that collapses the pet into
+   * mini-bar mode. Omitted in contexts where minimizing isn't allowed.
+   */
+  onMinimize?: () => void;
+```
+
+And update the destructure:
+
+```tsx
+export function StatusPill({ status, glow, disabled = false, onOpenChange, onMinimize }: StatusPillProps) {
+```
+
+- [ ] **Step 4: Render the button**
+
+In `src/components/StatusPill.tsx`, inside `<div className="pill-actions" data-testid="pill-actions">`, add this as the **first** child (before the session button):
+
+```tsx
+          {onMinimize && (
+            <button
+              type="button"
+              data-testid="pill-action-minimize"
+              className="pill-action-btn"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                playClickTap();
+                onMinimize();
+              }}
+              aria-label="Minimize to bar"
+              title="Minimize to bar"
+            >
+              <svg
+                className="pill-action-icon"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M6 19h12v2H6z" />
+              </svg>
+            </button>
+          )}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bunx vitest run src/__tests__/components/StatusPill.test.tsx`
+Expected: PASS (existing tests + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/StatusPill.tsx src/__tests__/components/StatusPill.test.tsx
+git commit -m "feat(mini-bar): minimize button in StatusPill"
+```
+
+### Task 7: Branch App render on mode + gate pet-mode effects
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Add imports**
+
+In `src/App.tsx`, add near the other component/hook imports:
+
+```tsx
+import { MiniBar } from "./components/MiniBar";
+import { useMiniMode } from "./hooks/useMiniMode";
+```
+
+- [ ] **Step 2: Instantiate the hook + wire drag-snap**
+
+Replace this line:
+
+```tsx
+  const { dragging, onMouseDown } = useDrag();
+```
+
+with:
+
+```tsx
+  const mini = useMiniMode(scale);
+  const { dragging, onMouseDown } = useDrag(
+    mini.mode === "mini" ? mini.snapToNearest : undefined
+  );
+```
+
+Note: `useScale()` is destructured above `useDrag` already (`const { scale } = useScale();`), so `scale` is in scope.
+
+- [ ] **Step 3: Pause the default-size hook while in mini mode**
+
+Replace the `useWindowDefaultSize(...)` call with:
+
+```tsx
+  useWindowDefaultSize(
+    scale,
+    mini.mode === "mini" ||
+      effectActive ||
+      sessionOpen ||
+      sessionClosing ||
+      bubbleGrowActive ||
+      visitors.length > 0
+  );
+```
+
+- [ ] **Step 4: Gate the three pet-mode resize effects**
+
+Add `if (mini.mode === "mini") return;` as the **first statement** inside each of these three `useEffect` bodies, and add `mini.mode` to each effect's dependency array:
+
+1. The bubble-grow effect (the one whose deps are `[bubbleGrowActive, sessionOpen, scale]`) → deps become `[bubbleGrowActive, sessionOpen, scale, mini.mode]`.
+2. The visitor-grow effect (deps `[visitors.length, scale]`) → `[visitors.length, scale, mini.mode]`.
+3. The session-dropdown-grow effect (deps `[sessionOpen, scale]`) → `[sessionOpen, scale, mini.mode]`.
+
+Example for the bubble-grow effect (apply the same pattern to the other two):
+
+```tsx
+  useEffect(() => {
+    if (mini.mode === "mini") return;
+    if (sessionOpen) return;
+    const win = getCurrentWindow();
+    // ...existing body unchanged...
+  }, [bubbleGrowActive, sessionOpen, scale, mini.mode]);
+```
+
+- [ ] **Step 5: Branch the render**
+
+Replace the container's `className` and `style` props and its children. Change the opening container tag to:
+
+```tsx
+    <div
+      ref={containerRef}
+      data-testid="app-container"
+      className={`container ${mini.mode === "mini" ? "mini-mode" : ""} ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${visitors.length > 0 ? "has-visitors" : ""} ${devAppBounds ? "dev-bounds" : ""} ${devContainerBounds ? "dev-container-bounds" : ""}`}
+      style={{
+        minWidth:
+          mini.mode === "mini"
+            ? undefined
+            : visitors.length > 0
+              ? "500px"
+              : `${PET_BASE_WIDTH}px`,
+        minHeight: mini.mode === "mini" ? undefined : `${PET_BASE_HEIGHT}px`,
+      }}
+      onMouseDown={onMouseDown}
+    >
+```
+
+Then wrap the existing children (the `<div className="main-col">…</div>` and the `{visitors.length > 0 && (<div className="visitors-col">…</div>)}` block) in a mode branch. Immediately after the opening container tag above, the body becomes:
+
+```tsx
+      {mini.mode === "mini" ? (
+        <MiniBar
+          status={status}
+          orientation={mini.orientation}
+          onRestore={mini.exitMini}
+        />
+      ) : (
+        <>
+          <div className="main-col">
+            {/* ...existing main-col contents unchanged... */}
+          </div>
+          {visitors.length > 0 && (
+            <div className="visitors-col" data-testid="visitors-col">
+              {/* ...existing visitors mapping unchanged... */}
+            </div>
+          )}
+        </>
+      )}
+```
+
+- [ ] **Step 6: Pass onMinimize to StatusPill**
+
+In the `main-col` branch, add `onMinimize={mini.enterMini}` to the `<StatusPill ... />` element (alongside the existing `status`, `glow`, `disabled`, `onOpenChange` props).
+
+- [ ] **Step 7: Type-check + run the suite**
+
+Run: `npx tsc --noEmit && bunx vitest run`
+Expected: tsc clean; all unit tests PASS.
+
+- [ ] **Step 8: Manual smoke test**
+
+Run: `bun run tauri dev`
+Verify: clicking the minimize button collapses the pet into a bar that snaps to the nearest edge; the bar glows with the status color; dragging it to another edge re-snaps and flips orientation (vertical on left/right, horizontal on top/bottom); the restore button brings back the full pet at its prior position.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat(mini-bar): wire mini mode into App (render branch + effect gating)"
+```
+
+---
+
+## Task Group 6: Peer tool in the mini bar (edge-aware popover)
+
+### Task 8: Inward popover position math
+
+**Files:**
+- Create: `src/utils/popoverPos.ts`
+- Test: `src/__tests__/utils/popoverPos.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/__tests__/utils/popoverPos.test.ts
+import { describe, it, expect } from "vitest";
+import { inwardPopoverPos } from "../../utils/popoverPos";
+
+const BAR = { x: 100, y: 200, width: 40, height: 168 }; // a vertical bar
+const PW = 280;
+const PH = 260;
+const GAP = 8;
+
+describe("inwardPopoverPos", () => {
+  it("opens to the RIGHT of a left-edge bar", () => {
+    const p = inwardPopoverPos(BAR, "left", PW, PH, GAP);
+    expect(p.x).toBe(100 + 40 + GAP); // bar.x + bar.width + gap
+    expect(p.y).toBe(200);
+  });
+
+  it("opens to the LEFT of a right-edge bar", () => {
+    const p = inwardPopoverPos(BAR, "right", PW, PH, GAP);
+    expect(p.x).toBe(100 - PW - GAP);
+    expect(p.y).toBe(200);
+  });
+
+  it("opens BELOW a top-edge bar", () => {
+    const hbar = { x: 300, y: 30, width: 168, height: 40 };
+    const p = inwardPopoverPos(hbar, "top", PW, PH, GAP);
+    expect(p.y).toBe(30 + 40 + GAP);
+    expect(p.x).toBe(300);
+  });
+
+  it("opens ABOVE a bottom-edge bar", () => {
+    const hbar = { x: 300, y: 752, width: 168, height: 40 };
+    const p = inwardPopoverPos(hbar, "bottom", PW, PH, GAP);
+    expect(p.y).toBe(752 - PH - GAP);
+    expect(p.x).toBe(300);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest run src/__tests__/utils/popoverPos.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/utils/popoverPos.ts
+import type { Edge, Rect } from "./snap";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Top-left position (logical screen px) for a popover that opens *inward*
+ * from a snapped mini bar, away from the screen edge it hugs.
+ */
+export function inwardPopoverPos(
+  bar: Rect,
+  edge: Edge,
+  popoverWidth: number,
+  popoverHeight: number,
+  gap: number
+): Point {
+  switch (edge) {
+    case "left":
+      return { x: Math.round(bar.x + bar.width + gap), y: Math.round(bar.y) };
+    case "right":
+      return { x: Math.round(bar.x - popoverWidth - gap), y: Math.round(bar.y) };
+    case "top":
+      return { x: Math.round(bar.x), y: Math.round(bar.y + bar.height + gap) };
+    case "bottom":
+    default:
+      return { x: Math.round(bar.x), y: Math.round(bar.y - popoverHeight - gap) };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bunx vitest run src/__tests__/utils/popoverPos.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/popoverPos.ts src/__tests__/utils/popoverPos.test.ts
+git commit -m "feat(mini-bar): inward popover position math"
+```
+
+### Task 9: Peer button in MiniBar (reuses the peer-list window)
+
+**Files:**
+- Modify: `src/components/MiniBar.tsx`
+- Modify: `src/hooks/useMiniMode.ts` (expose `edge`)
+- Test: `src/__tests__/components/MiniBar.test.tsx`
+
+- [ ] **Step 1: Expose the snapped `edge` from useMiniMode**
+
+In `src/hooks/useMiniMode.ts`, add an `edge` state mirroring `orientation`:
+
+- Add import: `type Edge` to the existing `from "../utils/snap"` import.
+- Add state: `const [edge, setEdge] = useState<Edge>("bottom");`
+- In `snapToNearest`, after `setOrientation(snap.orientation);` add `setEdge(snap.edge);`
+- In the returned object add `edge`: `return { mode, orientation, edge, enterMini, exitMini, snapToNearest };`
+
+- [ ] **Step 2: Write the failing test (append to MiniBar.test.tsx)**
+
+```tsx
+  it("renders a peer button that opens the peer-list popover", async () => {
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onRestore={() => {}} />);
+    const btn = screen.getByTestId("mini-bar-action-lan");
+    expect(btn).toBeInTheDocument();
+  });
+```
+
+Also add `edge="bottom"` to the three existing MiniBar renders in this file (the prop is now required).
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `bunx vitest run src/__tests__/components/MiniBar.test.tsx`
+Expected: FAIL — no `mini-bar-action-lan`; TS error on missing `edge` prop.
+
+- [ ] **Step 4: Update MiniBar**
+
+Replace `src/components/MiniBar.tsx` with:
+
+```tsx
+import { useRef } from "react";
+import {
+  getCurrentWindow,
+  LogicalPosition,
+} from "@tauri-apps/api/window";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import type { Status } from "../types/status";
+import type { Orientation, Edge } from "../utils/snap";
+import { inwardPopoverPos } from "../utils/popoverPos";
+import "../styles/mini-bar.css";
+
+/** Peer-list popover window size — must match tauri.conf.json. */
+const PEER_W = 280;
+const PEER_H = 260;
+const POPOVER_GAP = 8;
+
+interface MiniBarProps {
+  status: Status;
+  orientation: Orientation;
+  edge: Edge;
+  onRestore: () => void;
+}
+
+export function MiniBar({ status, orientation, edge, onRestore }: MiniBarProps) {
+  const lanButtonRef = useRef<HTMLButtonElement>(null);
+
+  const togglePeer = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const popover = await WebviewWindow.getByLabel("peer-list");
+    if (!popover) return;
+    if (await popover.isVisible()) {
+      await popover.hide();
+      return;
+    }
+    const main = getCurrentWindow();
+    const sf = await main.scaleFactor();
+    const pos = (await main.outerPosition()).toLogical(sf);
+    const size = (await main.outerSize()).toLogical(sf);
+    const p = inwardPopoverPos(
+      { x: pos.x, y: pos.y, width: size.width, height: size.height },
+      edge,
+      PEER_W,
+      PEER_H,
+      POPOVER_GAP
+    );
+    await popover.setPosition(new LogicalPosition(p.x, p.y));
+    await popover.show();
+    await popover.setFocus();
+  };
+
+  return (
+    <div
+      data-testid="mini-bar"
+      data-orientation={orientation}
+      className={`mini-bar ${orientation} ${status}`}
+    >
+      <span data-testid="mini-bar-dot" className={`dot ${status}`} />
+
+      <button
+        ref={lanButtonRef}
+        type="button"
+        data-testid="mini-bar-action-lan"
+        className="mini-bar-btn"
+        aria-label="Mime Around You"
+        title="Peers nearby"
+        onClick={togglePeer}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        data-testid="mini-bar-restore"
+        className="mini-bar-btn"
+        aria-label="Restore pet"
+        title="Restore"
+        onClick={onRestore}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M4 4h7v2H6v5H4V4zm9 0h7v7h-2V6h-5V4zM4 13h2v5h5v2H4v-7zm14 0h2v7h-7v-2h5v-5z" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Pass `edge` from App**
+
+In `src/App.tsx`, update the `<MiniBar />` element to pass `edge={mini.edge}`.
+
+- [ ] **Step 6: Add the webviewWindow mock alias (if not present)**
+
+Check `vitest.config.ts` for a `@tauri-apps/api/webviewWindow` alias. If missing, add to the `alias` map:
+
+```ts
+      "@tauri-apps/api/webviewWindow": resolve(
+        __dirname,
+        "./src/__mocks__/tauri-webview-window.ts"
+      ),
+```
+
+And create `src/__mocks__/tauri-webview-window.ts`:
+
+```ts
+export const WebviewWindow = {
+  getByLabel: vi.fn(async (_label: string) => null),
+};
+```
+
+(If `StatusPill.test.tsx` already passes today, the alias and a mock already exist — reuse it and skip this step.)
+
+- [ ] **Step 7: Run the test + type-check**
+
+Run: `npx tsc --noEmit && bunx vitest run src/__tests__/components/MiniBar.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/MiniBar.tsx src/hooks/useMiniMode.ts src/App.tsx vitest.config.ts src/__mocks__/tauri-webview-window.ts src/__tests__/components/MiniBar.test.tsx
+git commit -m "feat(mini-bar): peer tool with edge-aware popover"
+```
+
+---
+
+## Task Group 7: Session tool in the mini bar (extract dropdown + panel grow)
+
+### Task 10: Extract session grouping into a util
+
+**Files:**
+- Create: `src/utils/sessionGroups.ts`
+- Modify: `src/components/StatusPill.tsx`
+
+- [ ] **Step 1: Create the util by moving pure helpers out of StatusPill**
+
+Move these symbols **verbatim** from `src/components/StatusPill.tsx` into a new `src/utils/sessionGroups.ts` and `export` each: `statePriority`, `groupState`, `prettyPath`, `groupBasename`, `shellLabel`, the `Group` interface, `groupSessions`, `detectHome`, `reflectActiveServices`, `overlayClaudeState`. Add at the top:
+
+```ts
+import type { SessionInfo } from "../hooks/useSessions";
+```
+
+`src/utils/sessionGroups.ts` exports (signatures must match the originals exactly):
+
+```ts
+export const statePriority: Record<string, number>;
+export function groupState(sessions: SessionInfo[]): string;
+export function prettyPath(pwd: string, home?: string): string;
+export function groupBasename(g: { pwd: string; pretty: string; sessions: SessionInfo[] }): string;
+export function shellLabel(s: SessionInfo): string;
+export interface Group { key: string; pwd: string; pretty: string; sessions: SessionInfo[]; state: string; isClaudeFallback: boolean; }
+export function groupSessions(sessions: SessionInfo[], home?: string): Group[];
+export function detectHome(sessions: SessionInfo[]): string | undefined;
+export function reflectActiveServices(sessions: SessionInfo[]): SessionInfo[];
+export function overlayClaudeState(sessions: SessionInfo[]): SessionInfo[];
+```
+
+- [ ] **Step 2: Update StatusPill to import them**
+
+In `src/components/StatusPill.tsx`, delete the now-moved local definitions and add:
+
+```tsx
+import {
+  groupSessions,
+  detectHome,
+  reflectActiveServices,
+  overlayClaudeState,
+  groupBasename,
+  shellLabel,
+  type Group,
+} from "../utils/sessionGroups";
+```
+
+(Keep `SessionInfo` imported from `../hooks/useSessions` as today.)
+
+- [ ] **Step 3: Type-check + run the suite**
+
+Run: `npx tsc --noEmit && bunx vitest run`
+Expected: tsc clean; all tests PASS (pure move, no behavior change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/sessionGroups.ts src/components/StatusPill.tsx
+git commit -m "refactor(mini-bar): extract session grouping into sessionGroups util"
+```
+
+### Task 11: Extract the dropdown body into a shared SessionDropdown
+
+**Files:**
+- Create: `src/components/SessionDropdown.tsx`
+- Modify: `src/components/StatusPill.tsx`
+
+- [ ] **Step 1: Create SessionDropdown**
+
+Create `src/components/SessionDropdown.tsx` holding the presentational dropdown. It receives the already-computed `groups` plus interaction callbacks (no data fetching inside):
+
+```tsx
+import { invoke } from "@tauri-apps/api/core";
+import { groupBasename, shellLabel, type Group } from "../utils/sessionGroups";
+
+interface SessionDropdownProps {
+  groups: Group[];
+  collapsed: Set<string>;
+  toggleCollapsed: (key: string) => void;
+  onPickSession: () => void;
+  style?: React.CSSProperties;
+  showPathTooltip: (el: HTMLElement, text: string) => void;
+  hidePathTooltip: () => void;
+}
+
+export function SessionDropdown({
+  groups,
+  collapsed,
+  toggleCollapsed,
+  onPickSession,
+  style,
+  showPathTooltip,
+  hidePathTooltip,
+}: SessionDropdownProps) {
+  return (
+    <div
+      data-testid="session-dropdown"
+      className="session-dropdown"
+      role="menu"
+      style={style}
+    >
+      {groups.length === 0 ? (
+        <div className="session-empty">No active terminals</div>
+      ) : (
+        groups.map((g) => {
+          const isCollapsed = collapsed.has(g.key);
+          const headContent = (
+            <>
+              {!g.isClaudeFallback && (
+                <span className="session-group-caret" aria-hidden="true" />
+              )}
+              <span className={`dot small ${g.state}`} />
+              <span className="session-group-title-row">
+                <span className="session-group-title">{groupBasename(g)}</span>
+                {g.pretty && g.pretty !== groupBasename(g) && (
+                  <span
+                    className="session-group-info"
+                    aria-label={`Full path: ${g.pretty}`}
+                    onMouseEnter={(e) => showPathTooltip(e.currentTarget, g.pretty)}
+                    onMouseLeave={hidePathTooltip}
+                  >
+                    ?
+                  </span>
+                )}
+              </span>
+            </>
+          );
+          return (
+            <div
+              key={g.key}
+              className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
+              data-testid={`session-group-${g.key}`}
+            >
+              {g.isClaudeFallback ? (
+                <div className="session-group-head">{headContent}</div>
+              ) : (
+                <button
+                  type="button"
+                  className={`session-group-head clickable ${isCollapsed ? "collapsed" : ""}`}
+                  data-testid={`session-group-head-${g.key}`}
+                  aria-expanded={!isCollapsed}
+                  aria-controls={`session-children-${g.key}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleCollapsed(g.key);
+                  }}
+                >
+                  {headContent}
+                </button>
+              )}
+
+              {!g.isClaudeFallback && !isCollapsed && (
+                <div className="session-children" id={`session-children-${g.key}`}>
+                  {g.sessions.map((s) => (
+                    <button
+                      key={s.pid}
+                      type="button"
+                      className={`session-child ${s.has_claude ? "has-claude" : ""}`}
+                      data-testid={`session-item-${s.pid}`}
+                      title="Click to bring this terminal to the front"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        invoke("focus_terminal", { pid: s.pid, tty: s.tty || null }).catch(
+                          (err) => console.error("[focus_terminal]", err)
+                        );
+                        onPickSession();
+                      }}
+                    >
+                      <span className={`dot small ${s.ui_state}`} />
+                      <span className="session-child-label-row">
+                        <span className="session-child-label">{shellLabel(s)}</span>
+                        {s.has_claude && (
+                          <span
+                            className="session-child-claude"
+                            aria-label="Claude Code running"
+                          />
+                        )}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Use it in StatusPill**
+
+In `src/components/StatusPill.tsx`, replace the inline `{sessionListEnabled && sessionOpen && (<div className="session-dropdown" ...>…</div>)}` block with:
+
+```tsx
+      {sessionListEnabled && sessionOpen && (
+        <SessionDropdown
+          groups={groups}
+          collapsed={collapsed}
+          toggleCollapsed={(key) => void toggleCollapsed(key)}
+          onPickSession={() => setSessionOpen(false)}
+          style={{ top: `${dropdownTop}px`, maxHeight: `${dropdownMaxHeight}px` }}
+          showPathTooltip={showPathTooltip}
+          hidePathTooltip={hidePathTooltip}
+        />
+      )}
+```
+
+Add the import: `import { SessionDropdown } from "./SessionDropdown";`
+
+- [ ] **Step 3: Type-check + run the suite**
+
+Run: `npx tsc --noEmit && bunx vitest run`
+Expected: tsc clean; all tests PASS (StatusPill dropdown behavior unchanged — same testids).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SessionDropdown.tsx src/components/StatusPill.tsx
+git commit -m "refactor(mini-bar): extract shared SessionDropdown component"
+```
+
+### Task 12: Session button + inward panel in MiniBar
+
+**Files:**
+- Modify: `src/components/MiniBar.tsx`
+- Test: `src/__tests__/components/MiniBar.test.tsx`
+
+- [ ] **Step 1: Write the failing test (append to MiniBar.test.tsx)**
+
+```tsx
+  it("renders a session button and opens the dropdown when clicked", async () => {
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onRestore={() => {}} />);
+    const btn = screen.getByTestId("mini-bar-action-task");
+    fireEvent.click(btn);
+    // dropdown appears after the async fetch resolves (mocked -> empty list)
+    await screen.findByTestId("session-dropdown");
+  });
+```
+
+Ensure the test imports `fireEvent` and that `fetchSessions` resolves (the `@tauri-apps/api/core` mock returns a default). If `invoke("get_sessions")` is not mocked to return an array, add to `src/__mocks__/tauri.ts` a default for `get_sessions` returning `[]`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bunx vitest run src/__tests__/components/MiniBar.test.tsx`
+Expected: FAIL — no `mini-bar-action-task`.
+
+- [ ] **Step 3: Add session state + button + inward panel to MiniBar**
+
+Update `src/components/MiniBar.tsx`:
+
+Add imports:
+
+```tsx
+import { useState, useEffect } from "react";
+import { LogicalSize } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
+import { fetchSessions } from "../hooks/useSessions";
+import {
+  groupSessions,
+  detectHome,
+  reflectActiveServices,
+  overlayClaudeState,
+  type Group,
+} from "../utils/sessionGroups";
+import { useSessionList } from "../hooks/useSessionList";
+import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
+import { SessionDropdown } from "./SessionDropdown";
+```
+
+Add panel constants near the top:
+
+```tsx
+/** Mini-mode session panel size (logical px) when the list is open. */
+const PANEL_W = 320;
+const PANEL_LIST_H = 360;
+```
+
+Inside `MiniBar`, add state + the toggle + the window-grow effect:
+
+```tsx
+  const { enabled: sessionListEnabled } = useSessionList();
+  const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
+  const [sessionOpen, setSessionOpen] = useState(false);
+  const [groups, setGroups] = useState<Group[]>([]);
+
+  const toggleSession = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!sessionListEnabled) return;
+    if (sessionOpen) {
+      setSessionOpen(false);
+      return;
+    }
+    const list = await fetchSessions();
+    setGroups(groupSessions(overlayClaudeState(reflectActiveServices(list)), detectHome(list)));
+    setSessionOpen(true);
+  };
+
+  // Live refresh while open.
+  useEffect(() => {
+    if (!sessionOpen) return;
+    let cancelled = false;
+    const refresh = async () => {
+      const list = await fetchSessions();
+      if (cancelled) return;
+      setGroups(groupSessions(overlayClaudeState(reflectActiveServices(list)), detectHome(list)));
+    };
+    const unlistenP = listen("sessions-changed", () => void refresh());
+    return () => {
+      cancelled = true;
+      unlistenP.then((fn) => fn());
+    };
+  }, [sessionOpen]);
+
+  // Grow the bar window into a panel while the list is open.
+  // On close, re-snap (which resizes the window back to the bar).
+  useEffect(() => {
+    if (!sessionOpen) {
+      snapToNearest();
+      return;
+    }
+    const vertical = orientation === "vertical";
+    // Panel keeps the bar's thickness on its short axis and adds the list.
+    const w = vertical ? PANEL_W : Math.max(PANEL_W, 168);
+    const h = vertical ? PANEL_LIST_H : 40 + PANEL_LIST_H;
+    void getCurrentWindow().setSize(new LogicalSize(w, h)).catch(() => {});
+  }, [sessionOpen, orientation]); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+Add the session button (before the peer button) in the JSX:
+
+```tsx
+      {sessionListEnabled && (
+        <button
+          type="button"
+          data-testid="mini-bar-action-task"
+          className="mini-bar-btn"
+          aria-label="Show sessions list"
+          aria-expanded={sessionOpen}
+          title="Session list"
+          onClick={toggleSession}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM7 9h10v2H7V9zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" />
+          </svg>
+        </button>
+      )}
+```
+
+Render the dropdown panel below the bar contents (inside the root `.mini-bar` div, after the buttons):
+
+```tsx
+      {sessionOpen && (
+        <SessionDropdown
+          groups={groups}
+          collapsed={collapsed}
+          toggleCollapsed={(key) => void toggleCollapsed(key)}
+          onPickSession={() => setSessionOpen(false)}
+          style={{ position: "static", maxHeight: `${PANEL_LIST_H}px`, width: "100%" }}
+          showPathTooltip={() => {}}
+          hidePathTooltip={() => {}}
+        />
+      )}
+```
+
+The close branch above calls `snapToNearest()` to resize the window back to the bar (App's `useWindowDefaultSize` stays paused in mini mode, so the bar can't shrink itself otherwise). Add `snapToNearest: () => void;` to `MiniBarProps` and destructure it alongside the other props.
+
+- [ ] **Step 4: Pass `snapToNearest` from App**
+
+In `src/App.tsx`, add `snapToNearest={mini.snapToNearest}` to the `<MiniBar />` element.
+
+- [ ] **Step 5: Update existing MiniBar test renders**
+
+Add `snapToNearest={() => {}}` to every `<MiniBar .../>` render in `src/__tests__/components/MiniBar.test.tsx`.
+
+- [ ] **Step 6: Type-check + run the test**
+
+Run: `npx tsc --noEmit && bunx vitest run src/__tests__/components/MiniBar.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 7: Manual smoke test**
+
+Run: `bun run tauri dev`
+Verify in mini mode: clicking the session button grows the bar into a panel showing the session list; picking a session focuses that terminal and closes the panel; the bar re-snaps to its edge. Clicking the peer button opens the peer popover inward from the bar's edge.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/MiniBar.tsx src/App.tsx src/__tests__/components/MiniBar.test.tsx
+git commit -m "feat(mini-bar): session list panel in mini mode"
+```
+
+---
+
+## Task Group 8: End-to-end test
+
+### Task 13: Playwright e2e for minimize → bar → restore
+
+**Files:**
+- Create: `e2e/mini-bar.spec.ts`
+
+- [ ] **Step 1: Write the e2e**
+
+```ts
+// e2e/mini-bar.spec.ts
+import { test, expect } from "@playwright/test";
+
+test("minimize collapses the pet into a bar, restore brings it back", async ({ page }) => {
+  await page.goto("/");
+  // Enter mini mode.
+  await page.getByTestId("pill-action-minimize").click();
+  const bar = page.getByTestId("mini-bar");
+  await expect(bar).toBeVisible();
+  // Pet column is gone.
+  await expect(page.getByTestId("status-pill")).toHaveCount(0);
+  // Restore.
+  await page.getByTestId("mini-bar-restore").click();
+  await expect(page.getByTestId("status-pill")).toBeVisible();
+  await expect(page.getByTestId("mini-bar")).toHaveCount(0);
+});
+```
+
+- [ ] **Step 2: Run the e2e**
+
+Run: `bunx playwright test -c e2e/playwright.config.ts --project=chromium mini-bar`
+Expected: PASS. (If the mini bar relies on `currentMonitor`, confirm `e2e/tauri-mock.ts` provides a window `currentMonitor` stub; if missing, add one returning `{ scaleFactor: 1, position: {x:0,y:0}, size: {width:1440,height:900} }` and the `outerSize`/`scaleFactor` window methods.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/mini-bar.spec.ts e2e/tauri-mock.ts
+git commit -m "test(mini-bar): e2e for minimize/restore"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Full type-check:** `npx tsc --noEmit` → clean.
+- [ ] **Full unit suite:** `bunx vitest run` → all green.
+- [ ] **E2e:** `bunx playwright test -c e2e/playwright.config.ts --project=chromium` → green.
+- [ ] **Manual:** `bun run tauri dev` → minimize, drag to each of the 4 edges (verify vertical on left/right, horizontal on top/bottom), confirm glow tracks status, session + peer tools work in the bar, restore returns the pet to its prior spot.
+- [ ] **Backend untouched:** no Rust changes were required (confirm `git diff --stat src-tauri` is empty).
+
+---
+
+## Notes & Risks (for the implementer)
+
+- **`startDragging()` resolve timing (Task 5/7):** snapping fires when `startDragging()` resolves. The existing `useDrag` already relies on this resolve-on-release behavior. If snapping doesn't fire on some platform, add an `onMoved`-debounced re-snap in `useMiniMode` as a fallback (pattern exists in `StatusPill.tsx`'s `main.onMoved`).
+- **`currentMonitor()` work area (Task 1/4):** Tauri doesn't expose dock/menubar insets, so we approximate with `DEFAULT_MARGINS` (top gets the larger `menuBar` margin). Acceptable for v1; refine later if the bar overlaps the menu bar/dock.
+- **Session panel geometry (Task 12):** `PANEL_W`/`PANEL_LIST_H` are starting values; adjust during the manual smoke test so the panel reads well at each edge. This is the area most likely to need a visual tweak.
+- **No persistence:** per the spec, the app always launches in pet mode; nothing is written to `settings.json`.

--- a/docs/superpowers/specs/2026-06-15-mini-bar-mode-design.md
+++ b/docs/superpowers/specs/2026-06-15-mini-bar-mode-design.md
@@ -1,0 +1,202 @@
+# Mini Bar Mode — Design
+
+**Date:** 2026-06-15
+**Status:** Approved, ready for implementation plan
+
+## Summary
+
+Add a minimize button to the status pill below the pet. Clicking it collapses
+the floating pet into a thin **mini bar** that snaps to one of the four screen
+edges, stays always-on-top, and can be dragged from edge to edge. The bar shows
+the status (color only, no text) plus the session and peer tools, carries a glow
+matching the current status, and has a restore button to return to the full pet.
+
+## Goals
+
+- A minimize button in the status pill (below the pet) that switches into mini mode.
+- Mini mode is a thin bar that:
+  - Floats always-on-top.
+  - Snaps flush to the **nearest of the 4 screen edges** (left, top, right, bottom).
+  - Within the snapped edge, snaps to the **nearest corner**.
+  - Is **vertical** on the left/right edges and **horizontal** on the top/bottom edges.
+  - Is draggable; on drag-release it re-snaps to the nearest edge/corner.
+- The bar shows, in order: **status dot (color only, no text) → session button →
+  peer button → restore button**. No text labels, no numeric count badges.
+- The bar carries an outer glow whose color tracks the current status.
+- A restore button returns to the full floating pet at its previous position.
+
+## Non-Goals
+
+- No persistence: the app always launches as the full pet. Mini mode and the
+  chosen corner reset every launch.
+- No second Tauri window for the bar (we reshape the existing main window).
+- No new status types or backend changes — mini mode is purely a frontend
+  presentation of the existing `Status`.
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|----------|----------|
+| Restore interaction | Restore button on the bar |
+| Position along edge | Snap to nearest corner |
+| Persistence | Remember nothing (always launch as full pet) |
+| Bar contents | Dot + session + peer + restore, **no count badges** |
+| Architecture | Reuse the main window with a `mode` toggle (not a separate window) |
+
+## Architecture
+
+Reuse the single main window. Lift a `mode: 'pet' | 'mini'` state into `App.tsx`
+via a new `useMiniMode` hook. `App` renders either the existing pet column or a
+new `<MiniBar>` component based on `mode`.
+
+This follows the existing pattern: the main window is already resized and
+repositioned at runtime throughout `App.tsx` (bubble-grow, visitor-grow,
+session-dropdown-grow). Reshaping it into a bar is the same mechanism
+(`win.setSize` + `win.setPosition`).
+
+### New / changed units
+
+| Unit | Responsibility |
+|------|----------------|
+| `src/hooks/useMiniMode.ts` | Owns `mode` state + `enterMini()` / `exitMini()`. Saves the pet's pre-minimize position and restores it on exit. |
+| `src/components/MiniBar.tsx` | Renders the bar: status dot, session button, peer button, restore button. Receives `status`, `orientation`, and the tool handlers. |
+| `src/utils/snap.ts` | Pure `computeSnap(winPos, winSize, monitor, margins)` → `{ x, y, orientation, edge, corner }`. Unit-testable, no Tauri calls. |
+| `src/hooks/useMiniSnap.ts` | Wires native drag-release → read `outerPosition()` + `currentMonitor()` → `computeSnap` → `setPosition`. Also resizes the window to bar dimensions on enter and stores orientation. |
+| `src/components/StatusPill.tsx` | Add the minimize button to `pill-actions`. |
+| `src/App.tsx` | Branch render on `mode`; gate the pet-mode window effects while in mini mode. |
+| `src/styles/mini-bar.css` | Bar layout (horizontal/vertical), status-color glow. |
+
+## Behavior
+
+### Entering mini mode
+
+1. User clicks the minimize button in the status pill.
+2. `useMiniMode.enterMini()`:
+   - Records the current pet window position (logical) for later restore.
+   - Sets `mode = 'mini'`.
+3. On `mode === 'mini'`, the mini-mode effect:
+   - Resizes the window to the bar size for the **initial orientation**
+     (default horizontal at the bottom edge, or wherever the snap puts it).
+   - Computes the snap target from the current position and snaps there.
+
+### Exiting mini mode
+
+1. User clicks the restore button on the bar.
+2. `useMiniMode.exitMini()`:
+   - Sets `mode = 'pet'`.
+   - Restores the saved pet window size (default pet size) and the saved
+     pre-minimize position.
+
+### Snapping & orientation
+
+- Native drag is kept: `getCurrentWindow().startDragging()`. The `await`
+  resolves on drag-end (the existing `useDrag` relies on this), so on resolve we:
+  1. Read `outerPosition()` and `currentMonitor()` (position, size, scaleFactor).
+  2. Call `computeSnap()`:
+     - Find the **nearest of the 4 edges** by distance from the window center to
+       each monitor edge.
+     - Snap the bar flush to that edge with an ~8px margin (plus extra top
+       margin to clear the macOS menu bar on the top edge).
+     - Within the edge, snap to the **nearest corner** (the nearer of the edge's
+       two ends).
+     - Derive `orientation`: left/right → `'vertical'`, top/bottom → `'horizontal'`.
+  3. If orientation changed, resize the window to the new bar dimensions
+     (swap width/height) before/while setting position so the bar isn't clipped.
+  4. `setPosition()` to the snapped coordinates.
+
+`computeSnap` is a pure function (no Tauri) taking plain numbers so it can be
+unit-tested directly.
+
+### Bar layout & glow
+
+- **Horizontal bar:** ~`140 × 36` logical (scaled by `useScale`).
+- **Vertical bar:** ~`36 × 140` logical (scaled).
+- Contents in order: status dot → session button → peer button → restore button.
+  No text, no numeric count badges. The dot is color-only.
+- **Glow:** the bar element carries an outer `box-shadow` glow whose color is
+  driven by the current status, reusing the dot-color CSS custom properties
+  already defined in `status-pill.css` (busy/service/idle/disconnected/etc.).
+  The glow updates live as `useStatus()` changes.
+
+### Tools in bar shape
+
+- **Peer popover** is already its own always-on-top window (`peer-list`), so it
+  works in mini mode unchanged except for positioning. `computePopoverScreenPos`
+  (in `StatusPill.tsx`) becomes **edge-aware**: it opens the popover *inward*
+  from the bar — to the right of a left-edge bar, to the left of a right-edge
+  bar, above a bottom-edge bar, below a top-edge bar.
+- **Session list** is currently an *in-window* dropdown that grows the main
+  window to 400px tall. In mini mode the session button **grows the bar window
+  into a small panel that expands inward from the snapped corner**, reusing the
+  existing dropdown markup, then shrinks back to the bar when closed. This keeps
+  a single window and reuses the existing dropdown component rather than building
+  a second window.
+
+### Effect gating
+
+While `mode === 'mini'`, the pet-mode window effects in `App.tsx` are
+short-circuited so only mini-mode logic controls the window size/position:
+
+- `useWindowDefaultSize(...)` — paused.
+- Bubble-grow effect — skipped.
+- Visitor-grow effect — skipped.
+- Session-dropdown-grow effect — replaced by the mini-mode panel-grow path.
+
+(The bubble/visitor/effect *visuals* themselves are part of the pet column and
+won't render in mini mode since the pet column is replaced by `<MiniBar>`.)
+
+## Data Flow
+
+```
+Minimize click → useMiniMode.enterMini() → mode='mini'
+  → App renders <MiniBar> instead of pet column
+  → mini-mode effect: setSize(bar) + computeSnap + setPosition
+  → glow/dot driven by useStatus() (status-changed event, unchanged)
+
+Drag bar → startDragging() resolves on release
+  → useMiniSnap: outerPosition + currentMonitor → computeSnap
+  → (resize if orientation changed) + setPosition
+
+Restore click → useMiniMode.exitMini() → mode='pet'
+  → App renders pet column → restore saved size + position
+```
+
+## Error Handling
+
+- All `setSize` / `setPosition` / `currentMonitor` calls are wrapped in
+  try/catch (consistent with existing `App.tsx` resize effects); failures log to
+  `console.error` with a `[mini-bar]` tag and leave the window where it is.
+- If `currentMonitor()` returns null, fall back to snapping against the window's
+  current screen assuming origin `(0,0)` and a conservative default size, or skip
+  snapping for that release (log a warning) — the bar stays where dropped.
+
+## Testing
+
+Per project conventions, every interactive/observable element gets a `data-testid`:
+
+- `pill-action-minimize` — the minimize button in the status pill.
+- `mini-bar` — the bar container (also exposes `data-orientation`).
+- `mini-bar-dot` — the status dot.
+- `mini-bar-action-task`, `mini-bar-action-lan` — the tool buttons.
+- `mini-bar-restore` — the restore button.
+
+Tests:
+
+- **Unit (Vitest):** `computeSnap()` — table of (position, size, monitor) →
+  expected `{ edge, corner, orientation, x, y }` covering all four edges and both
+  corners per edge, plus the menu-bar top margin.
+- **Unit (RTL):** `<MiniBar>` renders the four elements in order; the dot class
+  tracks `status`; clicking minimize/restore/tools fires the right handlers.
+- **E2e (Playwright):** click minimize → assert `mini-bar` present and the pet
+  column gone; assert window resized via `__MOCK_WINDOW_SIZES__`; click restore →
+  assert pet column returns. Use `getByTestId` / `getByRole` per selector
+  priority.
+
+## Open Risks
+
+- `startDragging()` resolving on drag-end is relied upon for snap timing. If it
+  resolves early on some platform, add an `onMoved`-debounced re-snap as a
+  fallback (the existing `StatusPill` already uses `onMoved`).
+- `currentMonitor()` does not expose the work area (dock/menubar insets) in all
+  Tauri versions; we approximate with fixed margins. Acceptable for v1; can be
+  refined later.

--- a/e2e/mini-bar.spec.ts
+++ b/e2e/mini-bar.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { tauriMockScript } from "./tauri-mock";
+
+async function loadWithMock(page: import("@playwright/test").Page) {
+  await page.addInitScript(tauriMockScript);
+  await page.goto("/");
+}
+
+test("minimize collapses the pet into a bar, restore brings it back", async ({ page }) => {
+  await loadWithMock(page);
+  // Enter mini mode.
+  await page.getByTestId("pill-action-minimize").click();
+  const bar = page.getByTestId("mini-bar");
+  await expect(bar).toBeVisible();
+  // Pet column is gone.
+  await expect(page.getByTestId("status-pill")).toHaveCount(0);
+  // Restore.
+  await page.getByTestId("mini-bar-restore").click();
+  await expect(page.getByTestId("status-pill")).toBeVisible();
+  await expect(page.getByTestId("mini-bar")).toHaveCount(0);
+});

--- a/e2e/tauri-mock.ts
+++ b/e2e/tauri-mock.ts
@@ -102,7 +102,13 @@ export const tauriMockScript = `
       const path = ridToPath.get(args.rid) || 'store.json';
       const store = getOrCreateStore(path);
       const val = store.get(args.key);
-      return val !== undefined ? [val] : null;
+      // plugin-store v2 expects [value, exists] tuple
+      return val !== undefined ? [val, true] : [undefined, false];
+    }
+    if (cmd === 'plugin:store|has') {
+      const path = ridToPath.get(args.rid) || 'store.json';
+      const store = getOrCreateStore(path);
+      return store.has(args.key);
     }
     if (cmd === 'plugin:store|set') {
       const path = ridToPath.get(args.rid) || 'store.json';
@@ -178,8 +184,22 @@ export const tauriMockScript = `
     // Log plugin  ---------------------------------------------------------
     if (cmd === 'plugin:log|log') return null;
 
+    // Window plugin — additional stubs needed by App.tsx
+    if (cmd === 'plugin:window|scale_factor') return 1;
+    if (cmd === 'plugin:window|set_position') return null;
+    if (cmd === 'plugin:window|current_monitor') return {
+      name: 'mock',
+      scaleFactor: 1,
+      position: { x: 0, y: 0 },
+      size: { width: 1440, height: 900 },
+    };
+    if (cmd === 'plugin:window|get_all_windows') return [{ label: 'main' }];
+    if (cmd === 'plugin:window|is_visible') return false;
+
     // Custom app commands
     if (cmd === 'start_visit') return null;
+    if (cmd === 'get_sessions') return window.__MOCK_SESSIONS__ ?? [];
+    if (cmd === 'get_peers')    return window.__MOCK_PEERS__   ?? [];
 
     // Plugin manager commands
     if (cmd === 'get_plugins') {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main", "settings", "superpower", "peer-list"],
+  "windows": ["main", "settings", "superpower", "peer-list", "session-list"],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -242,6 +242,13 @@ fn set_dock_visible(visible: bool, app: tauri::AppHandle) {
     platform::set_dock_visibility(&app, visible);
 }
 
+/// Toggle OS window-movability so macOS Sequoia doesn't tile the mini bar when
+/// it reaches a screen edge. Mini mode passes `false`; pet mode passes `true`.
+#[tauri::command]
+fn set_window_movable(movable: bool, app: tauri::AppHandle) {
+    platform::set_window_movable(&app, movable);
+}
+
 #[tauri::command]
 fn set_tray_visible(visible: bool, app: tauri::AppHandle) {
     crate::app_log!("[app] set_tray_visible -> {}", visible);
@@ -626,7 +633,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
-        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, get_sessions, get_peers, focus_terminal, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible, set_tray_visible, request_local_network, claude_config::get_claude_config, claude_config::set_plugin_enabled, claude_config::get_command_content, claude_config::delete_command, claude_config::delete_mcp_server, claude_config::delete_hook_entry, install_plugin_from_dialog, uninstall_plugin, set_ani_plugin_enabled, get_plugins, set_plugin_hotkey, launch_plugin, plugin::gateway::plugin_call])
+        .invoke_handler(tauri::generate_handler![start_visit, get_logs, clear_logs, open_log_dir, get_sessions, get_peers, focus_terminal, open_superpower, set_dev_mode, scenario_override, preview_dialog, set_dock_visible, set_window_movable, set_tray_visible, request_local_network, claude_config::get_claude_config, claude_config::set_plugin_enabled, claude_config::get_command_content, claude_config::delete_command, claude_config::delete_mcp_server, claude_config::delete_hook_entry, install_plugin_from_dialog, uninstall_plugin, set_ani_plugin_enabled, get_plugins, set_plugin_hotkey, launch_plugin, plugin::gateway::plugin_call])
         .setup(|app| {
             crate::app_log!("[app] starting Ani-Mime v{}", env!("CARGO_PKG_VERSION"));
 

--- a/src-tauri/src/platform/linux.rs
+++ b/src-tauri/src/platform/linux.rs
@@ -126,6 +126,9 @@ pub fn set_dock_visibility(_app: &tauri::AppHandle, visible: bool) {
     crate::app_log!("[platform] linux dock visibility requested ({}) — no-op", if visible { "visible" } else { "hidden" });
 }
 
+/// macOS-Sequoia drag-to-tile doesn't exist on Linux; no-op.
+pub fn set_window_movable(_app: &tauri::AppHandle, _movable: bool) {}
+
 pub fn open_path(path: &std::path::Path) {
     if let Err(e) = std::process::Command::new("xdg-open").arg(path).spawn() {
         crate::app_error!("[platform] xdg-open path failed: {}", e);

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -68,6 +68,35 @@ pub fn setup_main_window(app: &tauri::App) {
     }
 }
 
+/// Toggle whether the OS treats the main window as user-movable.
+///
+/// In mini-bar mode we move the window ourselves via `setPosition`, so we set
+/// the NSWindow non-movable: this stops macOS Sequoia from treating the window
+/// reaching a screen edge as a "drag to tile" gesture (the split-screen zones).
+/// Programmatic `setPosition` still works. In pet mode we restore movability so
+/// the native pet drag (`startDragging`) keeps working.
+pub fn set_window_movable(app: &tauri::AppHandle, movable: bool) {
+    use cocoa::base::{id, NO, YES};
+    use tauri::Manager;
+
+    let Some(window) = app.get_webview_window("main") else {
+        crate::app_warn!("[platform] set_window_movable: main window not found");
+        return;
+    };
+    match window.ns_window() {
+        Ok(ns_win) => {
+            let ns_win = ns_win as id;
+            let flag = if movable { YES } else { NO };
+            unsafe {
+                let _: () = msg_send![ns_win, setMovable: flag];
+                let _: () = msg_send![ns_win, setMovableByWindowBackground: NO];
+            }
+            crate::app_log!("[platform] window movable -> {}", movable);
+        }
+        Err(e) => crate::app_error!("[platform] set_window_movable: NSWindow err: {:?}", e),
+    }
+}
+
 /// Toggle dock icon visibility at runtime.
 /// `visible = false` → Accessory (no dock, no Cmd+Tab)
 /// `visible = true`  → Regular (normal dock app)

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -7,11 +7,11 @@ mod linux;
 #[cfg(target_os = "macos")]
 pub use macos::{
     open_local_network_settings, open_path, open_url, run_update_command,
-    set_dock_visibility, setup_main_window, show_choose_list, show_dialog,
+    set_dock_visibility, set_window_movable, setup_main_window, show_choose_list, show_dialog,
 };
 
 #[cfg(target_os = "linux")]
 pub use linux::{
     open_local_network_settings, open_path, open_url, run_update_command,
-    set_dock_visibility, setup_main_window, show_choose_list, show_dialog,
+    set_dock_visibility, set_window_movable, setup_main_window, show_choose_list, show_dialog,
 };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,6 +64,21 @@
         "skipTaskbar": true,
         "focus": true,
         "shadow": false
+      },
+      {
+        "label": "session-list",
+        "title": "Sessions",
+        "url": "session-list.html",
+        "width": 280,
+        "height": 360,
+        "resizable": false,
+        "visible": false,
+        "decorations": false,
+        "transparent": true,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "focus": true,
+        "shadow": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -69,16 +69,13 @@
         "label": "session-list",
         "title": "Sessions",
         "url": "session-list.html",
-        "width": 280,
-        "height": 360,
-        "resizable": false,
+        "width": 300,
+        "height": 420,
+        "resizable": true,
         "visible": false,
-        "decorations": false,
-        "transparent": true,
+        "decorations": true,
         "alwaysOnTop": true,
-        "skipTaskbar": true,
-        "focus": true,
-        "shadow": false
+        "focus": true
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ function App() {
   const { scale } = useScale();
   const mini = useMiniMode(scale);
   const { dragging, onMouseDown } = useDrag(
-    mini.mode === "mini" ? mini.snapToNearest : undefined,
+    mini.mode === "mini" ? mini.magnetToNearest : undefined,
     { requireHandle: mini.mode === "mini" }
   );
   const devMode = useDevMode();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,10 +73,9 @@ function App() {
   const visitors = useVisitors();
   const { scale } = useScale();
   const mini = useMiniMode(scale);
-  const { dragging, onMouseDown } = useDrag(
-    mini.mode === "mini" ? mini.magnetToNearest : undefined,
-    { requireHandle: mini.mode === "mini" }
-  );
+  // Pet mode: drag the pet anywhere. Mini mode: the container does NOT drag —
+  // the bar is edge-docked and moved only via the grip (mini.startEdgeDrag).
+  const { dragging, onMouseDown } = useDrag();
   const devMode = useDevMode();
   const devTagToggle = useDevTagVisible();
   const appBoundsToggle = useDevAppBounds();
@@ -434,7 +433,7 @@ function App() {
               : `${PET_BASE_WIDTH}px`,
         minHeight: mini.mode === "mini" ? undefined : `${PET_BASE_HEIGHT}px`,
       }}
-      onMouseDown={onMouseDown}
+      onMouseDown={mini.mode === "mini" ? undefined : onMouseDown}
     >
       {mini.mode === "mini" ? (
         <MiniBar
@@ -442,6 +441,7 @@ function App() {
           orientation={mini.orientation}
           edge={mini.edge}
           snapToNearest={mini.snapToNearest}
+          onGripMouseDown={mini.startEdgeDrag}
           onRestore={mini.exitMini}
         />
       ) : (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,8 @@ function App() {
   const { scale } = useScale();
   const mini = useMiniMode(scale);
   const { dragging, onMouseDown } = useDrag(
-    mini.mode === "mini" ? mini.snapToNearest : undefined
+    mini.mode === "mini" ? mini.snapToNearest : undefined,
+    { requireHandle: mini.mode === "mini" }
   );
   const devMode = useDevMode();
   const devTagToggle = useDevTagVisible();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -440,7 +440,6 @@ function App() {
           status={status}
           orientation={mini.orientation}
           edge={mini.edge}
-          snapToNearest={mini.snapToNearest}
           onGripMouseDown={mini.startEdgeDrag}
           onRestore={mini.exitMini}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -440,6 +440,7 @@ function App() {
           status={status}
           orientation={mini.orientation}
           edge={mini.edge}
+          snapToNearest={mini.snapToNearest}
           onRestore={mini.exitMini}
         />
       ) : (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { Mascot } from "./components/Mascot";
 import { StatusPill } from "./components/StatusPill";
+import { MiniBar } from "./components/MiniBar";
+import { useMiniMode } from "./hooks/useMiniMode";
 import { SpeechBubble } from "./components/SpeechBubble";
 import { VisitorDog } from "./components/VisitorDog";
 import { DevTag } from "./components/DevTag";
@@ -67,10 +69,13 @@ function transitionToCaseId(prev: Status, next: Status): string | null {
 function App() {
   const { prompt, error: installError, clear } = useInstallPrompt();
   const { status, scenario } = useStatus();
-  const { dragging, onMouseDown } = useDrag();
   const { visible, message, dismiss } = useBubble();
   const visitors = useVisitors();
   const { scale } = useScale();
+  const mini = useMiniMode(scale);
+  const { dragging, onMouseDown } = useDrag(
+    mini.mode === "mini" ? mini.snapToNearest : undefined
+  );
   const devMode = useDevMode();
   const devTagToggle = useDevTagVisible();
   const appBoundsToggle = useDevAppBounds();
@@ -183,7 +188,12 @@ function App() {
   // default and this hook re-fires to confirm.
   useWindowDefaultSize(
     scale,
-    effectActive || sessionOpen || sessionClosing || bubbleGrowActive || visitors.length > 0
+    mini.mode === "mini" ||
+      effectActive ||
+      sessionOpen ||
+      sessionClosing ||
+      bubbleGrowActive ||
+      visitors.length > 0
   );
 
   // Bubble orchestration: every source funnels through useBubble's
@@ -202,6 +212,7 @@ function App() {
     // grown window). Don't skip during sessionClosing — it's an
     // unreliable transient flag and using it here was making the bubble
     // grow effect exit early when it shouldn't.
+    if (mini.mode === "mini") return;
     if (sessionOpen) return;
     const win = getCurrentWindow();
     const def = getDefaultPetSize(scale);
@@ -259,7 +270,7 @@ function App() {
         console.error("[bubble-grow] close resize failed:", err);
       }
     })();
-  }, [bubbleGrowActive, sessionOpen, scale]);
+  }, [bubbleGrowActive, sessionOpen, scale, mini.mode]);
 
   // Visitor count change → drive the window size directly.
   //
@@ -281,6 +292,7 @@ function App() {
   // Grow to 500 wide for visitor mode, then restore to default on the
   // last visitor leaving.
   useEffect(() => {
+    if (mini.mode === "mini") return;
     const win = getCurrentWindow();
     const def = getDefaultPetSize(scale);
 
@@ -327,7 +339,7 @@ function App() {
         console.error("[visitors] restore failed:", err);
       }
     })();
-  }, [visitors.length, scale]);
+  }, [visitors.length, scale, mini.mode]);
 
   // When the dropdown opens the window grows wider (>= SESSION_DROPDOWN_MIN_WIDTH).
   // Because #root centers its content, a wider window visibly shifts the
@@ -342,6 +354,7 @@ function App() {
   // sequential awaits make one change visible before the other and the
   // pet flickers between positions.
   useEffect(() => {
+    if (mini.mode === "mini") return;
     const win = getCurrentWindow();
     const def = getDefaultPetSize(scale);
     const newWidth = Math.max(def.width, SESSION_DROPDOWN_MIN_WIDTH);
@@ -399,24 +412,37 @@ function App() {
         setSessionClosing(false);
       }
     })();
-  }, [sessionOpen, scale]);
+  }, [sessionOpen, scale, mini.mode]);
 
   return (
     <>
     <div
       ref={containerRef}
       data-testid="app-container"
-      className={`container ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${visitors.length > 0 ? "has-visitors" : ""} ${devAppBounds ? "dev-bounds" : ""} ${devContainerBounds ? "dev-container-bounds" : ""}`}
+      className={`container ${mini.mode === "mini" ? "mini-mode" : ""} ${dragging ? "dragging" : ""} ${scenario ? "scenario-active" : ""} ${visitors.length > 0 ? "has-visitors" : ""} ${devAppBounds ? "dev-bounds" : ""} ${devContainerBounds ? "dev-container-bounds" : ""}`}
       style={{
         // Enforced inline (as well as via .has-visitors CSS rule) to
         // guarantee the highest specificity wins: whichever stylesheet
         // ordering or hot-reload state we're in, the min-width here
         // is authoritative.
-        minWidth: visitors.length > 0 ? "500px" : `${PET_BASE_WIDTH}px`,
-        minHeight: `${PET_BASE_HEIGHT}px`,
+        minWidth:
+          mini.mode === "mini"
+            ? undefined
+            : visitors.length > 0
+              ? "500px"
+              : `${PET_BASE_WIDTH}px`,
+        minHeight: mini.mode === "mini" ? undefined : `${PET_BASE_HEIGHT}px`,
       }}
       onMouseDown={onMouseDown}
     >
+      {mini.mode === "mini" ? (
+        <MiniBar
+          status={status}
+          orientation={mini.orientation}
+          onRestore={mini.exitMini}
+        />
+      ) : (
+        <>
       <div className="main-col">
         {scenario && <div data-testid="scenario-badge" className="scenario-badge">SCENARIO</div>}
         <EffectOverlay onActiveChange={setEffectActive} />
@@ -433,6 +459,7 @@ function App() {
           status={status}
           glow={visible}
           disabled={status === "visiting"}
+          onMinimize={mini.enterMini}
           onOpenChange={(open) => {
             // Flip sessionClosing to true in the SAME render batch that
             // sessionOpen becomes false — this keeps useWindowAutoSize
@@ -458,6 +485,8 @@ function App() {
             />
           ))}
         </div>
+      )}
+        </>
       )}
     </div>
     <InstallPromptDialog prompt={prompt} error={installError} onDone={clear} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -439,6 +439,7 @@ function App() {
         <MiniBar
           status={status}
           orientation={mini.orientation}
+          edge={mini.edge}
           onRestore={mini.exitMini}
         />
       ) : (

--- a/src/SessionListApp.tsx
+++ b/src/SessionListApp.tsx
@@ -5,7 +5,6 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { fetchSessions, type SessionInfo } from "./hooks/useSessions";
 import { useCollapsedSessionGroups } from "./hooks/useCollapsedSessionGroups";
-import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
 import { useQuickClose } from "./hooks/useQuickClose";
 import "./styles/theme.css";
 import "./styles/session-list-window.css";
@@ -150,7 +149,6 @@ function overlayClaudeState(sessions: SessionInfo[]): SessionInfo[] {
 
 export function SessionListApp() {
   useQuickClose();
-  const rootRef = useRef<HTMLDivElement>(null);
   const [groups, setGroups] = useState<Group[]>([]);
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
   const [pathTooltip, setPathTooltip] = useState<{
@@ -165,7 +163,6 @@ export function SessionListApp() {
   useLayoutEffect(() => {
     document.documentElement.setAttribute("data-theme", "light");
   }, []);
-  useWindowAutoSize(rootRef);
 
   // Refresh sessions on mount and whenever the backend fires
   // `sessions-changed` (fingerprint-gated emit). No polling.
@@ -191,11 +188,14 @@ export function SessionListApp() {
     };
   }, []);
 
-  // Hide on focus loss or Escape.
+  // A real window like the plugin dialogs (not a popover): it does NOT hide on
+  // blur. The native title-bar close button hides it (rather than destroying
+  // the static window, so it can reopen); Escape and ⌘W (useQuickClose) hide too.
   useEffect(() => {
     const win = getCurrentWindow();
-    const unlistenP = win.onFocusChanged(({ payload: focused }) => {
-      if (!focused) void win.hide();
+    const unlistenP = win.onCloseRequested((e) => {
+      e.preventDefault();
+      void win.hide();
     });
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") void win.hide();
@@ -254,29 +254,15 @@ export function SessionListApp() {
   };
 
   return (
-    <div ref={rootRef} className="session-list-shell">
+    <div className="session-list-shell">
       <div
         className="session-list-root"
         data-testid="session-list-root"
         role="menu"
       >
         <header className="session-list-header">
-          <div className="session-list-header-text">
-            <h1>Sessions</h1>
-            <p className="sub">Click a terminal to bring it to the front.</p>
-          </div>
-          <button
-            type="button"
-            className="session-list-close"
-            data-testid="session-list-close"
-            aria-label="Close"
-            title="Close (⌘W)"
-            onClick={() => void getCurrentWindow().hide()}
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" aria-hidden="true">
-              <path d="M6 6l12 12M18 6L6 18" />
-            </svg>
-          </button>
+          <h1>Sessions</h1>
+          <p className="sub">Click a terminal to bring it to the front.</p>
         </header>
         <div className="session-list-body">
         {groups.length === 0 ? (

--- a/src/SessionListApp.tsx
+++ b/src/SessionListApp.tsx
@@ -5,7 +5,6 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { fetchSessions, type SessionInfo } from "./hooks/useSessions";
 import { useCollapsedSessionGroups } from "./hooks/useCollapsedSessionGroups";
-import { useTheme } from "./hooks/useTheme";
 import { useWindowAutoSize } from "./hooks/useWindowAutoSize";
 import { useQuickClose } from "./hooks/useQuickClose";
 import "./styles/theme.css";
@@ -162,7 +161,10 @@ export function SessionListApp() {
   } | null>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
-  useTheme();
+  // This dialog is always light, regardless of the app theme.
+  useLayoutEffect(() => {
+    document.documentElement.setAttribute("data-theme", "light");
+  }, []);
   useWindowAutoSize(rootRef);
 
   // Refresh sessions on mount and whenever the backend fires
@@ -259,8 +261,22 @@ export function SessionListApp() {
         role="menu"
       >
         <header className="session-list-header">
-          <h1>Sessions</h1>
-          <p className="sub">Click a terminal to bring it to the front.</p>
+          <div className="session-list-header-text">
+            <h1>Sessions</h1>
+            <p className="sub">Click a terminal to bring it to the front.</p>
+          </div>
+          <button
+            type="button"
+            className="session-list-close"
+            data-testid="session-list-close"
+            aria-label="Close"
+            title="Close (⌘W)"
+            onClick={() => void getCurrentWindow().hide()}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" aria-hidden="true">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
         </header>
         <div className="session-list-body">
         {groups.length === 0 ? (

--- a/src/SessionListApp.tsx
+++ b/src/SessionListApp.tsx
@@ -258,6 +258,11 @@ export function SessionListApp() {
         data-testid="session-list-root"
         role="menu"
       >
+        <header className="session-list-header">
+          <h1>Sessions</h1>
+          <p className="sub">Click a terminal to bring it to the front.</p>
+        </header>
+        <div className="session-list-body">
         {groups.length === 0 ? (
           <div className="session-empty">No active terminals</div>
         ) : (
@@ -345,6 +350,7 @@ export function SessionListApp() {
             );
           })
         )}
+        </div>
       </div>
 
       {pathTooltip &&

--- a/src/__mocks__/setup.ts
+++ b/src/__mocks__/setup.ts
@@ -3,6 +3,19 @@
  */
 import "@testing-library/jest-dom";
 
+// jsdom does not implement HTMLMediaElement.play/pause — stub them so
+// components that call playAudio() (e.g. StatusPill) don't throw.
+Object.defineProperty(HTMLMediaElement.prototype, "play", {
+  configurable: true,
+  writable: true,
+  value: () => Promise.resolve(),
+});
+Object.defineProperty(HTMLMediaElement.prototype, "pause", {
+  configurable: true,
+  writable: true,
+  value: () => undefined,
+});
+
 import { resetMocks as resetTauri } from "./tauri";
 import { resetMocks as resetEvent } from "./tauri-event";
 import { resetMocks as resetMenu } from "./tauri-menu";

--- a/src/__mocks__/tauri-window.ts
+++ b/src/__mocks__/tauri-window.ts
@@ -2,12 +2,40 @@
  * Mock for @tauri-apps/api/window
  */
 
+export class LogicalPosition {
+  type = "Logical" as const;
+  constructor(public x: number, public y: number) {}
+}
+
+export class LogicalSize {
+  type = "Logical" as const;
+  constructor(public width: number, public height: number) {}
+}
+
+export class PhysicalPosition {
+  type = "Physical" as const;
+  constructor(public x: number, public y: number) {}
+  toLogical(_sf: number) {
+    return new LogicalPosition(this.x, this.y);
+  }
+}
+
+export class PhysicalSize {
+  type = "Physical" as const;
+  constructor(public width: number, public height: number) {}
+  toLogical(_sf: number) {
+    return new LogicalSize(this.width, this.height);
+  }
+}
+
 const mockWindow = {
   label: "main",
   startDragging: vi.fn(async () => {}),
   setPosition: vi.fn(async () => {}),
-  outerPosition: vi.fn(async () => ({ x: 0, y: 0 })),
+  outerPosition: vi.fn(async () => new PhysicalPosition(0, 0)),
+  outerSize: vi.fn(async () => new PhysicalSize(160, 240)),
   setSize: vi.fn(async () => {}),
+  scaleFactor: vi.fn(async () => 1),
   hide: vi.fn(async () => {}),
   close: vi.fn(async () => {}),
 };
@@ -16,11 +44,21 @@ export function getCurrentWindow() {
   return mockWindow;
 }
 
+export const currentMonitor = vi.fn(async () => ({
+  name: "mock",
+  scaleFactor: 1,
+  position: new PhysicalPosition(0, 0),
+  size: new PhysicalSize(1000, 800),
+}));
+
 export function resetMocks() {
   mockWindow.startDragging.mockClear();
   mockWindow.setPosition.mockClear();
   mockWindow.outerPosition.mockClear();
+  mockWindow.outerSize.mockClear();
   mockWindow.setSize.mockClear();
+  mockWindow.scaleFactor.mockClear();
   mockWindow.hide.mockClear();
   mockWindow.close.mockClear();
+  currentMonitor.mockClear();
 }

--- a/src/__mocks__/tauri.ts
+++ b/src/__mocks__/tauri.ts
@@ -4,6 +4,12 @@
  * Provides invoke mock with configurable responses, plus convertFileSrc and appDataDir.
  */
 
+// Defaults applied on every reset so common read-only commands don't throw
+// when a test doesn't care about them. Tests can override via mockInvoke().
+const invokeDefaults: Record<string, unknown> = {
+  get_sessions: [],
+};
+
 const invokeResponses = new Map<string, unknown>();
 
 export const invoke = vi.fn(async (cmd: string, args?: Record<string, unknown>) => {
@@ -24,5 +30,8 @@ export function convertFileSrc(path: string): string {
 
 export function resetMocks() {
   invokeResponses.clear();
+  for (const [cmd, response] of Object.entries(invokeDefaults)) {
+    invokeResponses.set(cmd, response);
+  }
   invoke.mockClear();
 }

--- a/src/__tests__/components/MiniBar.test.tsx
+++ b/src/__tests__/components/MiniBar.test.tsx
@@ -12,54 +12,56 @@ function enableLanList() {
 
 describe("MiniBar", () => {
   it("renders the status dot with the status class", () => {
-    render(<MiniBar status="busy" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="busy" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
     const dot = screen.getByTestId("mini-bar-dot");
     expect(dot).toHaveClass("dot");
     expect(dot).toHaveClass("busy");
   });
 
   it("reflects orientation via data-orientation + class", () => {
-    render(<MiniBar status="idle" orientation="vertical" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="vertical" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
     const bar = screen.getByTestId("mini-bar");
     expect(bar).toHaveAttribute("data-orientation", "vertical");
     expect(bar).toHaveClass("vertical");
     expect(bar).toHaveClass("idle");
   });
 
-  it("renders a drag handle marked for window dragging", () => {
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+  it("starts the edge drag on grip mousedown", () => {
+    const onGripMouseDown = vi.fn();
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={onGripMouseDown} onRestore={() => {}} />);
     const grip = screen.getByTestId("mini-bar-drag-handle");
     expect(grip).toBeInTheDocument();
-    expect(grip).toHaveAttribute("data-drag-handle");
+    fireEvent.mouseDown(grip);
+    expect(onGripMouseDown).toHaveBeenCalledTimes(1);
   });
 
   it("calls onRestore when the restore button is clicked", () => {
     const onRestore = vi.fn();
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={onRestore} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={onRestore} />);
     fireEvent.click(screen.getByTestId("mini-bar-restore"));
     expect(onRestore).toHaveBeenCalledTimes(1);
   });
 
   it("shows the peer button only when the LAN list is enabled", async () => {
     enableLanList();
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
     expect(await screen.findByTestId("mini-bar-action-lan")).toBeInTheDocument();
   });
 
   it("hides the peer button when the LAN list is disabled (matches pet mode default)", () => {
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
     expect(screen.queryByTestId("mini-bar-action-lan")).toBeNull();
   });
 
   it("disables the peer button while visiting", async () => {
     enableLanList();
-    render(<MiniBar status="visiting" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="visiting" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
     const btn = await screen.findByTestId("mini-bar-action-lan");
     expect(btn).toBeDisabled();
   });
 
   it("renders a session button and opens the dropdown when clicked", async () => {
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
     const btn = screen.getByTestId("mini-bar-action-task");
     fireEvent.click(btn);
     await screen.findByTestId("session-dropdown");

--- a/src/__tests__/components/MiniBar.test.tsx
+++ b/src/__tests__/components/MiniBar.test.tsx
@@ -26,6 +26,13 @@ describe("MiniBar", () => {
     expect(bar).toHaveClass("idle");
   });
 
+  it("renders a drag handle marked for window dragging", () => {
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    const grip = screen.getByTestId("mini-bar-drag-handle");
+    expect(grip).toBeInTheDocument();
+    expect(grip).toHaveAttribute("data-drag-handle");
+  });
+
   it("calls onRestore when the restore button is clicked", () => {
     const onRestore = vi.fn();
     render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={onRestore} />);

--- a/src/__tests__/components/MiniBar.test.tsx
+++ b/src/__tests__/components/MiniBar.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MiniBar } from "../../components/MiniBar";
+
+describe("MiniBar", () => {
+  it("renders the status dot with the status class", () => {
+    render(<MiniBar status="busy" orientation="horizontal" onRestore={() => {}} />);
+    const dot = screen.getByTestId("mini-bar-dot");
+    expect(dot).toHaveClass("dot");
+    expect(dot).toHaveClass("busy");
+  });
+
+  it("reflects orientation via data-orientation + class", () => {
+    render(<MiniBar status="idle" orientation="vertical" onRestore={() => {}} />);
+    const bar = screen.getByTestId("mini-bar");
+    expect(bar).toHaveAttribute("data-orientation", "vertical");
+    expect(bar).toHaveClass("vertical");
+    expect(bar).toHaveClass("idle");
+  });
+
+  it("calls onRestore when the restore button is clicked", () => {
+    const onRestore = vi.fn();
+    render(<MiniBar status="idle" orientation="horizontal" onRestore={onRestore} />);
+    fireEvent.click(screen.getByTestId("mini-bar-restore"));
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/components/MiniBar.test.tsx
+++ b/src/__tests__/components/MiniBar.test.tsx
@@ -4,14 +4,14 @@ import { MiniBar } from "../../components/MiniBar";
 
 describe("MiniBar", () => {
   it("renders the status dot with the status class", () => {
-    render(<MiniBar status="busy" orientation="horizontal" onRestore={() => {}} />);
+    render(<MiniBar status="busy" orientation="horizontal" edge="bottom" onRestore={() => {}} />);
     const dot = screen.getByTestId("mini-bar-dot");
     expect(dot).toHaveClass("dot");
     expect(dot).toHaveClass("busy");
   });
 
   it("reflects orientation via data-orientation + class", () => {
-    render(<MiniBar status="idle" orientation="vertical" onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="vertical" edge="bottom" onRestore={() => {}} />);
     const bar = screen.getByTestId("mini-bar");
     expect(bar).toHaveAttribute("data-orientation", "vertical");
     expect(bar).toHaveClass("vertical");
@@ -20,8 +20,14 @@ describe("MiniBar", () => {
 
   it("calls onRestore when the restore button is clicked", () => {
     const onRestore = vi.fn();
-    render(<MiniBar status="idle" orientation="horizontal" onRestore={onRestore} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onRestore={onRestore} />);
     fireEvent.click(screen.getByTestId("mini-bar-restore"));
     expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a peer button that opens the peer-list popover", async () => {
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onRestore={() => {}} />);
+    const btn = screen.getByTestId("mini-bar-action-lan");
+    expect(btn).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/MiniBar.test.tsx
+++ b/src/__tests__/components/MiniBar.test.tsx
@@ -12,14 +12,14 @@ function enableLanList() {
 
 describe("MiniBar", () => {
   it("renders the status dot with the status class", () => {
-    render(<MiniBar status="busy" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="busy" orientation="horizontal" edge="bottom" onGripMouseDown={() => {}} onRestore={() => {}} />);
     const dot = screen.getByTestId("mini-bar-dot");
     expect(dot).toHaveClass("dot");
     expect(dot).toHaveClass("busy");
   });
 
   it("reflects orientation via data-orientation + class", () => {
-    render(<MiniBar status="idle" orientation="vertical" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="vertical" edge="bottom" onGripMouseDown={() => {}} onRestore={() => {}} />);
     const bar = screen.getByTestId("mini-bar");
     expect(bar).toHaveAttribute("data-orientation", "vertical");
     expect(bar).toHaveClass("vertical");
@@ -28,7 +28,7 @@ describe("MiniBar", () => {
 
   it("starts the edge drag on grip mousedown", () => {
     const onGripMouseDown = vi.fn();
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={onGripMouseDown} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onGripMouseDown={onGripMouseDown} onRestore={() => {}} />);
     const grip = screen.getByTestId("mini-bar-drag-handle");
     expect(grip).toBeInTheDocument();
     fireEvent.mouseDown(grip);
@@ -37,33 +37,33 @@ describe("MiniBar", () => {
 
   it("calls onRestore when the restore button is clicked", () => {
     const onRestore = vi.fn();
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={onRestore} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onGripMouseDown={() => {}} onRestore={onRestore} />);
     fireEvent.click(screen.getByTestId("mini-bar-restore"));
     expect(onRestore).toHaveBeenCalledTimes(1);
   });
 
   it("shows the peer button only when the LAN list is enabled", async () => {
     enableLanList();
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onGripMouseDown={() => {}} onRestore={() => {}} />);
     expect(await screen.findByTestId("mini-bar-action-lan")).toBeInTheDocument();
   });
 
   it("hides the peer button when the LAN list is disabled (matches pet mode default)", () => {
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onGripMouseDown={() => {}} onRestore={() => {}} />);
     expect(screen.queryByTestId("mini-bar-action-lan")).toBeNull();
   });
 
   it("disables the peer button while visiting", async () => {
     enableLanList();
-    render(<MiniBar status="visiting" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
+    render(<MiniBar status="visiting" orientation="horizontal" edge="bottom" onGripMouseDown={() => {}} onRestore={() => {}} />);
     const btn = await screen.findByTestId("mini-bar-action-lan");
     expect(btn).toBeDisabled();
   });
 
-  it("renders a session button and opens the dropdown when clicked", async () => {
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onGripMouseDown={() => {}} onRestore={() => {}} />);
-    const btn = screen.getByTestId("mini-bar-action-task");
-    fireEvent.click(btn);
-    await screen.findByTestId("session-dropdown");
+  it("renders a session button (mini mode opens a window, not an inline list)", () => {
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onGripMouseDown={() => {}} onRestore={() => {}} />);
+    expect(screen.getByTestId("mini-bar-action-task")).toBeInTheDocument();
+    // The inline dropdown belongs to pet mode only; it must not render here.
+    expect(screen.queryByTestId("session-dropdown")).toBeNull();
   });
 });

--- a/src/__tests__/components/MiniBar.test.tsx
+++ b/src/__tests__/components/MiniBar.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { MiniBar } from "../../components/MiniBar";
+import { mockStoreValue } from "../../__mocks__/tauri-store";
+
+/** Turn the LAN-list setting on so the peer button renders (defaults off,
+ *  matching the pet-mode StatusPill). */
+function enableLanList() {
+  mockStoreValue("settings.json", "lanListDefaultFalseMigrated", true);
+  mockStoreValue("settings.json", "lanListEnabled", true);
+}
 
 describe("MiniBar", () => {
   it("renders the status dot with the status class", () => {
@@ -25,10 +33,22 @@ describe("MiniBar", () => {
     expect(onRestore).toHaveBeenCalledTimes(1);
   });
 
-  it("renders a peer button that opens the peer-list popover", async () => {
+  it("shows the peer button only when the LAN list is enabled", async () => {
+    enableLanList();
     render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
-    const btn = screen.getByTestId("mini-bar-action-lan");
-    expect(btn).toBeInTheDocument();
+    expect(await screen.findByTestId("mini-bar-action-lan")).toBeInTheDocument();
+  });
+
+  it("hides the peer button when the LAN list is disabled (matches pet mode default)", () => {
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    expect(screen.queryByTestId("mini-bar-action-lan")).toBeNull();
+  });
+
+  it("disables the peer button while visiting", async () => {
+    enableLanList();
+    render(<MiniBar status="visiting" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    const btn = await screen.findByTestId("mini-bar-action-lan");
+    expect(btn).toBeDisabled();
   });
 
   it("renders a session button and opens the dropdown when clicked", async () => {

--- a/src/__tests__/components/MiniBar.test.tsx
+++ b/src/__tests__/components/MiniBar.test.tsx
@@ -4,14 +4,14 @@ import { MiniBar } from "../../components/MiniBar";
 
 describe("MiniBar", () => {
   it("renders the status dot with the status class", () => {
-    render(<MiniBar status="busy" orientation="horizontal" edge="bottom" onRestore={() => {}} />);
+    render(<MiniBar status="busy" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
     const dot = screen.getByTestId("mini-bar-dot");
     expect(dot).toHaveClass("dot");
     expect(dot).toHaveClass("busy");
   });
 
   it("reflects orientation via data-orientation + class", () => {
-    render(<MiniBar status="idle" orientation="vertical" edge="bottom" onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="vertical" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
     const bar = screen.getByTestId("mini-bar");
     expect(bar).toHaveAttribute("data-orientation", "vertical");
     expect(bar).toHaveClass("vertical");
@@ -20,14 +20,21 @@ describe("MiniBar", () => {
 
   it("calls onRestore when the restore button is clicked", () => {
     const onRestore = vi.fn();
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onRestore={onRestore} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={onRestore} />);
     fireEvent.click(screen.getByTestId("mini-bar-restore"));
     expect(onRestore).toHaveBeenCalledTimes(1);
   });
 
   it("renders a peer button that opens the peer-list popover", async () => {
-    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" onRestore={() => {}} />);
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
     const btn = screen.getByTestId("mini-bar-action-lan");
     expect(btn).toBeInTheDocument();
+  });
+
+  it("renders a session button and opens the dropdown when clicked", async () => {
+    render(<MiniBar status="idle" orientation="horizontal" edge="bottom" snapToNearest={() => {}} onRestore={() => {}} />);
+    const btn = screen.getByTestId("mini-bar-action-task");
+    fireEvent.click(btn);
+    await screen.findByTestId("session-dropdown");
   });
 });

--- a/src/__tests__/components/StatusPill.test.tsx
+++ b/src/__tests__/components/StatusPill.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { StatusPill } from "../../components/StatusPill";
 import type { Status } from "../../types/status";
 
@@ -57,5 +57,18 @@ describe("StatusPill", () => {
     const { container } = render(<StatusPill status="idle" />);
     const pill = container.querySelector(".pill");
     expect(pill).not.toHaveClass("neon-busy");
+  });
+
+  it("renders a minimize button and calls onMinimize when clicked", () => {
+    const onMinimize = vi.fn();
+    render(<StatusPill status="idle" onMinimize={onMinimize} />);
+    const btn = screen.getByTestId("pill-action-minimize");
+    fireEvent.click(btn);
+    expect(onMinimize).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render a minimize button when onMinimize is omitted", () => {
+    render(<StatusPill status="idle" />);
+    expect(screen.queryByTestId("pill-action-minimize")).toBeNull();
   });
 });

--- a/src/__tests__/hooks/useDrag.test.tsx
+++ b/src/__tests__/hooks/useDrag.test.tsx
@@ -29,4 +29,27 @@ describe("useDrag", () => {
     });
     expect(getCurrentWindow().startDragging).not.toHaveBeenCalled();
   });
+
+  it("with requireHandle, only drags from a [data-drag-handle] element", async () => {
+    const onDragEnd = vi.fn();
+    const { result } = renderHook(() =>
+      useDrag(onDragEnd, { requireHandle: true })
+    );
+
+    // Press on a plain element inside the bar — must NOT drag.
+    const plain = document.createElement("div");
+    await act(async () => {
+      await result.current.onMouseDown(mouseEvent(plain));
+    });
+    expect(getCurrentWindow().startDragging).not.toHaveBeenCalled();
+
+    // Press on the drag handle — must drag and re-snap.
+    const handle = document.createElement("span");
+    handle.setAttribute("data-drag-handle", "");
+    await act(async () => {
+      await result.current.onMouseDown(mouseEvent(handle));
+    });
+    expect(getCurrentWindow().startDragging).toHaveBeenCalledTimes(1);
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/__tests__/hooks/useDrag.test.tsx
+++ b/src/__tests__/hooks/useDrag.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useDrag } from "../../hooks/useDrag";
+import { getCurrentWindow, resetMocks } from "../../__mocks__/tauri-window";
+
+function mouseEvent(target: HTMLElement, button = 0) {
+  return { button, target } as unknown as React.MouseEvent;
+}
+
+describe("useDrag", () => {
+  beforeEach(() => resetMocks());
+
+  it("calls onDragEnd after a drag completes", async () => {
+    const onDragEnd = vi.fn();
+    const { result } = renderHook(() => useDrag(onDragEnd));
+    const div = document.createElement("div");
+    await act(async () => {
+      await result.current.onMouseDown(mouseEvent(div));
+    });
+    expect(getCurrentWindow().startDragging).toHaveBeenCalled();
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a drag when the target is a button", async () => {
+    const { result } = renderHook(() => useDrag());
+    const btn = document.createElement("button");
+    await act(async () => {
+      await result.current.onMouseDown(mouseEvent(btn));
+    });
+    expect(getCurrentWindow().startDragging).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/hooks/useMiniMode.test.tsx
+++ b/src/__tests__/hooks/useMiniMode.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { useMiniMode } from "../../hooks/useMiniMode";
+import { getCurrentWindow, resetMocks } from "../../__mocks__/tauri-window";
+
+describe("useMiniMode", () => {
+  beforeEach(() => resetMocks());
+
+  it("starts in pet mode", () => {
+    const { result } = renderHook(() => useMiniMode(1));
+    expect(result.current.mode).toBe("pet");
+  });
+
+  it("enterMini flips to mini and resizes + positions the window", async () => {
+    const { result } = renderHook(() => useMiniMode(1));
+    await act(async () => {
+      await result.current.enterMini();
+    });
+    await waitFor(() => expect(result.current.mode).toBe("mini"));
+    const win = getCurrentWindow();
+    expect(win.setSize).toHaveBeenCalled();
+    expect(win.setPosition).toHaveBeenCalled();
+  });
+
+  it("exitMini flips back to pet and restores pet size", async () => {
+    const { result } = renderHook(() => useMiniMode(1));
+    await act(async () => {
+      await result.current.enterMini();
+    });
+    const win = getCurrentWindow();
+    win.setSize.mockClear();
+    await act(async () => {
+      await result.current.exitMini();
+    });
+    await waitFor(() => expect(result.current.mode).toBe("pet"));
+    expect(win.setSize).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/hooks/useMiniMode.test.tsx
+++ b/src/__tests__/hooks/useMiniMode.test.tsx
@@ -34,5 +34,6 @@ describe("useMiniMode", () => {
     });
     await waitFor(() => expect(result.current.mode).toBe("pet"));
     expect(win.setSize).toHaveBeenCalled();
+    expect(win.setPosition).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/utils/popoverPos.test.ts
+++ b/src/__tests__/utils/popoverPos.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { inwardPopoverPos } from "../../utils/popoverPos";
+
+const BAR = { x: 100, y: 200, width: 40, height: 168 }; // a vertical bar
+const PW = 280;
+const PH = 260;
+const GAP = 8;
+
+describe("inwardPopoverPos", () => {
+  it("opens to the RIGHT of a left-edge bar", () => {
+    const p = inwardPopoverPos(BAR, "left", PW, PH, GAP);
+    expect(p.x).toBe(100 + 40 + GAP);
+    expect(p.y).toBe(200);
+  });
+
+  it("opens to the LEFT of a right-edge bar", () => {
+    const p = inwardPopoverPos(BAR, "right", PW, PH, GAP);
+    expect(p.x).toBe(100 - PW - GAP);
+    expect(p.y).toBe(200);
+  });
+
+  it("opens BELOW a top-edge bar", () => {
+    const hbar = { x: 300, y: 30, width: 168, height: 40 };
+    const p = inwardPopoverPos(hbar, "top", PW, PH, GAP);
+    expect(p.y).toBe(30 + 40 + GAP);
+    expect(p.x).toBe(300);
+  });
+
+  it("opens ABOVE a bottom-edge bar", () => {
+    const hbar = { x: 300, y: 752, width: 168, height: 40 };
+    const p = inwardPopoverPos(hbar, "bottom", PW, PH, GAP);
+    expect(p.y).toBe(752 - PH - GAP);
+    expect(p.x).toBe(300);
+  });
+});

--- a/src/__tests__/utils/snap.test.ts
+++ b/src/__tests__/utils/snap.test.ts
@@ -53,7 +53,7 @@ describe("computeSnap", () => {
     expect(DEFAULT_MARGINS.menuBar).toBeGreaterThanOrEqual(DEFAULT_MARGINS.edge);
     expect(DEFAULT_MARGINS).toEqual({ edge: 8, menuBar: 30 });
     expect(BAR_LONG).toBe(168);
-    expect(BAR_SHORT).toBe(40);
+    expect(BAR_SHORT).toBe(28);
   });
 
   it("snaps to the LEFT edge on a secondary monitor with negative origin", () => {

--- a/src/__tests__/utils/snap.test.ts
+++ b/src/__tests__/utils/snap.test.ts
@@ -59,13 +59,16 @@ describe("computeSnap", () => {
 });
 
 describe("miniBarLength", () => {
-  it("accounts for dot, padding and borders with zero buttons", () => {
+  it("accounts for dot, grip, padding and borders with zero action buttons", () => {
     expect(miniBarLength(0)).toBe(
-      2 * MINI_BAR.border + 2 * MINI_BAR.padding + MINI_BAR.dot
+      2 * MINI_BAR.border +
+        2 * MINI_BAR.padding +
+        MINI_BAR.dot +
+        (MINI_BAR.gap + MINI_BAR.grip)
     );
   });
 
-  it("grows by exactly one button + gap per added tool", () => {
+  it("grows by exactly one button + gap per added action button", () => {
     expect(miniBarLength(3) - miniBarLength(2)).toBe(MINI_BAR.gap + MINI_BAR.button);
   });
 

--- a/src/__tests__/utils/snap.test.ts
+++ b/src/__tests__/utils/snap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeSnap, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS } from "../../utils/snap";
+import { computeSnap, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS, miniBarLength, MINI_BAR } from "../../utils/snap";
 
 const MON = { x: 0, y: 0, width: 1000, height: 800 };
 
@@ -55,5 +55,22 @@ describe("computeSnap", () => {
     const r = computeSnap(win, secondMon, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("left");
     expect(r.x).toBe(-2560 + DEFAULT_MARGINS.edge);
+  });
+});
+
+describe("miniBarLength", () => {
+  it("accounts for dot, padding and borders with zero buttons", () => {
+    expect(miniBarLength(0)).toBe(
+      2 * MINI_BAR.border + 2 * MINI_BAR.padding + MINI_BAR.dot
+    );
+  });
+
+  it("grows by exactly one button + gap per added tool", () => {
+    expect(miniBarLength(3) - miniBarLength(2)).toBe(MINI_BAR.gap + MINI_BAR.button);
+  });
+
+  it("hugs content far tighter than the legacy fixed width", () => {
+    // 2 buttons (session + restore, peer off) should be well under BAR_LONG.
+    expect(miniBarLength(2)).toBeLessThan(BAR_LONG);
   });
 });

--- a/src/__tests__/utils/snap.test.ts
+++ b/src/__tests__/utils/snap.test.ts
@@ -4,40 +4,48 @@ import { computeSnap, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS, miniBarLength, MINI_
 const MON = { x: 0, y: 0, width: 1000, height: 800 };
 
 describe("computeSnap", () => {
-  it("snaps to the LEFT edge, TOP corner (vertical bar)", () => {
-    const r = computeSnap({ x: 30, y: 16, width: 40, height: 168 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
+  it("snaps to the LEFT edge, keeping the dropped Y (vertical bar)", () => {
+    const r = computeSnap({ x: 30, y: 300, width: 40, height: 168 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("left");
     expect(r.orientation).toBe("vertical");
     expect(r.width).toBe(BAR_SHORT);
     expect(r.height).toBe(BAR_LONG);
-    expect(r.x).toBe(8);
-    expect(r.y).toBe(30);
+    expect(r.x).toBe(8); // flush to left edge + margin
+    expect(r.y).toBe(300); // along-edge position preserved
   });
 
-  it("snaps to the RIGHT edge, BOTTOM corner (vertical bar)", () => {
-    const r = computeSnap({ x: 930, y: 616, width: 40, height: 168 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
+  it("snaps to the RIGHT edge, keeping the dropped Y (vertical bar)", () => {
+    const r = computeSnap({ x: 930, y: 600, width: 40, height: 168 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("right");
     expect(r.orientation).toBe("vertical");
     expect(r.x).toBe(1000 - BAR_SHORT - 8);
-    expect(r.y).toBe(800 - BAR_LONG - 8);
+    expect(r.y).toBe(600); // preserved
   });
 
-  it("snaps to the TOP edge, RIGHT corner (horizontal bar)", () => {
-    const r = computeSnap({ x: 816, y: 30, width: 168, height: 40 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
+  it("snaps to the TOP edge, keeping the dropped X (horizontal bar)", () => {
+    const r = computeSnap({ x: 400, y: 20, width: 168, height: 40 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("top");
     expect(r.orientation).toBe("horizontal");
     expect(r.width).toBe(BAR_LONG);
     expect(r.height).toBe(BAR_SHORT);
-    expect(r.y).toBe(30);
-    expect(r.x).toBe(1000 - BAR_LONG - 8);
+    expect(r.y).toBe(30); // menu-bar clearance
+    expect(r.x).toBe(400); // preserved
   });
 
-  it("snaps to the BOTTOM edge, LEFT corner (horizontal bar)", () => {
-    const r = computeSnap({ x: 16, y: 730, width: 168, height: 40 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
+  it("snaps to the BOTTOM edge, keeping the dropped X (horizontal bar)", () => {
+    const r = computeSnap({ x: 300, y: 740, width: 168, height: 40 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("bottom");
     expect(r.orientation).toBe("horizontal");
     expect(r.y).toBe(800 - BAR_SHORT - 8);
-    expect(r.x).toBe(8);
+    expect(r.x).toBe(300); // preserved
+  });
+
+  it("clamps the along-edge position so the bar stays fully on-screen", () => {
+    // Dropped near the top, far to the right — should stay on top edge but
+    // clamp X so the bar doesn't overflow past the right edge.
+    const r = computeSnap({ x: 870, y: 10, width: 168, height: 40 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("top");
+    expect(r.x).toBe(1000 - BAR_LONG - 8); // clamped to max X (824)
   });
 
   it("exports sane default bar constants", () => {
@@ -50,11 +58,12 @@ describe("computeSnap", () => {
 
   it("snaps to the LEFT edge on a secondary monitor with negative origin", () => {
     const secondMon = { x: -2560, y: 0, width: 2560, height: 1440 };
-    // Window centered near the left edge of the secondary monitor
+    // Window near the left edge of the secondary monitor
     const win = { x: -2550, y: 600, width: BAR_SHORT, height: BAR_LONG };
     const r = computeSnap(win, secondMon, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("left");
     expect(r.x).toBe(-2560 + DEFAULT_MARGINS.edge);
+    expect(r.y).toBe(600); // preserved
   });
 });
 

--- a/src/__tests__/utils/snap.test.ts
+++ b/src/__tests__/utils/snap.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { computeSnap, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS } from "../../utils/snap";
+
+const MON = { x: 0, y: 0, width: 1000, height: 800 };
+const LONG = 168;
+const SHORT = 40;
+
+describe("computeSnap", () => {
+  it("snaps to the LEFT edge, TOP corner (vertical bar)", () => {
+    const r = computeSnap({ x: 30, y: 16, width: 40, height: 168 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("left");
+    expect(r.orientation).toBe("vertical");
+    expect(r.width).toBe(SHORT);
+    expect(r.height).toBe(LONG);
+    expect(r.x).toBe(8);
+    expect(r.y).toBe(30);
+  });
+
+  it("snaps to the RIGHT edge, BOTTOM corner (vertical bar)", () => {
+    const r = computeSnap({ x: 930, y: 616, width: 40, height: 168 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("right");
+    expect(r.orientation).toBe("vertical");
+    expect(r.x).toBe(1000 - SHORT - 8);
+    expect(r.y).toBe(800 - LONG - 8);
+  });
+
+  it("snaps to the TOP edge, RIGHT corner (horizontal bar)", () => {
+    const r = computeSnap({ x: 816, y: 30, width: 168, height: 40 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("top");
+    expect(r.orientation).toBe("horizontal");
+    expect(r.width).toBe(LONG);
+    expect(r.height).toBe(SHORT);
+    expect(r.y).toBe(30);
+    expect(r.x).toBe(1000 - LONG - 8);
+  });
+
+  it("snaps to the BOTTOM edge, LEFT corner (horizontal bar)", () => {
+    const r = computeSnap({ x: 16, y: 730, width: 168, height: 40 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("bottom");
+    expect(r.orientation).toBe("horizontal");
+    expect(r.y).toBe(800 - SHORT - 8);
+    expect(r.x).toBe(8);
+  });
+
+  it("exports sane default bar constants", () => {
+    expect(BAR_LONG).toBeGreaterThan(BAR_SHORT);
+    expect(DEFAULT_MARGINS.menuBar).toBeGreaterThanOrEqual(DEFAULT_MARGINS.edge);
+  });
+});

--- a/src/__tests__/utils/snap.test.ts
+++ b/src/__tests__/utils/snap.test.ts
@@ -53,7 +53,7 @@ describe("computeSnap", () => {
     expect(DEFAULT_MARGINS.menuBar).toBeGreaterThanOrEqual(DEFAULT_MARGINS.edge);
     expect(DEFAULT_MARGINS).toEqual({ edge: 8, menuBar: 30 });
     expect(BAR_LONG).toBe(168);
-    expect(BAR_SHORT).toBe(28);
+    expect(BAR_SHORT).toBe(22);
   });
 
   it("snaps to the LEFT edge on a secondary monitor with negative origin", () => {

--- a/src/__tests__/utils/snap.test.ts
+++ b/src/__tests__/utils/snap.test.ts
@@ -2,48 +2,58 @@ import { describe, it, expect } from "vitest";
 import { computeSnap, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS } from "../../utils/snap";
 
 const MON = { x: 0, y: 0, width: 1000, height: 800 };
-const LONG = 168;
-const SHORT = 40;
 
 describe("computeSnap", () => {
   it("snaps to the LEFT edge, TOP corner (vertical bar)", () => {
-    const r = computeSnap({ x: 30, y: 16, width: 40, height: 168 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    const r = computeSnap({ x: 30, y: 16, width: 40, height: 168 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("left");
     expect(r.orientation).toBe("vertical");
-    expect(r.width).toBe(SHORT);
-    expect(r.height).toBe(LONG);
+    expect(r.width).toBe(BAR_SHORT);
+    expect(r.height).toBe(BAR_LONG);
     expect(r.x).toBe(8);
     expect(r.y).toBe(30);
   });
 
   it("snaps to the RIGHT edge, BOTTOM corner (vertical bar)", () => {
-    const r = computeSnap({ x: 930, y: 616, width: 40, height: 168 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    const r = computeSnap({ x: 930, y: 616, width: 40, height: 168 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("right");
     expect(r.orientation).toBe("vertical");
-    expect(r.x).toBe(1000 - SHORT - 8);
-    expect(r.y).toBe(800 - LONG - 8);
+    expect(r.x).toBe(1000 - BAR_SHORT - 8);
+    expect(r.y).toBe(800 - BAR_LONG - 8);
   });
 
   it("snaps to the TOP edge, RIGHT corner (horizontal bar)", () => {
-    const r = computeSnap({ x: 816, y: 30, width: 168, height: 40 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    const r = computeSnap({ x: 816, y: 30, width: 168, height: 40 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("top");
     expect(r.orientation).toBe("horizontal");
-    expect(r.width).toBe(LONG);
-    expect(r.height).toBe(SHORT);
+    expect(r.width).toBe(BAR_LONG);
+    expect(r.height).toBe(BAR_SHORT);
     expect(r.y).toBe(30);
-    expect(r.x).toBe(1000 - LONG - 8);
+    expect(r.x).toBe(1000 - BAR_LONG - 8);
   });
 
   it("snaps to the BOTTOM edge, LEFT corner (horizontal bar)", () => {
-    const r = computeSnap({ x: 16, y: 730, width: 168, height: 40 }, MON, LONG, SHORT, DEFAULT_MARGINS);
+    const r = computeSnap({ x: 16, y: 730, width: 168, height: 40 }, MON, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
     expect(r.edge).toBe("bottom");
     expect(r.orientation).toBe("horizontal");
-    expect(r.y).toBe(800 - SHORT - 8);
+    expect(r.y).toBe(800 - BAR_SHORT - 8);
     expect(r.x).toBe(8);
   });
 
   it("exports sane default bar constants", () => {
     expect(BAR_LONG).toBeGreaterThan(BAR_SHORT);
     expect(DEFAULT_MARGINS.menuBar).toBeGreaterThanOrEqual(DEFAULT_MARGINS.edge);
+    expect(DEFAULT_MARGINS).toEqual({ edge: 8, menuBar: 30 });
+    expect(BAR_LONG).toBe(168);
+    expect(BAR_SHORT).toBe(40);
+  });
+
+  it("snaps to the LEFT edge on a secondary monitor with negative origin", () => {
+    const secondMon = { x: -2560, y: 0, width: 2560, height: 1440 };
+    // Window centered near the left edge of the secondary monitor
+    const win = { x: -2550, y: 600, width: BAR_SHORT, height: BAR_LONG };
+    const r = computeSnap(win, secondMon, BAR_LONG, BAR_SHORT, DEFAULT_MARGINS);
+    expect(r.edge).toBe("left");
+    expect(r.x).toBe(-2560 + DEFAULT_MARGINS.edge);
   });
 });

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -47,7 +47,10 @@ interface MiniBarProps {
 }
 
 export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }: MiniBarProps) {
-  const didMountRef = useRef(false);
+  // Tracks the session panel's previous open state so we only snap the bar
+  // back when the panel actually closes — NOT on orientation changes, which
+  // would otherwise interrupt the magnet glide mid-flight.
+  const prevSessionOpenRef = useRef(false);
 
   const { enabled: sessionListEnabled } = useSessionList();
   const { enabled: lanListEnabled } = useLanList();
@@ -111,11 +114,16 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
   // On close, re-snap (which resizes the window back to the bar).
   useEffect(() => {
     if (!sessionOpen) {
-      if (didMountRef.current) snapToNearest();
-      didMountRef.current = true;
+      // Only restore the bar size when the panel was just open (panel→bar).
+      // Orientation changes while closed come from a snap that already
+      // positioned the bar, so don't re-snap here.
+      if (prevSessionOpenRef.current) {
+        prevSessionOpenRef.current = false;
+        snapToNearest();
+      }
       return;
     }
-    didMountRef.current = true;
+    prevSessionOpenRef.current = true;
     const vertical = orientation === "vertical";
     const w = PANEL_W;
     const h = vertical ? PANEL_LIST_H : PANEL_HEADER_H + PANEL_LIST_H;

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -259,7 +259,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
           onRestore();
         }}
       >
-        <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <svg className="pill-action-icon" width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
         </svg>
       </button>

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -1,69 +1,47 @@
-import { useRef, useState, useEffect } from "react";
-import {
-  getCurrentWindow,
-  currentMonitor,
-  LogicalPosition,
-  LogicalSize,
-} from "@tauri-apps/api/window";
+import { useState, useEffect } from "react";
+import { getCurrentWindow, LogicalPosition } from "@tauri-apps/api/window";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { listen } from "@tauri-apps/api/event";
 import type { Status } from "../types/status";
 import type { Orientation, Edge } from "../utils/snap";
 import { inwardPopoverPos } from "../utils/popoverPos";
-import { fetchSessions } from "../hooks/useSessions";
-import {
-  groupSessions,
-  detectHome,
-  reflectActiveServices,
-  overlayClaudeState,
-  type Group,
-} from "../utils/sessionGroups";
 import { useSessionList } from "../hooks/useSessionList";
 import { useLanList } from "../hooks/useLanList";
-import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import { usePeers } from "../hooks/usePeers";
 import { useSoundSettings } from "../hooks/useSoundSettings";
 import { playAudio } from "../utils/audio";
-import { SessionDropdown } from "./SessionDropdown";
 import "../styles/mini-bar.css";
 import "../styles/status-pill.css";
 
-/** Peer-list popover window size — must match tauri.conf.json. */
+/** Tool-window sizes — must match the window defs in tauri.conf.json. */
 const PEER_W = 280;
 const PEER_H = 260;
+const SESSION_W = 280;
+const SESSION_H = 360;
 const POPOVER_GAP = 8;
-
-/** Mini-mode session panel size (logical px) when the list is open. */
-const PANEL_W = 320;
-const PANEL_LIST_H = 360;
-const PANEL_HEADER_H = 40;
 
 interface MiniBarProps {
   status: Status;
   orientation: Orientation;
   edge: Edge;
-  snapToNearest: () => void;
-  /** mousedown on the grip — starts the edge-constrained drag. */
+  /** mousedown on the grip — starts the drag. */
   onGripMouseDown: (e: React.MouseEvent) => void;
   onRestore: () => void;
 }
 
-export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseDown, onRestore }: MiniBarProps) {
-  // Tracks the session panel's previous open state so we only snap the bar
-  // back when the panel actually closes — NOT on orientation changes, which
-  // would otherwise interrupt the magnet glide mid-flight.
-  const prevSessionOpenRef = useRef(false);
-
+/**
+ * The collapsed mini bar. In mini mode each tool (session list, peers) opens
+ * its OWN window docked inward from the bar — never an inline list/panel. (Pet
+ * mode keeps the inline dropdown in StatusPill.)
+ */
+export function MiniBar({ status, orientation, edge, onGripMouseDown, onRestore }: MiniBarProps) {
   const { enabled: sessionListEnabled } = useSessionList();
   const { enabled: lanListEnabled } = useLanList();
-  // Mirrors StatusPill: the peer popover is unavailable while visiting
-  // (you can't start a second visit). The session list stays available.
+  // Mirrors StatusPill: the peer tool is unavailable while visiting (you can't
+  // start a second visit). The session list stays available.
   const peerDisabled = status === "visiting";
-  const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
   const peers = usePeers();
   const [sessionOpen, setSessionOpen] = useState(false);
   const [peerOpen, setPeerOpen] = useState(false);
-  const [groups, setGroups] = useState<Group[]>([]);
 
   // UI click feedback, gated by the master sound toggle — same as StatusPill.
   const soundSettings = useSoundSettings();
@@ -71,133 +49,15 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseD
     if (soundSettings.master) playAudio("tap");
   };
 
-  const toggleSession = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!sessionListEnabled) return;
-    playClickTap();
-    if (sessionOpen) {
-      setSessionOpen(false);
-      return;
-    }
-    // Only one popover at a time — hide the peer popover before opening.
-    // Guarded so a popover lookup failure never blocks opening the list.
-    try {
-      const popover = await WebviewWindow.getByLabel("peer-list");
-      if (popover && (await popover.isVisible())) {
-        await popover.hide().catch(() => {});
-        setPeerOpen(false);
-      }
-    } catch {
-      /* peer window unavailable — ignore */
-    }
-    const list = await fetchSessions();
-    setGroups(groupSessions(overlayClaudeState(reflectActiveServices(list)), detectHome(list)));
-    setSessionOpen(true);
+  const hideToolWindow = async (label: string) => {
+    const win = await WebviewWindow.getByLabel(label);
+    await win?.hide().catch(() => {});
   };
 
-  // Live refresh while open.
-  useEffect(() => {
-    if (!sessionOpen) return;
-    let cancelled = false;
-    const refresh = async () => {
-      const list = await fetchSessions();
-      if (cancelled) return;
-      setGroups(groupSessions(overlayClaudeState(reflectActiveServices(list)), detectHome(list)));
-    };
-    const unlistenP = listen("sessions-changed", () => void refresh());
-    return () => {
-      cancelled = true;
-      unlistenP.then((fn) => fn());
-    };
-  }, [sessionOpen]);
-
-  // Grow the bar window into a panel while the list is open.
-  // On close, re-snap (which resizes the window back to the bar).
-  useEffect(() => {
-    if (!sessionOpen) {
-      // Only restore the bar size when the panel was just open (panel→bar).
-      // Orientation changes while closed come from a snap that already
-      // positioned the bar, so don't re-snap here.
-      if (prevSessionOpenRef.current) {
-        prevSessionOpenRef.current = false;
-        snapToNearest();
-      }
-      return;
-    }
-    prevSessionOpenRef.current = true;
-    const vertical = orientation === "vertical";
-    const w = PANEL_W;
-    const h = vertical ? PANEL_LIST_H : PANEL_HEADER_H + PANEL_LIST_H;
-    void (async () => {
-      const win = getCurrentWindow();
-      try {
-        const sf = await win.scaleFactor();
-        const pos = (await win.outerPosition()).toLogical(sf);
-        let x = pos.x;
-        let y = pos.y;
-        const mon = await currentMonitor();
-        if (mon) {
-          const msf = mon.scaleFactor || 1;
-          const mx = mon.position.x / msf;
-          const my = mon.position.y / msf;
-          const mw = mon.size.width / msf;
-          const mh = mon.size.height / msf;
-          // Clamp so the whole panel stays on-screen (expands inward
-          // from whichever edge/corner the bar is snapped to).
-          x = Math.min(Math.max(x, mx + 8), mx + mw - w - 8);
-          y = Math.min(Math.max(y, my + 8), my + mh - h - 8);
-        }
-        await win.setSize(new LogicalSize(w, h));
-        await win.setPosition(new LogicalPosition(x, y));
-      } catch (err) {
-        console.error("[mini-bar] panel grow failed:", err);
-      }
-    })();
-  }, [sessionOpen, orientation]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Keep the peer popover hidden when the LAN list is turned off or while
-  // visiting — mirrors StatusPill so the two modes behave identically.
-  useEffect(() => {
-    if (lanListEnabled && !peerDisabled) return;
-    void (async () => {
-      const popover = await WebviewWindow.getByLabel("peer-list");
-      await popover?.hide().catch(() => {});
-    })();
-    setPeerOpen(false);
-  }, [lanListEnabled, peerDisabled]);
-
-  // Reset the active-state highlight when the popover loses focus (e.g. the
-  // user clicks elsewhere) — same pattern as StatusPill.
-  useEffect(() => {
-    let unlisten: (() => void) | undefined;
-    (async () => {
-      const popover = await WebviewWindow.getByLabel("peer-list");
-      if (!popover) return;
-      const fn = await popover.onFocusChanged(({ payload: focused }) => {
-        if (!focused) setPeerOpen(false);
-      });
-      unlisten = fn;
-    })();
-    return () => {
-      unlisten?.();
-    };
-  }, []);
-
-  const togglePeer = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!lanListEnabled || peerDisabled) return;
-    playClickTap();
-    const popover = await WebviewWindow.getByLabel("peer-list");
-    if (!popover) return;
-    if (await popover.isVisible()) {
-      await popover.hide();
-      setPeerOpen(false);
-      return;
-    }
-    // Only one popover at a time — close the session list before showing.
-    if (sessionOpen) setSessionOpen(false);
+  /** Show a tool window docked inward from the bar's snapped edge. */
+  const showToolWindow = async (label: string, w: number, h: number) => {
+    const win = await WebviewWindow.getByLabel(label);
+    if (!win) return false;
     const main = getCurrentWindow();
     const sf = await main.scaleFactor();
     const pos = (await main.outerPosition()).toLogical(sf);
@@ -205,15 +65,88 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseD
     const p = inwardPopoverPos(
       { x: pos.x, y: pos.y, width: size.width, height: size.height },
       edge,
-      PEER_W,
-      PEER_H,
+      w,
+      h,
       POPOVER_GAP
     );
-    await popover.setPosition(new LogicalPosition(p.x, p.y));
-    await popover.show();
-    await popover.setFocus();
-    setPeerOpen(true);
+    await win.setPosition(new LogicalPosition(p.x, p.y));
+    await win.show();
+    await win.setFocus();
+    return true;
   };
+
+  const toggleSession = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!sessionListEnabled) return;
+    playClickTap();
+    const win = await WebviewWindow.getByLabel("session-list");
+    if (win && (await win.isVisible())) {
+      await win.hide();
+      setSessionOpen(false);
+      return;
+    }
+    // Only one tool window open at a time.
+    if (peerOpen) {
+      await hideToolWindow("peer-list");
+      setPeerOpen(false);
+    }
+    if (await showToolWindow("session-list", SESSION_W, SESSION_H)) {
+      setSessionOpen(true);
+    }
+  };
+
+  const togglePeer = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!lanListEnabled || peerDisabled) return;
+    playClickTap();
+    const win = await WebviewWindow.getByLabel("peer-list");
+    if (win && (await win.isVisible())) {
+      await win.hide();
+      setPeerOpen(false);
+      return;
+    }
+    if (sessionOpen) {
+      await hideToolWindow("session-list");
+      setSessionOpen(false);
+    }
+    if (await showToolWindow("peer-list", PEER_W, PEER_H)) {
+      setPeerOpen(true);
+    }
+  };
+
+  // Hide the peer window when the LAN list is turned off or while visiting.
+  useEffect(() => {
+    if (lanListEnabled && !peerDisabled) return;
+    void hideToolWindow("peer-list");
+    setPeerOpen(false);
+  }, [lanListEnabled, peerDisabled]);
+
+  // Reset a tool button's active highlight when its window loses focus (the
+  // window hides itself on blur; this just keeps the button state in sync).
+  useEffect(() => {
+    const unsubs: Array<() => void> = [];
+    void (async () => {
+      const peer = await WebviewWindow.getByLabel("peer-list");
+      if (peer) {
+        unsubs.push(
+          await peer.onFocusChanged(({ payload }) => {
+            if (!payload) setPeerOpen(false);
+          })
+        );
+      }
+      const sess = await WebviewWindow.getByLabel("session-list");
+      if (sess) {
+        unsubs.push(
+          await sess.onFocusChanged(({ payload }) => {
+            if (!payload) setSessionOpen(false);
+          })
+        );
+      }
+    })();
+    return () => unsubs.forEach((fn) => fn());
+  }, []);
 
   return (
     <div
@@ -293,18 +226,6 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseD
           <circle cx="3.9" cy="9.9" r="1.1" />
         </svg>
       </span>
-
-      {sessionOpen && (
-        <SessionDropdown
-          groups={groups}
-          collapsed={collapsed}
-          toggleCollapsed={(key) => void toggleCollapsed(key)}
-          onPickSession={() => setSessionOpen(false)}
-          style={{ position: "static", transform: "none", left: "auto", maxHeight: `${PANEL_LIST_H}px`, width: "100%" }}
-          showPathTooltip={() => {}}
-          hidePathTooltip={() => {}}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -233,7 +233,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseD
           title="Session list"
           onClick={toggleSession}
         >
-          <svg className="pill-action-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM7 9h10v2H7V9zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" />
           </svg>
         </button>
@@ -250,7 +250,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseD
           onClick={togglePeer}
           disabled={peerDisabled}
         >
-          <svg className="pill-action-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
           </svg>
         </button>
@@ -269,7 +269,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseD
           onRestore();
         }}
       >
-        <svg className="pill-action-icon" width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <svg className="pill-action-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
         </svg>
       </button>

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -259,7 +259,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
           onRestore();
         }}
       >
-        <svg className="pill-action-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <svg className="pill-action-icon" width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
         </svg>
       </button>

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -1,19 +1,54 @@
+import { useRef } from "react";
+import {
+  getCurrentWindow,
+  LogicalPosition,
+} from "@tauri-apps/api/window";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { Status } from "../types/status";
-import type { Orientation } from "../utils/snap";
+import type { Orientation, Edge } from "../utils/snap";
+import { inwardPopoverPos } from "../utils/popoverPos";
 import "../styles/mini-bar.css";
+
+/** Peer-list popover window size — must match tauri.conf.json. */
+const PEER_W = 280;
+const PEER_H = 260;
+const POPOVER_GAP = 8;
 
 interface MiniBarProps {
   status: Status;
   orientation: Orientation;
+  edge: Edge;
   onRestore: () => void;
 }
 
-/**
- * The collapsed "mini bar" view. Reuses the `.dot` status classes from
- * status-pill.css (loaded globally because StatusPill is imported by App).
- * The status class on the root drives the glow color (see mini-bar.css).
- */
-export function MiniBar({ status, orientation, onRestore }: MiniBarProps) {
+export function MiniBar({ status, orientation, edge, onRestore }: MiniBarProps) {
+  const lanButtonRef = useRef<HTMLButtonElement>(null);
+
+  const togglePeer = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const popover = await WebviewWindow.getByLabel("peer-list");
+    if (!popover) return;
+    if (await popover.isVisible()) {
+      await popover.hide();
+      return;
+    }
+    const main = getCurrentWindow();
+    const sf = await main.scaleFactor();
+    const pos = (await main.outerPosition()).toLogical(sf);
+    const size = (await main.outerSize()).toLogical(sf);
+    const p = inwardPopoverPos(
+      { x: pos.x, y: pos.y, width: size.width, height: size.height },
+      edge,
+      PEER_W,
+      PEER_H,
+      POPOVER_GAP
+    );
+    await popover.setPosition(new LogicalPosition(p.x, p.y));
+    await popover.show();
+    await popover.setFocus();
+  };
+
   return (
     <div
       data-testid="mini-bar"
@@ -21,6 +56,21 @@ export function MiniBar({ status, orientation, onRestore }: MiniBarProps) {
       className={`mini-bar ${orientation} ${status}`}
     >
       <span data-testid="mini-bar-dot" className={`dot ${status}`} />
+
+      <button
+        ref={lanButtonRef}
+        type="button"
+        data-testid="mini-bar-action-lan"
+        className="mini-bar-btn"
+        aria-label="Mime Around You"
+        title="Peers nearby"
+        onClick={togglePeer}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
+        </svg>
+      </button>
+
       <button
         type="button"
         data-testid="mini-bar-restore"

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -43,10 +43,12 @@ interface MiniBarProps {
   orientation: Orientation;
   edge: Edge;
   snapToNearest: () => void;
+  /** mousedown on the grip — starts the edge-constrained drag. */
+  onGripMouseDown: (e: React.MouseEvent) => void;
   onRestore: () => void;
 }
 
-export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }: MiniBarProps) {
+export function MiniBar({ status, orientation, edge, snapToNearest, onGripMouseDown, onRestore }: MiniBarProps) {
   // Tracks the session panel's previous open state so we only snap the bar
   // back when the panel actually closes — NOT on orientation changes, which
   // would otherwise interrupt the magnet glide mid-flight.
@@ -274,11 +276,11 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
 
       <span
         data-testid="mini-bar-drag-handle"
-        data-drag-handle
         className="mini-bar-grip"
         role="separator"
         aria-label="Drag to move"
         title="Hold to move"
+        onMouseDown={onGripMouseDown}
       >
         {/* Tight, flush 2×3 grip so its right edge hugs the bar edge the
             same ~8px as the status dot hugs the left. */}

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -211,7 +211,9 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
       data-orientation={orientation}
       className={`mini-bar ${orientation} ${status}`}
     >
-      <span data-testid="mini-bar-dot" className={`dot ${status}`} />
+      <span className="mini-bar-dot-slot">
+        <span data-testid="mini-bar-dot" className={`dot ${status}`} />
+      </span>
 
       {sessionListEnabled && (
         <button

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -223,7 +223,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
           title="Session list"
           onClick={toggleSession}
         >
-          <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg className="pill-action-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM7 9h10v2H7V9zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" />
           </svg>
         </button>
@@ -240,7 +240,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
           onClick={togglePeer}
           disabled={peerDisabled}
         >
-          <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg className="pill-action-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
           </svg>
         </button>
@@ -259,7 +259,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
           onRestore();
         }}
       >
-        <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <svg className="pill-action-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
         </svg>
       </button>

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -19,6 +19,7 @@ import {
   type Group,
 } from "../utils/sessionGroups";
 import { useSessionList } from "../hooks/useSessionList";
+import { useLanList } from "../hooks/useLanList";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import { SessionDropdown } from "./SessionDropdown";
 import "../styles/mini-bar.css";
@@ -46,6 +47,10 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
   const didMountRef = useRef(false);
 
   const { enabled: sessionListEnabled } = useSessionList();
+  const { enabled: lanListEnabled } = useLanList();
+  // Mirrors StatusPill: the peer popover is unavailable while visiting
+  // (you can't start a second visit). The session list stays available.
+  const peerDisabled = status === "visiting";
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
   const [sessionOpen, setSessionOpen] = useState(false);
   const [groups, setGroups] = useState<Group[]>([]);
@@ -118,9 +123,20 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
     })();
   }, [sessionOpen, orientation]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Keep the peer popover hidden when the LAN list is turned off or while
+  // visiting — mirrors StatusPill so the two modes behave identically.
+  useEffect(() => {
+    if (lanListEnabled && !peerDisabled) return;
+    void (async () => {
+      const popover = await WebviewWindow.getByLabel("peer-list");
+      await popover?.hide().catch(() => {});
+    })();
+  }, [lanListEnabled, peerDisabled]);
+
   const togglePeer = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!lanListEnabled || peerDisabled) return;
     const popover = await WebviewWindow.getByLabel("peer-list");
     if (!popover) return;
     if (await popover.isVisible()) {
@@ -167,18 +183,21 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
         </button>
       )}
 
-      <button
-        type="button"
-        data-testid="mini-bar-action-lan"
-        className="mini-bar-btn"
-        aria-label="Mime Around You"
-        title="Peers nearby"
-        onClick={togglePeer}
-      >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
-        </svg>
-      </button>
+      {lanListEnabled && (
+        <button
+          type="button"
+          data-testid="mini-bar-action-lan"
+          className="mini-bar-btn"
+          aria-label="Mime Around You"
+          title="Peers nearby"
+          onClick={togglePeer}
+          disabled={peerDisabled}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
+          </svg>
+        </button>
+      )}
 
       <button
         type="button"

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -260,7 +260,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
         }}
       >
         <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M4 4h7v2H6v5H4V4zm9 0h7v7h-2V6h-5V4zM4 13h2v5h5v2H4v-7zm14 0h2v7h-7v-2h5v-5z" />
+          <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
         </svg>
       </button>
 

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -30,6 +30,7 @@ const POPOVER_GAP = 8;
 /** Mini-mode session panel size (logical px) when the list is open. */
 const PANEL_W = 320;
 const PANEL_LIST_H = 360;
+const PANEL_HEADER_H = 40;
 
 interface MiniBarProps {
   status: Status;
@@ -41,6 +42,7 @@ interface MiniBarProps {
 
 export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }: MiniBarProps) {
   const lanButtonRef = useRef<HTMLButtonElement>(null);
+  const didMountRef = useRef(false);
 
   const { enabled: sessionListEnabled } = useSessionList();
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
@@ -80,12 +82,14 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
   // On close, re-snap (which resizes the window back to the bar).
   useEffect(() => {
     if (!sessionOpen) {
-      snapToNearest();
+      if (didMountRef.current) snapToNearest();
+      didMountRef.current = true;
       return;
     }
+    didMountRef.current = true;
     const vertical = orientation === "vertical";
-    const w = vertical ? PANEL_W : Math.max(PANEL_W, 168);
-    const h = vertical ? PANEL_LIST_H : 40 + PANEL_LIST_H;
+    const w = PANEL_W;
+    const h = vertical ? PANEL_LIST_H : PANEL_HEADER_H + PANEL_LIST_H;
     void getCurrentWindow().setSize(new LogicalSize(w, h)).catch(() => {});
   }, [sessionOpen, orientation]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -211,9 +211,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
       data-orientation={orientation}
       className={`mini-bar ${orientation} ${status}`}
     >
-      <span className="mini-bar-dot-slot">
-        <span data-testid="mini-bar-dot" className={`dot ${status}`} />
-      </span>
+      <span data-testid="mini-bar-dot" className={`dot ${status}`} />
 
       {sessionListEnabled && (
         <button
@@ -274,13 +272,15 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
         aria-label="Drag to move"
         title="Hold to move"
       >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <circle cx="9" cy="6" r="1.6" />
-          <circle cx="15" cy="6" r="1.6" />
-          <circle cx="9" cy="12" r="1.6" />
-          <circle cx="15" cy="12" r="1.6" />
-          <circle cx="9" cy="18" r="1.6" />
-          <circle cx="15" cy="18" r="1.6" />
+        {/* Tight, flush 2×3 grip so its right edge hugs the bar edge the
+            same ~8px as the status dot hugs the left. */}
+        <svg width="7" height="14" viewBox="0 0 7 14" fill="currentColor" aria-hidden="true">
+          <circle cx="1.5" cy="1.5" r="1.5" />
+          <circle cx="5.5" cy="1.5" r="1.5" />
+          <circle cx="1.5" cy="7" r="1.5" />
+          <circle cx="5.5" cy="7" r="1.5" />
+          <circle cx="1.5" cy="12.5" r="1.5" />
+          <circle cx="5.5" cy="12.5" r="1.5" />
         </svg>
       </span>
 

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -1,0 +1,38 @@
+import type { Status } from "../types/status";
+import type { Orientation } from "../utils/snap";
+import "../styles/mini-bar.css";
+
+interface MiniBarProps {
+  status: Status;
+  orientation: Orientation;
+  onRestore: () => void;
+}
+
+/**
+ * The collapsed "mini bar" view. Reuses the `.dot` status classes from
+ * status-pill.css (loaded globally because StatusPill is imported by App).
+ * The status class on the root drives the glow color (see mini-bar.css).
+ */
+export function MiniBar({ status, orientation, onRestore }: MiniBarProps) {
+  return (
+    <div
+      data-testid="mini-bar"
+      data-orientation={orientation}
+      className={`mini-bar ${orientation} ${status}`}
+    >
+      <span data-testid="mini-bar-dot" className={`dot ${status}`} />
+      <button
+        type="button"
+        data-testid="mini-bar-restore"
+        className="mini-bar-btn"
+        aria-label="Restore pet"
+        title="Restore"
+        onClick={onRestore}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M4 4h7v2H6v5H4V4zm9 0h7v7h-2V6h-5V4zM4 13h2v5h5v2H4v-7zm14 0h2v7h-7v-2h5v-5z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useEffect } from "react";
 import {
   getCurrentWindow,
+  currentMonitor,
   LogicalPosition,
   LogicalSize,
 } from "@tauri-apps/api/window";
@@ -21,6 +22,7 @@ import { useSessionList } from "../hooks/useSessionList";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import { SessionDropdown } from "./SessionDropdown";
 import "../styles/mini-bar.css";
+import "../styles/status-pill.css";
 
 /** Peer-list popover window size — must match tauri.conf.json. */
 const PEER_W = 280;
@@ -41,7 +43,6 @@ interface MiniBarProps {
 }
 
 export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }: MiniBarProps) {
-  const lanButtonRef = useRef<HTMLButtonElement>(null);
   const didMountRef = useRef(false);
 
   const { enabled: sessionListEnabled } = useSessionList();
@@ -90,7 +91,31 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
     const vertical = orientation === "vertical";
     const w = PANEL_W;
     const h = vertical ? PANEL_LIST_H : PANEL_HEADER_H + PANEL_LIST_H;
-    void getCurrentWindow().setSize(new LogicalSize(w, h)).catch(() => {});
+    void (async () => {
+      const win = getCurrentWindow();
+      try {
+        const sf = await win.scaleFactor();
+        const pos = (await win.outerPosition()).toLogical(sf);
+        let x = pos.x;
+        let y = pos.y;
+        const mon = await currentMonitor();
+        if (mon) {
+          const msf = mon.scaleFactor || 1;
+          const mx = mon.position.x / msf;
+          const my = mon.position.y / msf;
+          const mw = mon.size.width / msf;
+          const mh = mon.size.height / msf;
+          // Clamp so the whole panel stays on-screen (expands inward
+          // from whichever edge/corner the bar is snapped to).
+          x = Math.min(Math.max(x, mx + 8), mx + mw - w - 8);
+          y = Math.min(Math.max(y, my + 8), my + mh - h - 8);
+        }
+        await win.setSize(new LogicalSize(w, h));
+        await win.setPosition(new LogicalPosition(x, y));
+      } catch (err) {
+        console.error("[mini-bar] panel grow failed:", err);
+      }
+    })();
   }, [sessionOpen, orientation]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const togglePeer = async (e: React.MouseEvent) => {
@@ -143,7 +168,6 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
       )}
 
       <button
-        ref={lanButtonRef}
         type="button"
         data-testid="mini-bar-action-lan"
         className="mini-bar-btn"
@@ -175,7 +199,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
           collapsed={collapsed}
           toggleCollapsed={(key) => void toggleCollapsed(key)}
           onPickSession={() => setSessionOpen(false)}
-          style={{ position: "static", maxHeight: `${PANEL_LIST_H}px`, width: "100%" }}
+          style={{ position: "static", transform: "none", left: "auto", maxHeight: `${PANEL_LIST_H}px`, width: "100%" }}
           showPathTooltip={() => {}}
           hidePathTooltip={() => {}}
         />

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -1,12 +1,25 @@
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
 import {
   getCurrentWindow,
   LogicalPosition,
+  LogicalSize,
 } from "@tauri-apps/api/window";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { listen } from "@tauri-apps/api/event";
 import type { Status } from "../types/status";
 import type { Orientation, Edge } from "../utils/snap";
 import { inwardPopoverPos } from "../utils/popoverPos";
+import { fetchSessions } from "../hooks/useSessions";
+import {
+  groupSessions,
+  detectHome,
+  reflectActiveServices,
+  overlayClaudeState,
+  type Group,
+} from "../utils/sessionGroups";
+import { useSessionList } from "../hooks/useSessionList";
+import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
+import { SessionDropdown } from "./SessionDropdown";
 import "../styles/mini-bar.css";
 
 /** Peer-list popover window size — must match tauri.conf.json. */
@@ -14,15 +27,67 @@ const PEER_W = 280;
 const PEER_H = 260;
 const POPOVER_GAP = 8;
 
+/** Mini-mode session panel size (logical px) when the list is open. */
+const PANEL_W = 320;
+const PANEL_LIST_H = 360;
+
 interface MiniBarProps {
   status: Status;
   orientation: Orientation;
   edge: Edge;
+  snapToNearest: () => void;
   onRestore: () => void;
 }
 
-export function MiniBar({ status, orientation, edge, onRestore }: MiniBarProps) {
+export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }: MiniBarProps) {
   const lanButtonRef = useRef<HTMLButtonElement>(null);
+
+  const { enabled: sessionListEnabled } = useSessionList();
+  const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
+  const [sessionOpen, setSessionOpen] = useState(false);
+  const [groups, setGroups] = useState<Group[]>([]);
+
+  const toggleSession = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!sessionListEnabled) return;
+    if (sessionOpen) {
+      setSessionOpen(false);
+      return;
+    }
+    const list = await fetchSessions();
+    setGroups(groupSessions(overlayClaudeState(reflectActiveServices(list)), detectHome(list)));
+    setSessionOpen(true);
+  };
+
+  // Live refresh while open.
+  useEffect(() => {
+    if (!sessionOpen) return;
+    let cancelled = false;
+    const refresh = async () => {
+      const list = await fetchSessions();
+      if (cancelled) return;
+      setGroups(groupSessions(overlayClaudeState(reflectActiveServices(list)), detectHome(list)));
+    };
+    const unlistenP = listen("sessions-changed", () => void refresh());
+    return () => {
+      cancelled = true;
+      unlistenP.then((fn) => fn());
+    };
+  }, [sessionOpen]);
+
+  // Grow the bar window into a panel while the list is open.
+  // On close, re-snap (which resizes the window back to the bar).
+  useEffect(() => {
+    if (!sessionOpen) {
+      snapToNearest();
+      return;
+    }
+    const vertical = orientation === "vertical";
+    const w = vertical ? PANEL_W : Math.max(PANEL_W, 168);
+    const h = vertical ? PANEL_LIST_H : 40 + PANEL_LIST_H;
+    void getCurrentWindow().setSize(new LogicalSize(w, h)).catch(() => {});
+  }, [sessionOpen, orientation]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const togglePeer = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -57,6 +122,22 @@ export function MiniBar({ status, orientation, edge, onRestore }: MiniBarProps) 
     >
       <span data-testid="mini-bar-dot" className={`dot ${status}`} />
 
+      {sessionListEnabled && (
+        <button
+          type="button"
+          data-testid="mini-bar-action-task"
+          className="mini-bar-btn"
+          aria-label="Show sessions list"
+          aria-expanded={sessionOpen}
+          title="Session list"
+          onClick={toggleSession}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM7 9h10v2H7V9zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" />
+          </svg>
+        </button>
+      )}
+
       <button
         ref={lanButtonRef}
         type="button"
@@ -83,6 +164,18 @@ export function MiniBar({ status, orientation, edge, onRestore }: MiniBarProps) 
           <path d="M4 4h7v2H6v5H4V4zm9 0h7v7h-2V6h-5V4zM4 13h2v5h5v2H4v-7zm14 0h2v7h-7v-2h5v-5z" />
         </svg>
       </button>
+
+      {sessionOpen && (
+        <SessionDropdown
+          groups={groups}
+          collapsed={collapsed}
+          toggleCollapsed={(key) => void toggleCollapsed(key)}
+          onPickSession={() => setSessionOpen(false)}
+          style={{ position: "static", maxHeight: `${PANEL_LIST_H}px`, width: "100%" }}
+          showPathTooltip={() => {}}
+          hidePathTooltip={() => {}}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -21,6 +21,9 @@ import {
 import { useSessionList } from "../hooks/useSessionList";
 import { useLanList } from "../hooks/useLanList";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
+import { usePeers } from "../hooks/usePeers";
+import { useSoundSettings } from "../hooks/useSoundSettings";
+import { playAudio } from "../utils/audio";
 import { SessionDropdown } from "./SessionDropdown";
 import "../styles/mini-bar.css";
 import "../styles/status-pill.css";
@@ -52,16 +55,36 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
   // (you can't start a second visit). The session list stays available.
   const peerDisabled = status === "visiting";
   const { collapsed, toggle: toggleCollapsed } = useCollapsedSessionGroups();
+  const peers = usePeers();
   const [sessionOpen, setSessionOpen] = useState(false);
+  const [peerOpen, setPeerOpen] = useState(false);
   const [groups, setGroups] = useState<Group[]>([]);
+
+  // UI click feedback, gated by the master sound toggle — same as StatusPill.
+  const soundSettings = useSoundSettings();
+  const playClickTap = () => {
+    if (soundSettings.master) playAudio("tap");
+  };
 
   const toggleSession = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (!sessionListEnabled) return;
+    playClickTap();
     if (sessionOpen) {
       setSessionOpen(false);
       return;
+    }
+    // Only one popover at a time — hide the peer popover before opening.
+    // Guarded so a popover lookup failure never blocks opening the list.
+    try {
+      const popover = await WebviewWindow.getByLabel("peer-list");
+      if (popover && (await popover.isVisible())) {
+        await popover.hide().catch(() => {});
+        setPeerOpen(false);
+      }
+    } catch {
+      /* peer window unavailable — ignore */
     }
     const list = await fetchSessions();
     setGroups(groupSessions(overlayClaudeState(reflectActiveServices(list)), detectHome(list)));
@@ -131,18 +154,40 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
       const popover = await WebviewWindow.getByLabel("peer-list");
       await popover?.hide().catch(() => {});
     })();
+    setPeerOpen(false);
   }, [lanListEnabled, peerDisabled]);
+
+  // Reset the active-state highlight when the popover loses focus (e.g. the
+  // user clicks elsewhere) — same pattern as StatusPill.
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      const popover = await WebviewWindow.getByLabel("peer-list");
+      if (!popover) return;
+      const fn = await popover.onFocusChanged(({ payload: focused }) => {
+        if (!focused) setPeerOpen(false);
+      });
+      unlisten = fn;
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, []);
 
   const togglePeer = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (!lanListEnabled || peerDisabled) return;
+    playClickTap();
     const popover = await WebviewWindow.getByLabel("peer-list");
     if (!popover) return;
     if (await popover.isVisible()) {
       await popover.hide();
+      setPeerOpen(false);
       return;
     }
+    // Only one popover at a time — close the session list before showing.
+    if (sessionOpen) setSessionOpen(false);
     const main = getCurrentWindow();
     const sf = await main.scaleFactor();
     const pos = (await main.outerPosition()).toLogical(sf);
@@ -157,6 +202,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
     await popover.setPosition(new LogicalPosition(p.x, p.y));
     await popover.show();
     await popover.setFocus();
+    setPeerOpen(true);
   };
 
   return (
@@ -171,13 +217,13 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
         <button
           type="button"
           data-testid="mini-bar-action-task"
-          className="mini-bar-btn"
+          className={`pill-action-btn ${sessionOpen ? "is-active" : ""}`}
           aria-label="Show sessions list"
           aria-expanded={sessionOpen}
           title="Session list"
           onClick={toggleSession}
         >
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1s-2.4.84-2.82 2H5a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM7 9h10v2H7V9zm0 4h10v2H7v-2zm0 4h7v2H7v-2z" />
           </svg>
         </button>
@@ -187,13 +233,14 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
         <button
           type="button"
           data-testid="mini-bar-action-lan"
-          className="mini-bar-btn"
+          className={`pill-action-btn ${peerOpen ? "is-active" : ""} ${peers.length > 0 ? "has-peers" : ""}`}
           aria-label="Mime Around You"
+          aria-expanded={peerOpen}
           title="Peers nearby"
           onClick={togglePeer}
           disabled={peerDisabled}
         >
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
             <path d="M9 2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h2v3H5a1 1 0 0 0-1 1v1h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H6v-1h12v1h-1a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1h-2v-1a1 1 0 0 0-1-1h-6V9h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H9z" />
           </svg>
         </button>
@@ -202,12 +249,17 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
       <button
         type="button"
         data-testid="mini-bar-restore"
-        className="mini-bar-btn"
+        className="pill-action-btn"
         aria-label="Restore pet"
         title="Restore"
-        onClick={onRestore}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          playClickTap();
+          onRestore();
+        }}
       >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M4 4h7v2H6v5H4V4zm9 0h7v7h-2V6h-5V4zM4 13h2v5h5v2H4v-7zm14 0h2v7h-7v-2h5v-5z" />
         </svg>
       </button>

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -264,6 +264,24 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
         </svg>
       </button>
 
+      <span
+        data-testid="mini-bar-drag-handle"
+        data-drag-handle
+        className="mini-bar-grip"
+        role="separator"
+        aria-label="Drag to move"
+        title="Hold to move"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <circle cx="9" cy="6" r="1.6" />
+          <circle cx="15" cy="6" r="1.6" />
+          <circle cx="9" cy="12" r="1.6" />
+          <circle cx="15" cy="12" r="1.6" />
+          <circle cx="9" cy="18" r="1.6" />
+          <circle cx="15" cy="18" r="1.6" />
+        </svg>
+      </span>
+
       {sessionOpen && (
         <SessionDropdown
           groups={groups}

--- a/src/components/MiniBar.tsx
+++ b/src/components/MiniBar.tsx
@@ -259,7 +259,7 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
           onRestore();
         }}
       >
-        <svg className="pill-action-icon" width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <svg className="pill-action-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
         </svg>
       </button>
@@ -274,13 +274,13 @@ export function MiniBar({ status, orientation, edge, snapToNearest, onRestore }:
       >
         {/* Tight, flush 2×3 grip so its right edge hugs the bar edge the
             same ~8px as the status dot hugs the left. */}
-        <svg width="7" height="14" viewBox="0 0 7 14" fill="currentColor" aria-hidden="true">
-          <circle cx="1.5" cy="1.5" r="1.5" />
-          <circle cx="5.5" cy="1.5" r="1.5" />
-          <circle cx="1.5" cy="7" r="1.5" />
-          <circle cx="5.5" cy="7" r="1.5" />
-          <circle cx="1.5" cy="12.5" r="1.5" />
-          <circle cx="5.5" cy="12.5" r="1.5" />
+        <svg width="5" height="11" viewBox="0 0 5 11" fill="currentColor" aria-hidden="true">
+          <circle cx="1.1" cy="1.1" r="1.1" />
+          <circle cx="3.9" cy="1.1" r="1.1" />
+          <circle cx="1.1" cy="5.5" r="1.1" />
+          <circle cx="3.9" cy="5.5" r="1.1" />
+          <circle cx="1.1" cy="9.9" r="1.1" />
+          <circle cx="3.9" cy="9.9" r="1.1" />
         </svg>
       </span>
 

--- a/src/components/SessionDropdown.tsx
+++ b/src/components/SessionDropdown.tsx
@@ -1,0 +1,127 @@
+import { invoke } from "@tauri-apps/api/core";
+import { groupBasename, shellLabel, type Group } from "../utils/sessionGroups";
+
+interface SessionDropdownProps {
+  groups: Group[];
+  collapsed: Set<string>;
+  toggleCollapsed: (key: string) => void;
+  onPickSession: () => void;
+  style?: React.CSSProperties;
+  showPathTooltip: (el: HTMLElement, text: string) => void;
+  hidePathTooltip: () => void;
+}
+
+export function SessionDropdown({
+  groups,
+  collapsed,
+  toggleCollapsed,
+  onPickSession,
+  style,
+  showPathTooltip,
+  hidePathTooltip,
+}: SessionDropdownProps) {
+  return (
+    <div
+      data-testid="session-dropdown"
+      className="session-dropdown"
+      role="menu"
+      style={style}
+    >
+      {groups.length === 0 ? (
+        <div className="session-empty">No active terminals</div>
+      ) : (
+        groups.map((g) => {
+          const isCollapsed = collapsed.has(g.key);
+          const headContent = (
+            <>
+              {!g.isClaudeFallback && (
+                <span className="session-group-caret" aria-hidden="true" />
+              )}
+              <span className={`dot small ${g.state}`} />
+              <span className="session-group-title-row">
+                <span className="session-group-title">{groupBasename(g)}</span>
+                {g.pretty && g.pretty !== groupBasename(g) && (
+                  <span
+                    className="session-group-info"
+                    aria-label={`Full path: ${g.pretty}`}
+                    onMouseEnter={(e) =>
+                      showPathTooltip(e.currentTarget, g.pretty)
+                    }
+                    onMouseLeave={hidePathTooltip}
+                  >
+                    ?
+                  </span>
+                )}
+              </span>
+            </>
+          );
+          return (
+            <div
+              key={g.key}
+              className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
+              data-testid={`session-group-${g.key}`}
+            >
+              {g.isClaudeFallback ? (
+                <div className="session-group-head">{headContent}</div>
+              ) : (
+                <button
+                  type="button"
+                  className={`session-group-head clickable ${isCollapsed ? "collapsed" : ""}`}
+                  data-testid={`session-group-head-${g.key}`}
+                  aria-expanded={!isCollapsed}
+                  aria-controls={`session-children-${g.key}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleCollapsed(g.key);
+                  }}
+                >
+                  {headContent}
+                </button>
+              )}
+
+              {!g.isClaudeFallback && !isCollapsed && (
+                <div
+                  className="session-children"
+                  id={`session-children-${g.key}`}
+                >
+                  {g.sessions.map((s) => (
+                    <button
+                      key={s.pid}
+                      type="button"
+                      className={`session-child ${s.has_claude ? "has-claude" : ""}`}
+                      data-testid={`session-item-${s.pid}`}
+                      title="Click to bring this terminal to the front"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        invoke("focus_terminal", {
+                          pid: s.pid,
+                          tty: s.tty || null,
+                        }).catch((err) =>
+                          console.error("[focus_terminal]", err)
+                        );
+                        onPickSession();
+                      }}
+                    >
+                      <span className={`dot small ${s.ui_state}`} />
+                      <span className="session-child-label-row">
+                        <span className="session-child-label">
+                          {shellLabel(s)}
+                        </span>
+                        {s.has_claude && (
+                          <span
+                            className="session-child-claude"
+                            aria-label="Claude Code running"
+                          />
+                        )}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import {
   getCurrentWindow,
@@ -15,11 +14,10 @@ import {
   detectHome,
   reflectActiveServices,
   overlayClaudeState,
-  groupBasename,
-  shellLabel,
   type Group,
 } from "../utils/sessionGroups";
 import { useSessionList } from "../hooks/useSessionList";
+import { SessionDropdown } from "./SessionDropdown";
 import { useSessionGroupCount } from "../hooks/useSessionGroupCount";
 import { useLanList } from "../hooks/useLanList";
 import { useOpacity } from "../hooks/useOpacity";
@@ -438,107 +436,15 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange, onMin
       </div>
 
       {sessionListEnabled && sessionOpen && (
-        <div
-          data-testid="session-dropdown"
-          className="session-dropdown"
-          role="menu"
-          style={{
-            top: `${dropdownTop}px`,
-            maxHeight: `${dropdownMaxHeight}px`,
-          }}
-        >
-          {groups.length === 0 ? (
-            <div className="session-empty">No active terminals</div>
-          ) : (
-            groups.map((g) => {
-              const isCollapsed = collapsed.has(g.key);
-              const headContent = (
-                <>
-                  {!g.isClaudeFallback && (
-                    <span className="session-group-caret" aria-hidden="true" />
-                  )}
-                  <span className={`dot small ${g.state}`} />
-                  <span className="session-group-title-row">
-                    <span className="session-group-title">
-                      {groupBasename(g)}
-                    </span>
-                    {g.pretty && g.pretty !== groupBasename(g) && (
-                      <span
-                        className="session-group-info"
-                        aria-label={`Full path: ${g.pretty}`}
-                        onMouseEnter={(e) =>
-                          showPathTooltip(e.currentTarget, g.pretty)
-                        }
-                        onMouseLeave={hidePathTooltip}
-                      >
-                        ?
-                      </span>
-                    )}
-                  </span>
-                </>
-              );
-              return (
-                <div
-                  key={g.key}
-                  className={`session-group ${g.isClaudeFallback ? "claude" : ""}`}
-                  data-testid={`session-group-${g.key}`}
-                >
-                  {g.isClaudeFallback ? (
-                    <div className="session-group-head">{headContent}</div>
-                  ) : (
-                    <button
-                      type="button"
-                      className={`session-group-head clickable ${isCollapsed ? "collapsed" : ""}`}
-                      data-testid={`session-group-head-${g.key}`}
-                      aria-expanded={!isCollapsed}
-                      aria-controls={`session-children-${g.key}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void toggleCollapsed(g.key);
-                      }}
-                    >
-                      {headContent}
-                    </button>
-                  )}
-
-                  {!g.isClaudeFallback && !isCollapsed && (
-                    <div
-                      className="session-children"
-                      id={`session-children-${g.key}`}
-                    >
-                      {g.sessions.map((s) => (
-                        <button
-                          key={s.pid}
-                          type="button"
-                          className={`session-child ${s.has_claude ? "has-claude" : ""}`}
-                          data-testid={`session-item-${s.pid}`}
-                          title="Click to bring this terminal to the front"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            invoke("focus_terminal", { pid: s.pid, tty: s.tty || null })
-                              .catch((err) => console.error("[focus_terminal]", err));
-                            setSessionOpen(false);
-                          }}
-                        >
-                          <span className={`dot small ${s.ui_state}`} />
-                          <span className="session-child-label-row">
-                            <span className="session-child-label">{shellLabel(s)}</span>
-                            {s.has_claude && (
-                              <span
-                                className="session-child-claude"
-                                aria-label="Claude Code running"
-                              />
-                            )}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              );
-            })
-          )}
-        </div>
+        <SessionDropdown
+          groups={groups}
+          collapsed={collapsed}
+          toggleCollapsed={(key) => void toggleCollapsed(key)}
+          onPickSession={() => setSessionOpen(false)}
+          style={{ top: `${dropdownTop}px`, maxHeight: `${dropdownMaxHeight}px` }}
+          showPathTooltip={showPathTooltip}
+          hidePathTooltip={hidePathTooltip}
+        />
       )}
 
       {pathTooltip &&

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -35,6 +35,11 @@ interface StatusPillProps {
    * window while the fixed-positioned dropdown is visible.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * When provided, renders a minimize button that collapses the pet into
+   * mini-bar mode. Omitted in contexts where minimizing isn't allowed.
+   */
+  onMinimize?: () => void;
 }
 
 const dotClassMap: Record<Status, string> = {
@@ -225,7 +230,7 @@ async function computePopoverScreenPos(
   return new LogicalPosition(Math.round(left), Math.round(top));
 }
 
-export function StatusPill({ status, glow, disabled = false, onOpenChange }: StatusPillProps) {
+export function StatusPill({ status, glow, disabled = false, onOpenChange, onMinimize }: StatusPillProps) {
   // --- Session list state ---
   const [sessionOpen, setSessionOpen] = useState(false);
   const [groups, setGroups] = useState<Group[]>([]);
@@ -481,6 +486,32 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange }: Sta
         </span>
 
         <div className="pill-actions" data-testid="pill-actions">
+          {onMinimize && (
+            <button
+              type="button"
+              data-testid="pill-action-minimize"
+              className="pill-action-btn"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                playClickTap();
+                onMinimize();
+              }}
+              aria-label="Minimize to bar"
+              title="Minimize to bar"
+            >
+              <svg
+                className="pill-action-icon"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M6 19h12v2H6z" />
+              </svg>
+            </button>
+          )}
           {sessionListEnabled && (
             <button
               type="button"

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -349,32 +349,6 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange, onMin
         </span>
 
         <div className="pill-actions" data-testid="pill-actions">
-          {onMinimize && (
-            <button
-              type="button"
-              data-testid="pill-action-minimize"
-              className="pill-action-btn"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                playClickTap();
-                onMinimize();
-              }}
-              aria-label="Minimize to bar"
-              title="Minimize to bar"
-            >
-              <svg
-                className="pill-action-icon"
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M6 19h12v2H6z" />
-              </svg>
-            </button>
-          )}
           {sessionListEnabled && (
             <button
               type="button"
@@ -431,6 +405,33 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange, onMin
               </span>
             )}
           </button>
+          )}
+
+          {onMinimize && (
+            <button
+              type="button"
+              data-testid="pill-action-minimize"
+              className="pill-action-btn"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                playClickTap();
+                onMinimize();
+              }}
+              aria-label="Minimize to bar"
+              title="Minimize to bar"
+            >
+              <svg
+                className="pill-action-icon"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z" />
+              </svg>
+            </button>
           )}
         </div>
       </div>

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -423,8 +423,8 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange, onMin
             >
               <svg
                 className="pill-action-icon"
-                width="12"
-                height="12"
+                width="16"
+                height="16"
                 viewBox="0 0 24 24"
                 fill="currentColor"
                 aria-hidden="true"

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -9,7 +9,16 @@ import {
 } from "@tauri-apps/api/window";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { Status } from "../types/status";
-import { fetchSessions, type SessionInfo } from "../hooks/useSessions";
+import { fetchSessions } from "../hooks/useSessions";
+import {
+  groupSessions,
+  detectHome,
+  reflectActiveServices,
+  overlayClaudeState,
+  groupBasename,
+  shellLabel,
+  type Group,
+} from "../utils/sessionGroups";
 import { useSessionList } from "../hooks/useSessionList";
 import { useSessionGroupCount } from "../hooks/useSessionGroupCount";
 import { useLanList } from "../hooks/useLanList";
@@ -61,150 +70,6 @@ const labelMap: Record<Status, string> = {
   searching: "Searching...",
   visiting: "Visiting...",
 };
-
-// Priority for picking a group's summary state: busy > service > idle.
-const statePriority: Record<string, number> = {
-  busy: 3,
-  service: 2,
-  idle: 1,
-};
-
-function groupState(sessions: SessionInfo[]): string {
-  let best = "idle";
-  let bestP = 0;
-  for (const s of sessions) {
-    const p = statePriority[s.ui_state] ?? 0;
-    if (p > bestP) {
-      bestP = p;
-      best = s.ui_state;
-    }
-  }
-  return best;
-}
-
-/** Turn /Users/you/dev/foo into ~/dev/foo when home is known. */
-function prettyPath(pwd: string, home?: string): string {
-  if (!pwd) return "";
-  if (home && pwd.startsWith(home)) return "~" + pwd.slice(home.length);
-  return pwd;
-}
-
-/** Last path segment of a group (the leaf folder name). Falls back to the
- *  pretty path or a sensible string when pwd is missing. */
-function groupBasename(g: { pwd: string; pretty: string; sessions: SessionInfo[] }): string {
-  if (g.pwd) {
-    const leaf = g.pwd.split("/").filter(Boolean).pop();
-    if (leaf) return leaf;
-  }
-  return g.pretty || g.sessions[0]?.title || "";
-}
-
-/** Human-readable label for what's happening in a single shell. */
-function shellLabel(s: SessionInfo): string {
-  if (s.has_claude) return "claude";
-  if (s.fg_cmd) {
-    return s.fg_cmd.replace(/^-/, "");
-  }
-  if (s.ui_state === "busy" && s.busy_type) return s.busy_type;
-  if (s.ui_state === "service") return "service";
-  return "idle";
-}
-
-interface Group {
-  key: string;
-  pwd: string;
-  pretty: string;
-  sessions: SessionInfo[];
-  state: string;
-  isClaudeFallback: boolean;
-}
-
-function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
-  const claudeVirtual = sessions.find((s) => s.pid === 0);
-  const anyShellHasClaude = sessions.some((s) => s.pid !== 0 && s.has_claude);
-
-  const byKey = new Map<string, { pwd: string; list: SessionInfo[] }>();
-  for (const s of sessions) {
-    if (s.pid === 0) continue;
-    if (s.is_claude_proc) continue;
-    const key = s.pwd || s.title || String(s.pid);
-    if (!byKey.has(key)) byKey.set(key, { pwd: s.pwd, list: [] });
-    byKey.get(key)!.list.push(s);
-  }
-
-  const groups: Group[] = [];
-  for (const [key, { pwd, list }] of byKey.entries()) {
-    const pretty = pwd
-      ? prettyPath(pwd, home)
-      : list[0].title || `pid ${list[0].pid}`;
-    // Sort children within a group by pid so row order stays stable
-    // across refreshes. The backend returns sessions from a HashMap,
-    // so iteration order can change between invocations — without this
-    // sort, rows can swap under the cursor every 3s refresh and the
-    // CSS :hover highlight flickers off the row you're hovering.
-    list.sort((a, b) => a.pid - b.pid);
-    groups.push({
-      key,
-      pwd,
-      pretty,
-      sessions: list,
-      state: groupState(list),
-      isClaudeFallback: false,
-    });
-  }
-
-  groups.sort((a, b) => {
-    const pa = statePriority[a.state] ?? 0;
-    const pb = statePriority[b.state] ?? 0;
-    if (pa !== pb) return pb - pa;
-    return a.pretty.localeCompare(b.pretty);
-  });
-
-  if (claudeVirtual && !anyShellHasClaude) {
-    groups.push({
-      key: "claude-virtual",
-      pwd: "",
-      pretty: "Claude Code",
-      sessions: [claudeVirtual],
-      state: claudeVirtual.ui_state,
-      isClaudeFallback: true,
-    });
-  }
-
-  return groups;
-}
-
-function detectHome(sessions: SessionInfo[]): string | undefined {
-  for (const s of sessions) {
-    const m = s.pwd.match(/^(\/Users\/[^/]+|\/home\/[^/]+)/);
-    if (m) return m[1];
-  }
-  return undefined;
-}
-
-function reflectActiveServices(sessions: SessionInfo[]): SessionInfo[] {
-  return sessions.map((s) =>
-    s.busy_type === "service" && s.ui_state === "idle"
-      ? { ...s, ui_state: "service" }
-      : s,
-  );
-}
-
-function overlayClaudeState(sessions: SessionInfo[]): SessionInfo[] {
-  const sessionByPid = new Map<number, SessionInfo>();
-  for (const s of sessions) sessionByPid.set(s.pid, s);
-
-  return sessions.map((s) => {
-    if (!s.has_claude) return s;
-    const claudeSession =
-      (s.claude_pid != null && sessionByPid.get(s.claude_pid)) ||
-      sessionByPid.get(0);
-    if (!claudeSession) return s;
-    const claudeP = statePriority[claudeSession.ui_state] ?? 0;
-    const ownP = statePriority[s.ui_state] ?? 0;
-    return ownP >= claudeP ? s : { ...s, ui_state: claudeSession.ui_state };
-  });
-}
 
 /** Width of the peer-list popover window — must match tauri.conf.json. */
 const POPOVER_WIDTH = 280;

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -423,8 +423,8 @@ export function StatusPill({ status, glow, disabled = false, onOpenChange, onMin
             >
               <svg
                 className="pill-action-icon"
-                width="16"
-                height="16"
+                width="12"
+                height="12"
                 viewBox="0 0 24 24"
                 fill="currentColor"
                 aria-hidden="true"

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -1,18 +1,25 @@
 import { useState, useCallback } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
-export function useDrag() {
+export function useDrag(onDragEnd?: () => void) {
   const [dragging, setDragging] = useState(false);
 
-  const onMouseDown = useCallback(async (e: React.MouseEvent) => {
-    if (e.button !== 0) return;
-    // Don't start a window drag when interacting with the pill dropdown.
-    // Match by data-testid rather than class name per project conventions.
-    if ((e.target as HTMLElement).closest('[data-testid="status-pill-wrap"]')) return;
-    setDragging(true);
-    await getCurrentWindow().startDragging();
-    setDragging(false);
-  }, []);
+  const onMouseDown = useCallback(
+    async (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      const target = e.target as HTMLElement | null;
+      // Don't start a window drag when interacting with the pill dropdown.
+      // Match by data-testid rather than class name per project conventions.
+      if (target?.closest('[data-testid="status-pill-wrap"]')) return;
+      // Don't drag when pressing a button (minimize/restore/tools/session).
+      if (target?.closest("button")) return;
+      setDragging(true);
+      await getCurrentWindow().startDragging();
+      setDragging(false);
+      onDragEnd?.();
+    },
+    [onDragEnd]
+  );
 
   return { dragging, onMouseDown };
 }

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -1,24 +1,39 @@
 import { useState, useCallback } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
-export function useDrag(onDragEnd?: () => void) {
+interface UseDragOptions {
+  /**
+   * When true, a drag only starts if the press began on an element marked
+   * with `data-drag-handle` (used by the mini bar's grip). Pressing anywhere
+   * else does nothing — the window stays put.
+   */
+  requireHandle?: boolean;
+}
+
+export function useDrag(onDragEnd?: () => void, opts: UseDragOptions = {}) {
+  const { requireHandle = false } = opts;
   const [dragging, setDragging] = useState(false);
 
   const onMouseDown = useCallback(
     async (e: React.MouseEvent) => {
       if (e.button !== 0) return;
       const target = e.target as HTMLElement | null;
-      // Don't start a window drag when interacting with the pill dropdown.
-      // Match by data-testid rather than class name per project conventions.
-      if (target?.closest('[data-testid="status-pill-wrap"]')) return;
-      // Don't drag when pressing a button (minimize/restore/tools/session).
-      if (target?.closest("button")) return;
+      if (requireHandle) {
+        // Only the explicit drag handle initiates a move.
+        if (!target?.closest("[data-drag-handle]")) return;
+      } else {
+        // Don't start a window drag when interacting with the pill dropdown.
+        // Match by data-testid rather than class name per project conventions.
+        if (target?.closest('[data-testid="status-pill-wrap"]')) return;
+        // Don't drag when pressing a button (minimize/restore/tools/session).
+        if (target?.closest("button")) return;
+      }
       setDragging(true);
       await getCurrentWindow().startDragging();
       setDragging(false);
       onDragEnd?.();
     },
-    [onDragEnd]
+    [onDragEnd, requireHandle]
   );
 
   return { dragging, onMouseDown };

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -7,6 +7,7 @@ import {
   LogicalSize,
   type Monitor,
 } from "@tauri-apps/api/window";
+import { invoke } from "@tauri-apps/api/core";
 import { getDefaultPetSize } from "./useWindowDefaultSize";
 import { useSessionList } from "./useSessionList";
 import { useLanList } from "./useLanList";
@@ -214,12 +215,17 @@ export function useMiniMode(scale: number) {
       console.error("[mini-bar] capture pet position failed:", err);
     }
     setMode("mini");
+    // Make the window non-movable to the OS so macOS Sequoia won't tile it when
+    // it reaches a screen edge (we still move it via setPosition).
+    void invoke("set_window_movable", { movable: false }).catch(() => {});
     await snapToNearest();
   }, [snapToNearest]);
 
   const exitMini = useCallback(async () => {
     const win = getCurrentWindow();
     setMode("pet");
+    // Restore movability so the native pet drag works again.
+    void invoke("set_window_movable", { movable: true }).catch(() => {});
     try {
       const def = getDefaultPetSize(scale);
       await win.setSize(new LogicalSize(def.width, def.height));

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -7,6 +7,7 @@ import {
   LogicalSize,
   type Monitor,
 } from "@tauri-apps/api/window";
+import { warn } from "@tauri-apps/plugin-log";
 import { getDefaultPetSize } from "./useWindowDefaultSize";
 import { useSessionList } from "./useSessionList";
 import { useLanList } from "./useLanList";
@@ -208,10 +209,10 @@ export function useMiniMode(scale: number) {
         x: e.screenX,
         y: e.screenY,
       };
+      let lastDock: { x: number; y: number; width: number; height: number } | null = null;
       let raf = 0;
       let curW = -1;
       let curH = -1;
-      let logged = false;
 
       const apply = () => {
         raf = 0;
@@ -226,14 +227,7 @@ export function useMiniMode(scale: number) {
           barShort,
           DEFAULT_MARGINS
         );
-        if (!logged) {
-          logged = true;
-          console.log("[mini-bar] drag dock", {
-            cursor: pending,
-            monitor,
-            dock,
-          });
-        }
+        lastDock = { x: dock.x, y: dock.y, width: dock.width, height: dock.height };
         setOrientation(dock.orientation);
         setEdge(dock.edge);
         if (dock.width !== curW || dock.height !== curH) {
@@ -253,6 +247,19 @@ export function useMiniMode(scale: number) {
         document.removeEventListener("mouseup", onUp);
         if (raf) cancelAnimationFrame(raf);
         apply(); // ensure the final position is committed
+        // DIAGNOSTIC: compare intended dock vs the window's actual placement.
+        void (async () => {
+          try {
+            const sf = await win.scaleFactor();
+            const actual = (await win.outerPosition()).toLogical(sf);
+            const size = (await win.outerSize()).toLogical(sf);
+            void warn(
+              `[mini-bar] DBG monitors=${JSON.stringify(monitors)} cursor=${JSON.stringify(pending)} sf=${sf} intended=${JSON.stringify(lastDock)} actualPos=${Math.round(actual.x)},${Math.round(actual.y)} actualSize=${Math.round(size.width)}x${Math.round(size.height)} screen=${window.screen.width}x${window.screen.height} dpr=${window.devicePixelRatio}`
+            );
+          } catch (err) {
+            void warn(`[mini-bar] DBG failed: ${String(err)}`);
+          }
+        })();
       };
 
       document.addEventListener("mousemove", onMove);

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -22,9 +22,9 @@ import {
 
 export type Mode = "pet" | "mini";
 
-/** Edge gaps for the docked bar: hug the screen edge (2px), but keep enough
- *  top clearance to sit just below the macOS menu bar. */
-const MINI_MARGINS: SnapMargins = { edge: 2, menuBar: 28 };
+/** Edge gaps for the docked bar: flush against the screen edge (0px), but keep
+ *  enough top clearance to sit just below the macOS menu bar. */
+const MINI_MARGINS: SnapMargins = { edge: 0, menuBar: 28 };
 
 /** Convert a Tauri Monitor (physical px) to a logical-px rect, the same space
  *  as event.screenX/Y and Tauri's LogicalPosition (setPosition). */

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -74,81 +74,12 @@ const clamp = (v: number, lo: number, hi: number) =>
   Math.max(lo, Math.min(v, hi));
 
 /**
- * Dock geometry for a given cursor position on a monitor: the bar is glued to
- * whichever edge the cursor is NEAREST, and positioned along that edge so the
- * bar's leading corner sits at `cursorAlong + alongOffset` (clamped on-screen).
- * Pass the offset captured at grab time so the bar keeps the point you grabbed
- * instead of recentring on the cursor. When `alongOffset` is null the bar is
- * centred on the cursor. The top edge uses the larger menu-bar margin.
- */
-function dockToCursor(
-  cursorX: number,
-  cursorY: number,
-  monitor: Rect,
-  barLong: number,
-  barShort: number,
-  margins: SnapMargins,
-  alongOffset: number | null
-): { x: number; y: number; width: number; height: number; edge: Edge; orientation: Orientation } {
-  const distLeft = cursorX - monitor.x;
-  const distRight = monitor.x + monitor.width - cursorX;
-  const distTop = cursorY - monitor.y;
-  const distBottom = monitor.y + monitor.height - cursorY;
-  const min = Math.min(distLeft, distRight, distTop, distBottom);
-
-  let edge: Edge;
-  if (min === distLeft) edge = "left";
-  else if (min === distRight) edge = "right";
-  else if (min === distTop) edge = "top";
-  else edge = "bottom";
-
-  const vertical = edge === "left" || edge === "right";
-  const width = vertical ? barShort : barLong;
-  const height = vertical ? barLong : barShort;
-
-  let x: number;
-  let y: number;
-  if (vertical) {
-    x =
-      edge === "left"
-        ? monitor.x + margins.edge
-        : monitor.x + monitor.width - width - margins.edge;
-    const alongY = alongOffset == null ? cursorY - height / 2 : cursorY + alongOffset;
-    y = clamp(
-      alongY,
-      monitor.y + margins.menuBar,
-      monitor.y + monitor.height - height - margins.edge
-    );
-  } else {
-    y =
-      edge === "top"
-        ? monitor.y + margins.menuBar
-        : monitor.y + monitor.height - height - margins.edge;
-    const alongX = alongOffset == null ? cursorX - width / 2 : cursorX + alongOffset;
-    x = clamp(
-      alongX,
-      monitor.x + margins.edge,
-      monitor.x + monitor.width - width - margins.edge
-    );
-  }
-
-  return {
-    x: Math.round(x),
-    y: Math.round(y),
-    width,
-    height,
-    edge,
-    orientation: vertical ? "vertical" : "horizontal",
-  };
-}
-
-/**
  * Owns the pet <-> mini transition and the window mechanics.
  *
- * Mini mode behaves like an edge-docked toolbar: the bar is always glued to a
- * screen edge. Holding the grip drags it ALONG the nearest edge; pulling the
- * cursor toward a different edge re-docks the bar to that edge. It never floats
- * free. No persistence (the app always launches in pet mode).
+ * Mini mode behaves like a magnet-docked toolbar: while the grip is held the
+ * bar follows the cursor freely (2D), and on release it snaps to the nearest
+ * screen edge. At rest it is always docked to an edge. No persistence (the app
+ * always launches in pet mode).
  */
 export function useMiniMode(scale: number) {
   const [mode, setMode] = useState<Mode>("pet");
@@ -196,10 +127,11 @@ export function useMiniMode(scale: number) {
     }
   }, [scale, barLongLogical]);
 
-  // Edge-constrained drag. Started from the grip's mousedown. While the button
-  // is held, the bar tracks the global cursor (event.screenX/Y, delivered to
-  // this window for the whole press) and docks to whichever monitor + edge the
-  // cursor is on, sliding along it. rAF-throttled so we don't flood the IPC.
+  // Drag. Started from the grip's mousedown. While the button is held the bar
+  // follows the cursor FREELY in 2D (so it goes wherever the pointer goes), and
+  // on release it snaps to the nearest edge (snapToNearest). The grab offset is
+  // captured so the grabbed point stays under the cursor (no jump on grab), and
+  // a plain click never moves the bar. rAF-throttled to avoid flooding the IPC.
   const startEdgeDrag = useCallback(
     async (e: React.MouseEvent) => {
       if (e.button !== 0) return;
@@ -209,77 +141,58 @@ export function useMiniMode(scale: number) {
       const win = getCurrentWindow();
       const monitors = await allMonitorRects();
       if (monitors.length === 0) return;
-      const barLong = Math.round(barLongLogical * scale);
-      const barShort = Math.round(BAR_SHORT * scale);
-
-      // Capture the grab point so the bar keeps its position relative to the
-      // cursor (no jump-to-centre on grab). Derive the current orientation from
-      // the window's own dimensions, and the along-axis offset from its position.
       const sf = await win.scaleFactor();
       const startPos = (await win.outerPosition()).toLogical(sf);
       const startSize = (await win.outerSize()).toLogical(sf);
-      let grabOrientation: Orientation =
-        startSize.width <= startSize.height ? "vertical" : "horizontal";
-      let grabOffset =
-        grabOrientation === "vertical"
-          ? startPos.y - e.screenY
-          : startPos.x - e.screenX;
+      const w = Math.round(startSize.width);
+      const h = Math.round(startSize.height);
+      // Offset between the window's top-left and the cursor at grab time, so
+      // the grabbed point tracks the cursor instead of recentring.
+      const offX = startPos.x - e.screenX;
+      const offY = startPos.y - e.screenY;
+
+      // Free 2D position for a cursor, clamped to stay on its monitor (and
+      // below the menu bar). Keeps the bar's current size during the drag.
+      const freePos = (cx: number, cy: number) => {
+        const m = monitorContaining(cx, cy, monitors) ?? monitors[0];
+        return {
+          x: Math.round(clamp(cx + offX, m.x, m.x + m.width - w)),
+          y: Math.round(
+            clamp(cy + offY, m.y + MINI_MARGINS.menuBar, m.y + m.height - h)
+          ),
+        };
+      };
 
       let pending: { x: number; y: number } | null = null;
       let raf = 0;
-      let curW = -1;
-      let curH = -1;
 
       const apply = () => {
         raf = 0;
         if (!pending) return;
-        const monitor =
-          monitorContaining(pending.x, pending.y, monitors) ?? monitors[0];
-
-        // Peek the edge the cursor is nearest to decide orientation. When it
-        // flips to a different edge, recentre (the grab offset no longer maps
-        // across axes); otherwise keep the captured grab offset.
-        const peek = dockToCursor(pending.x, pending.y, monitor, barLong, barShort, MINI_MARGINS, null);
-        if (peek.orientation !== grabOrientation) {
-          grabOrientation = peek.orientation;
-          grabOffset = -barLong / 2; // centre on the cursor after a flip
-        }
-
-        const dock = dockToCursor(
-          pending.x,
-          pending.y,
-          monitor,
-          barLong,
-          barShort,
-          MINI_MARGINS,
-          grabOffset
-        );
-        setOrientation(dock.orientation);
-        setEdge(dock.edge);
-        if (dock.width !== curW || dock.height !== curH) {
-          curW = dock.width;
-          curH = dock.height;
-          void win.setSize(new LogicalSize(dock.width, dock.height)).catch(() => {});
-        }
-        void win.setPosition(new LogicalPosition(dock.x, dock.y)).catch(() => {});
+        const p = freePos(pending.x, pending.y);
+        void win.setPosition(new LogicalPosition(p.x, p.y)).catch(() => {});
       };
 
       const onMove = (ev: MouseEvent) => {
         pending = { x: ev.screenX, y: ev.screenY };
         if (!raf) raf = requestAnimationFrame(apply);
       };
-      const onUp = () => {
+      const onUp = async () => {
         document.removeEventListener("mousemove", onMove);
         document.removeEventListener("mouseup", onUp);
         if (raf) cancelAnimationFrame(raf);
-        if (pending) apply(); // commit final position only if actually moved
+        if (!pending) return; // plain click — never moved
+        // Commit the final free position, then snap to the nearest edge.
+        const p = freePos(pending.x, pending.y);
+        await win.setPosition(new LogicalPosition(p.x, p.y)).catch(() => {});
+        void snapToNearest();
       };
 
       document.addEventListener("mousemove", onMove);
       document.addEventListener("mouseup", onUp);
-      // No immediate apply(): a plain click must not move the bar.
+      // No immediate move: a plain click must not move the bar.
     },
-    [scale, barLongLogical]
+    [snapToNearest]
   );
 
   // Re-fit the bar when the visible-tool count changes (a tool toggled in

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -12,6 +12,7 @@ import {
   BAR_SHORT,
   DEFAULT_MARGINS,
   type Orientation,
+  type Edge,
   type Rect,
 } from "../utils/snap";
 
@@ -37,6 +38,7 @@ async function monitorLogicalRect(): Promise<Rect | null> {
 export function useMiniMode(scale: number) {
   const [mode, setMode] = useState<Mode>("pet");
   const [orientation, setOrientation] = useState<Orientation>("horizontal");
+  const [edge, setEdge] = useState<Edge>("bottom");
   const savedPetPosRef = useRef<LogicalPosition | null>(null);
 
   const snapToNearest = useCallback(async () => {
@@ -60,6 +62,7 @@ export function useMiniMode(scale: number) {
         DEFAULT_MARGINS
       );
       setOrientation(snap.orientation);
+      setEdge(snap.edge);
       await win.setSize(new LogicalSize(snap.width, snap.height));
       await win.setPosition(new LogicalPosition(snap.x, snap.y));
     } catch (err) {
@@ -97,5 +100,5 @@ export function useMiniMode(scale: number) {
     }
   }, [scale]);
 
-  return { mode, orientation, enterMini, exitMini, snapToNearest };
+  return { mode, orientation, edge, enterMini, exitMini, snapToNearest };
 }

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getCurrentWindow,
   currentMonitor,
@@ -6,9 +6,11 @@ import {
   LogicalSize,
 } from "@tauri-apps/api/window";
 import { getDefaultPetSize } from "./useWindowDefaultSize";
+import { useSessionList } from "./useSessionList";
+import { useLanList } from "./useLanList";
 import {
   computeSnap,
-  BAR_LONG,
+  miniBarLength,
   BAR_SHORT,
   DEFAULT_MARGINS,
   type Orientation,
@@ -41,6 +43,14 @@ export function useMiniMode(scale: number) {
   const [edge, setEdge] = useState<Edge>("bottom");
   const savedPetPosRef = useRef<LogicalPosition | null>(null);
 
+  // Size the bar to hug its content: dot + restore button + whichever
+  // tools are enabled (must match which buttons MiniBar actually renders).
+  const { enabled: sessionListEnabled } = useSessionList();
+  const { enabled: lanListEnabled } = useLanList();
+  const barButtons =
+    1 /* restore */ + (sessionListEnabled ? 1 : 0) + (lanListEnabled ? 1 : 0);
+  const barLongLogical = miniBarLength(barButtons);
+
   const snapToNearest = useCallback(async () => {
     const win = getCurrentWindow();
     try {
@@ -52,7 +62,7 @@ export function useMiniMode(scale: number) {
       const sf = await win.scaleFactor();
       const pos = (await win.outerPosition()).toLogical(sf);
       const size = (await win.outerSize()).toLogical(sf);
-      const barLong = Math.round(BAR_LONG * scale);
+      const barLong = Math.round(barLongLogical * scale);
       const barShort = Math.round(BAR_SHORT * scale);
       const snap = computeSnap(
         { x: pos.x, y: pos.y, width: size.width, height: size.height },
@@ -68,7 +78,13 @@ export function useMiniMode(scale: number) {
     } catch (err) {
       console.error("[mini-bar] snap failed:", err);
     }
-  }, [scale]);
+  }, [scale, barLongLogical]);
+
+  // Re-fit the bar when the visible-tool count changes (a tool toggled in
+  // Settings while minimized) so the bar always hugs its content.
+  useEffect(() => {
+    if (mode === "mini") void snapToNearest();
+  }, [barLongLogical, mode, snapToNearest]);
 
   const enterMini = useCallback(async () => {
     const win = getCurrentWindow();

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -43,12 +43,14 @@ export function useMiniMode(scale: number) {
   const [edge, setEdge] = useState<Edge>("bottom");
   const savedPetPosRef = useRef<LogicalPosition | null>(null);
 
-  // Size the bar to hug its content: dot + restore button + whichever
-  // tools are enabled (must match which buttons MiniBar actually renders).
+  // Size the bar to hug its content: dot + restore + grip handle + whichever
+  // tools are enabled (must match which elements MiniBar actually renders).
   const { enabled: sessionListEnabled } = useSessionList();
   const { enabled: lanListEnabled } = useLanList();
   const barButtons =
-    1 /* restore */ + (sessionListEnabled ? 1 : 0) + (lanListEnabled ? 1 : 0);
+    2 /* restore + grip */ +
+    (sessionListEnabled ? 1 : 0) +
+    (lanListEnabled ? 1 : 0);
   const barLongLogical = miniBarLength(barButtons);
 
   const snapToNearest = useCallback(async () => {

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -1,0 +1,100 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  getCurrentWindow,
+  currentMonitor,
+  LogicalPosition,
+  LogicalSize,
+} from "@tauri-apps/api/window";
+import { getDefaultPetSize } from "./useWindowDefaultSize";
+import {
+  computeSnap,
+  BAR_LONG,
+  BAR_SHORT,
+  DEFAULT_MARGINS,
+  type Orientation,
+  type Rect,
+} from "../utils/snap";
+
+export type Mode = "pet" | "mini";
+
+/** Read the current monitor as a logical-pixel rect, or null if unavailable. */
+async function monitorLogicalRect(): Promise<Rect | null> {
+  const m = await currentMonitor();
+  if (!m) return null;
+  const sf = m.scaleFactor || 1;
+  return {
+    x: m.position.x / sf,
+    y: m.position.y / sf,
+    width: m.size.width / sf,
+    height: m.size.height / sf,
+  };
+}
+
+/**
+ * Owns the pet <-> mini transition and the window resize/snap mechanics.
+ * No persistence (the app always launches in pet mode).
+ */
+export function useMiniMode(scale: number) {
+  const [mode, setMode] = useState<Mode>("pet");
+  const [orientation, setOrientation] = useState<Orientation>("horizontal");
+  const savedPetPosRef = useRef<LogicalPosition | null>(null);
+
+  const snapToNearest = useCallback(async () => {
+    const win = getCurrentWindow();
+    try {
+      const monitor = await monitorLogicalRect();
+      if (!monitor) {
+        console.warn("[mini-bar] no monitor; leaving bar where dropped");
+        return;
+      }
+      const sf = await win.scaleFactor();
+      const pos = (await win.outerPosition()).toLogical(sf);
+      const size = (await win.outerSize()).toLogical(sf);
+      const barLong = Math.round(BAR_LONG * scale);
+      const barShort = Math.round(BAR_SHORT * scale);
+      const snap = computeSnap(
+        { x: pos.x, y: pos.y, width: size.width, height: size.height },
+        monitor,
+        barLong,
+        barShort,
+        DEFAULT_MARGINS
+      );
+      setOrientation(snap.orientation);
+      await win.setSize(new LogicalSize(snap.width, snap.height));
+      await win.setPosition(new LogicalPosition(snap.x, snap.y));
+    } catch (err) {
+      console.error("[mini-bar] snap failed:", err);
+    }
+  }, [scale]);
+
+  const enterMini = useCallback(async () => {
+    const win = getCurrentWindow();
+    try {
+      const sf = await win.scaleFactor();
+      const pos = (await win.outerPosition()).toLogical(sf);
+      savedPetPosRef.current = new LogicalPosition(
+        Math.round(pos.x),
+        Math.round(pos.y)
+      );
+    } catch (err) {
+      console.error("[mini-bar] capture pet position failed:", err);
+    }
+    setMode("mini");
+    await snapToNearest();
+  }, [snapToNearest]);
+
+  const exitMini = useCallback(async () => {
+    const win = getCurrentWindow();
+    setMode("pet");
+    try {
+      const def = getDefaultPetSize(scale);
+      await win.setSize(new LogicalSize(def.width, def.height));
+      const saved = savedPetPosRef.current;
+      if (saved) await win.setPosition(saved);
+    } catch (err) {
+      console.error("[mini-bar] restore failed:", err);
+    }
+  }, [scale]);
+
+  return { mode, orientation, enterMini, exitMini, snapToNearest };
+}

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -91,6 +91,7 @@ export function useMiniMode(scale: number) {
       await win.setSize(new LogicalSize(def.width, def.height));
       const saved = savedPetPosRef.current;
       if (saved) await win.setPosition(saved);
+      savedPetPosRef.current = null;
     } catch (err) {
       console.error("[mini-bar] restore failed:", err);
     }

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -33,6 +33,56 @@ async function monitorLogicalRect(): Promise<Rect | null> {
   };
 }
 
+/** Magnet glide duration when the bar is released near an edge. */
+const MAGNET_DURATION_MS = 220;
+
+/** Ease-out: quick pull, then settle gently onto the edge. */
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+type TauriWindow = ReturnType<typeof getCurrentWindow>;
+
+/**
+ * Glide the window from (fromX,fromY) to (toX,toY) over MAGNET_DURATION_MS
+ * using an ease-out curve, so releasing the bar feels like it's magnetically
+ * inhaled to the nearest edge. Falls back to an instant move when there's no
+ * distance to cover or the user prefers reduced motion.
+ */
+async function animateWindowTo(
+  win: TauriWindow,
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number
+): Promise<void> {
+  if ((fromX === toX && fromY === toY) || prefersReducedMotion()) {
+    await win.setPosition(new LogicalPosition(toX, toY)).catch(() => {});
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / MAGNET_DURATION_MS);
+      const e = easeOutCubic(t);
+      const x = Math.round(fromX + (toX - fromX) * e);
+      const y = Math.round(fromY + (toY - fromY) * e);
+      void win.setPosition(new LogicalPosition(x, y)).catch(() => {});
+      if (t < 1) requestAnimationFrame(tick);
+      else resolve();
+    };
+    requestAnimationFrame(tick);
+  });
+}
+
 /**
  * Owns the pet <-> mini transition and the window resize/snap mechanics.
  * No persistence (the app always launches in pet mode).
@@ -52,34 +102,54 @@ export function useMiniMode(scale: number) {
     1 /* restore */ + (sessionListEnabled ? 1 : 0) + (lanListEnabled ? 1 : 0);
   const barLongLogical = miniBarLength(actionButtons);
 
-  const snapToNearest = useCallback(async () => {
-    const win = getCurrentWindow();
-    try {
-      const monitor = await monitorLogicalRect();
-      if (!monitor) {
-        console.warn("[mini-bar] no monitor; leaving bar where dropped");
-        return;
+  // Compute the nearest-edge snap and apply it. When `animate` is true the
+  // window glides to the edge (magnet effect); otherwise it moves instantly
+  // (used on enter, panel close, and tool-count re-fit).
+  const applySnap = useCallback(
+    async (animate: boolean) => {
+      const win = getCurrentWindow();
+      try {
+        const monitor = await monitorLogicalRect();
+        if (!monitor) {
+          console.warn("[mini-bar] no monitor; leaving bar where dropped");
+          return;
+        }
+        const sf = await win.scaleFactor();
+        const pos = (await win.outerPosition()).toLogical(sf);
+        const size = (await win.outerSize()).toLogical(sf);
+        const barLong = Math.round(barLongLogical * scale);
+        const barShort = Math.round(BAR_SHORT * scale);
+        const snap = computeSnap(
+          { x: pos.x, y: pos.y, width: size.width, height: size.height },
+          monitor,
+          barLong,
+          barShort,
+          DEFAULT_MARGINS
+        );
+        setOrientation(snap.orientation);
+        setEdge(snap.edge);
+        await win.setSize(new LogicalSize(snap.width, snap.height));
+        if (animate) {
+          await animateWindowTo(
+            win,
+            Math.round(pos.x),
+            Math.round(pos.y),
+            snap.x,
+            snap.y
+          );
+        } else {
+          await win.setPosition(new LogicalPosition(snap.x, snap.y));
+        }
+      } catch (err) {
+        console.error("[mini-bar] snap failed:", err);
       }
-      const sf = await win.scaleFactor();
-      const pos = (await win.outerPosition()).toLogical(sf);
-      const size = (await win.outerSize()).toLogical(sf);
-      const barLong = Math.round(barLongLogical * scale);
-      const barShort = Math.round(BAR_SHORT * scale);
-      const snap = computeSnap(
-        { x: pos.x, y: pos.y, width: size.width, height: size.height },
-        monitor,
-        barLong,
-        barShort,
-        DEFAULT_MARGINS
-      );
-      setOrientation(snap.orientation);
-      setEdge(snap.edge);
-      await win.setSize(new LogicalSize(snap.width, snap.height));
-      await win.setPosition(new LogicalPosition(snap.x, snap.y));
-    } catch (err) {
-      console.error("[mini-bar] snap failed:", err);
-    }
-  }, [scale, barLongLogical]);
+    },
+    [scale, barLongLogical]
+  );
+
+  const snapToNearest = useCallback(() => applySnap(false), [applySnap]);
+  /** Animated snap — used on drag release for the magnet "inhale" feel. */
+  const magnetToNearest = useCallback(() => applySnap(true), [applySnap]);
 
   // Re-fit the bar when the visible-tool count changes (a tool toggled in
   // Settings while minimized) so the bar always hugs its content.
@@ -117,5 +187,5 @@ export function useMiniMode(scale: number) {
     }
   }, [scale]);
 
-  return { mode, orientation, edge, enterMini, exitMini, snapToNearest };
+  return { mode, orientation, edge, enterMini, exitMini, snapToNearest, magnetToNearest };
 }

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -54,15 +54,22 @@ type TauriWindow = ReturnType<typeof getCurrentWindow>;
 /**
  * Glide the window from (fromX,fromY) to (toX,toY) over MAGNET_DURATION_MS
  * using an ease-out curve, so releasing the bar feels like it's magnetically
- * inhaled to the nearest edge. Falls back to an instant move when there's no
- * distance to cover or the user prefers reduced motion.
+ * inhaled to the nearest edge.
+ *
+ * Robustness:
+ * - `alive()` lets a newer snap cancel this one (rapid re-drags don't fight).
+ * - A safety timeout GUARANTEES the bar lands exactly on the edge even if
+ *   requestAnimationFrame is throttled/paused for the small transparent
+ *   window (which previously left it stranded mid-screen).
+ * Falls back to an instant move when there's no distance or reduced motion.
  */
 async function animateWindowTo(
   win: TauriWindow,
   fromX: number,
   fromY: number,
   toX: number,
-  toY: number
+  toY: number,
+  alive: () => boolean
 ): Promise<void> {
   if ((fromX === toX && fromY === toY) || prefersReducedMotion()) {
     await win.setPosition(new LogicalPosition(toX, toY)).catch(() => {});
@@ -70,16 +77,33 @@ async function animateWindowTo(
   }
   await new Promise<void>((resolve) => {
     const start = performance.now();
+    let done = false;
+    const finish = (landOnEdge: boolean) => {
+      if (done) return;
+      done = true;
+      if (landOnEdge && alive()) {
+        void win.setPosition(new LogicalPosition(toX, toY)).catch(() => {});
+      }
+      resolve();
+    };
     const tick = (now: number) => {
+      if (done) return;
+      if (!alive()) {
+        finish(false);
+        return;
+      }
       const t = Math.min(1, (now - start) / MAGNET_DURATION_MS);
       const e = easeOutCubic(t);
       const x = Math.round(fromX + (toX - fromX) * e);
       const y = Math.round(fromY + (toY - fromY) * e);
       void win.setPosition(new LogicalPosition(x, y)).catch(() => {});
       if (t < 1) requestAnimationFrame(tick);
-      else resolve();
+      else finish(true);
     };
     requestAnimationFrame(tick);
+    // Safety net: if rAF stalls, force the final landing so the bar never
+    // gets stuck partway (the core "ends up in the middle" bug).
+    setTimeout(() => finish(true), MAGNET_DURATION_MS + 80);
   });
 }
 
@@ -92,6 +116,8 @@ export function useMiniMode(scale: number) {
   const [orientation, setOrientation] = useState<Orientation>("horizontal");
   const [edge, setEdge] = useState<Edge>("bottom");
   const savedPetPosRef = useRef<LogicalPosition | null>(null);
+  // Bumped on every snap so a newer snap cancels an in-flight magnet glide.
+  const animSeqRef = useRef(0);
 
   // Size the bar to hug its content. miniBarLength already includes the
   // leading dot and trailing grip; here we count only the 20px action
@@ -128,6 +154,9 @@ export function useMiniMode(scale: number) {
         );
         setOrientation(snap.orientation);
         setEdge(snap.edge);
+        // Supersede any in-flight glide (rapid re-drags / an instant snap
+        // landing during an animation).
+        const mySeq = ++animSeqRef.current;
         await win.setSize(new LogicalSize(snap.width, snap.height));
         if (animate) {
           await animateWindowTo(
@@ -135,7 +164,8 @@ export function useMiniMode(scale: number) {
             Math.round(pos.x),
             Math.round(pos.y),
             snap.x,
-            snap.y
+            snap.y,
+            () => animSeqRef.current === mySeq
           );
         } else {
           await win.setPosition(new LogicalPosition(snap.x, snap.y));

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -7,7 +7,6 @@ import {
   LogicalSize,
   type Monitor,
 } from "@tauri-apps/api/window";
-import { warn } from "@tauri-apps/plugin-log";
 import { getDefaultPetSize } from "./useWindowDefaultSize";
 import { useSessionList } from "./useSessionList";
 import { useLanList } from "./useLanList";
@@ -15,7 +14,6 @@ import {
   computeSnap,
   miniBarLength,
   BAR_SHORT,
-  DEFAULT_MARGINS,
   type SnapMargins,
   type Orientation,
   type Edge,
@@ -23,6 +21,10 @@ import {
 } from "../utils/snap";
 
 export type Mode = "pet" | "mini";
+
+/** Edge gaps for the docked bar: hug the screen edge (2px), but keep enough
+ *  top clearance to sit just below the macOS menu bar. */
+const MINI_MARGINS: SnapMargins = { edge: 2, menuBar: 28 };
 
 /** Convert a Tauri Monitor (physical px) to a logical-px rect, the same space
  *  as event.screenX/Y and Tauri's LogicalPosition (setPosition). */
@@ -178,7 +180,7 @@ export function useMiniMode(scale: number) {
         monitor,
         barLong,
         barShort,
-        DEFAULT_MARGINS
+        MINI_MARGINS
       );
       setOrientation(snap.orientation);
       setEdge(snap.edge);
@@ -209,7 +211,6 @@ export function useMiniMode(scale: number) {
         x: e.screenX,
         y: e.screenY,
       };
-      let lastDock: { x: number; y: number; width: number; height: number } | null = null;
       let raf = 0;
       let curW = -1;
       let curH = -1;
@@ -225,9 +226,8 @@ export function useMiniMode(scale: number) {
           monitor,
           barLong,
           barShort,
-          DEFAULT_MARGINS
+          MINI_MARGINS
         );
-        lastDock = { x: dock.x, y: dock.y, width: dock.width, height: dock.height };
         setOrientation(dock.orientation);
         setEdge(dock.edge);
         if (dock.width !== curW || dock.height !== curH) {
@@ -247,19 +247,6 @@ export function useMiniMode(scale: number) {
         document.removeEventListener("mouseup", onUp);
         if (raf) cancelAnimationFrame(raf);
         apply(); // ensure the final position is committed
-        // DIAGNOSTIC: compare intended dock vs the window's actual placement.
-        void (async () => {
-          try {
-            const sf = await win.scaleFactor();
-            const actual = (await win.outerPosition()).toLogical(sf);
-            const size = (await win.outerSize()).toLogical(sf);
-            void warn(
-              `[mini-bar] DBG monitors=${JSON.stringify(monitors)} cursor=${JSON.stringify(pending)} sf=${sf} intended=${JSON.stringify(lastDock)} actualPos=${Math.round(actual.x)},${Math.round(actual.y)} actualSize=${Math.round(size.width)}x${Math.round(size.height)} screen=${window.screen.width}x${window.screen.height} dpr=${window.devicePixelRatio}`
-            );
-          } catch (err) {
-            void warn(`[mini-bar] DBG failed: ${String(err)}`);
-          }
-        })();
       };
 
       document.addEventListener("mousemove", onMove);

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -75,9 +75,11 @@ const clamp = (v: number, lo: number, hi: number) =>
 
 /**
  * Dock geometry for a given cursor position on a monitor: the bar is glued to
- * whichever edge the cursor is NEAREST, and slides along that edge centred on
- * the cursor (clamped on-screen). The top edge uses the larger menu-bar margin
- * to clear the macOS menu bar. Pure, so it can be reasoned about easily.
+ * whichever edge the cursor is NEAREST, and positioned along that edge so the
+ * bar's leading corner sits at `cursorAlong + alongOffset` (clamped on-screen).
+ * Pass the offset captured at grab time so the bar keeps the point you grabbed
+ * instead of recentring on the cursor. When `alongOffset` is null the bar is
+ * centred on the cursor. The top edge uses the larger menu-bar margin.
  */
 function dockToCursor(
   cursorX: number,
@@ -85,7 +87,8 @@ function dockToCursor(
   monitor: Rect,
   barLong: number,
   barShort: number,
-  margins: SnapMargins
+  margins: SnapMargins,
+  alongOffset: number | null
 ): { x: number; y: number; width: number; height: number; edge: Edge; orientation: Orientation } {
   const distLeft = cursorX - monitor.x;
   const distRight = monitor.x + monitor.width - cursorX;
@@ -110,8 +113,9 @@ function dockToCursor(
       edge === "left"
         ? monitor.x + margins.edge
         : monitor.x + monitor.width - width - margins.edge;
+    const alongY = alongOffset == null ? cursorY - height / 2 : cursorY + alongOffset;
     y = clamp(
-      cursorY - height / 2,
+      alongY,
       monitor.y + margins.menuBar,
       monitor.y + monitor.height - height - margins.edge
     );
@@ -120,8 +124,9 @@ function dockToCursor(
       edge === "top"
         ? monitor.y + margins.menuBar
         : monitor.y + monitor.height - height - margins.edge;
+    const alongX = alongOffset == null ? cursorX - width / 2 : cursorX + alongOffset;
     x = clamp(
-      cursorX - width / 2,
+      alongX,
       monitor.x + margins.edge,
       monitor.x + monitor.width - width - margins.edge
     );
@@ -207,10 +212,20 @@ export function useMiniMode(scale: number) {
       const barLong = Math.round(barLongLogical * scale);
       const barShort = Math.round(BAR_SHORT * scale);
 
-      let pending: { x: number; y: number } | null = {
-        x: e.screenX,
-        y: e.screenY,
-      };
+      // Capture the grab point so the bar keeps its position relative to the
+      // cursor (no jump-to-centre on grab). Derive the current orientation from
+      // the window's own dimensions, and the along-axis offset from its position.
+      const sf = await win.scaleFactor();
+      const startPos = (await win.outerPosition()).toLogical(sf);
+      const startSize = (await win.outerSize()).toLogical(sf);
+      let grabOrientation: Orientation =
+        startSize.width <= startSize.height ? "vertical" : "horizontal";
+      let grabOffset =
+        grabOrientation === "vertical"
+          ? startPos.y - e.screenY
+          : startPos.x - e.screenX;
+
+      let pending: { x: number; y: number } | null = null;
       let raf = 0;
       let curW = -1;
       let curH = -1;
@@ -220,13 +235,24 @@ export function useMiniMode(scale: number) {
         if (!pending) return;
         const monitor =
           monitorContaining(pending.x, pending.y, monitors) ?? monitors[0];
+
+        // Peek the edge the cursor is nearest to decide orientation. When it
+        // flips to a different edge, recentre (the grab offset no longer maps
+        // across axes); otherwise keep the captured grab offset.
+        const peek = dockToCursor(pending.x, pending.y, monitor, barLong, barShort, MINI_MARGINS, null);
+        if (peek.orientation !== grabOrientation) {
+          grabOrientation = peek.orientation;
+          grabOffset = -barLong / 2; // centre on the cursor after a flip
+        }
+
         const dock = dockToCursor(
           pending.x,
           pending.y,
           monitor,
           barLong,
           barShort,
-          MINI_MARGINS
+          MINI_MARGINS,
+          grabOffset
         );
         setOrientation(dock.orientation);
         setEdge(dock.edge);
@@ -246,12 +272,12 @@ export function useMiniMode(scale: number) {
         document.removeEventListener("mousemove", onMove);
         document.removeEventListener("mouseup", onUp);
         if (raf) cancelAnimationFrame(raf);
-        apply(); // ensure the final position is committed
+        if (pending) apply(); // commit final position only if actually moved
       };
 
       document.addEventListener("mousemove", onMove);
       document.addEventListener("mouseup", onUp);
-      apply(); // dock immediately on grab
+      // No immediate apply(): a plain click must not move the bar.
     },
     [scale, barLongLogical]
   );

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -43,15 +43,14 @@ export function useMiniMode(scale: number) {
   const [edge, setEdge] = useState<Edge>("bottom");
   const savedPetPosRef = useRef<LogicalPosition | null>(null);
 
-  // Size the bar to hug its content: dot + restore + grip handle + whichever
-  // tools are enabled (must match which elements MiniBar actually renders).
+  // Size the bar to hug its content. miniBarLength already includes the
+  // leading dot and trailing grip; here we count only the 20px action
+  // buttons (restore + whichever tools are enabled).
   const { enabled: sessionListEnabled } = useSessionList();
   const { enabled: lanListEnabled } = useLanList();
-  const barButtons =
-    2 /* restore + grip */ +
-    (sessionListEnabled ? 1 : 0) +
-    (lanListEnabled ? 1 : 0);
-  const barLongLogical = miniBarLength(barButtons);
+  const actionButtons =
+    1 /* restore */ + (sessionListEnabled ? 1 : 0) + (lanListEnabled ? 1 : 0);
+  const barLongLogical = miniBarLength(actionButtons);
 
   const snapToNearest = useCallback(async () => {
     const win = getCurrentWindow();

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getCurrentWindow,
+  currentMonitor,
+  availableMonitors,
   LogicalPosition,
   LogicalSize,
+  type Monitor,
 } from "@tauri-apps/api/window";
 import { getDefaultPetSize } from "./useWindowDefaultSize";
 import { useSessionList } from "./useSessionList";
@@ -11,6 +14,7 @@ import {
   computeSnap,
   miniBarLength,
   BAR_SHORT,
+  DEFAULT_MARGINS,
   type SnapMargins,
   type Orientation,
   type Edge,
@@ -19,24 +23,48 @@ import {
 
 export type Mode = "pet" | "mini";
 
-/** Gap from the work-area edges (uniform — the work area already excludes the
- *  menu bar and Dock, so no special top margin is needed). */
-const WORK_MARGINS: SnapMargins = { edge: 8, menuBar: 8 };
-
-/**
- * The current screen's WORK AREA in CSS pixels — the same unit as
- * `event.screenX/Y` (cursor) and Tauri's `LogicalPosition` (setPosition), so
- * snapping math is consistent end-to-end. `avail*` excludes the macOS menu bar
- * and Dock, so the bar docks against the usable area, not under them.
- */
-function screenWorkArea(): Rect {
-  const s = window.screen as Screen & { availLeft?: number; availTop?: number };
+/** Convert a Tauri Monitor (physical px) to a logical-px rect, the same space
+ *  as event.screenX/Y and Tauri's LogicalPosition (setPosition). */
+function monitorToLogical(m: Monitor): Rect {
+  const sf = m.scaleFactor || 1;
   return {
-    x: s.availLeft ?? 0,
-    y: s.availTop ?? 0,
-    width: s.availWidth,
-    height: s.availHeight,
+    x: m.position.x / sf,
+    y: m.position.y / sf,
+    width: m.size.width / sf,
+    height: m.size.height / sf,
   };
+}
+
+/** The monitor the window is on, as a logical rect (or null). */
+async function windowMonitorRect(): Promise<Rect | null> {
+  const m = await currentMonitor();
+  return m ? monitorToLogical(m) : null;
+}
+
+/** All monitors as logical rects (for picking the one under the cursor). */
+async function allMonitorRects(): Promise<Rect[]> {
+  const ms = await availableMonitors();
+  return ms.map(monitorToLogical);
+}
+
+/** Pick the monitor rect that contains the point, else the nearest by centre. */
+function monitorContaining(x: number, y: number, monitors: Rect[]): Rect | null {
+  if (monitors.length === 0) return null;
+  for (const m of monitors) {
+    if (x >= m.x && x < m.x + m.width && y >= m.y && y < m.y + m.height) return m;
+  }
+  let best = monitors[0];
+  let bestD = Infinity;
+  for (const m of monitors) {
+    const dx = x - (m.x + m.width / 2);
+    const dy = y - (m.y + m.height / 2);
+    const d = dx * dx + dy * dy;
+    if (d < bestD) {
+      bestD = d;
+      best = m;
+    }
+  }
+  return best;
 }
 
 const clamp = (v: number, lo: number, hi: number) =>
@@ -45,7 +73,8 @@ const clamp = (v: number, lo: number, hi: number) =>
 /**
  * Dock geometry for a given cursor position on a monitor: the bar is glued to
  * whichever edge the cursor is NEAREST, and slides along that edge centred on
- * the cursor (clamped on-screen). Pure, so it can be reasoned about easily.
+ * the cursor (clamped on-screen). The top edge uses the larger menu-bar margin
+ * to clear the macOS menu bar. Pure, so it can be reasoned about easily.
  */
 function dockToCursor(
   cursorX: number,
@@ -53,7 +82,7 @@ function dockToCursor(
   monitor: Rect,
   barLong: number,
   barShort: number,
-  margin: number
+  margins: SnapMargins
 ): { x: number; y: number; width: number; height: number; edge: Edge; orientation: Orientation } {
   const distLeft = cursorX - monitor.x;
   const distRight = monitor.x + monitor.width - cursorX;
@@ -76,22 +105,22 @@ function dockToCursor(
   if (vertical) {
     x =
       edge === "left"
-        ? monitor.x + margin
-        : monitor.x + monitor.width - width - margin;
+        ? monitor.x + margins.edge
+        : monitor.x + monitor.width - width - margins.edge;
     y = clamp(
       cursorY - height / 2,
-      monitor.y + margin,
-      monitor.y + monitor.height - height - margin
+      monitor.y + margins.menuBar,
+      monitor.y + monitor.height - height - margins.edge
     );
   } else {
     y =
       edge === "top"
-        ? monitor.y + margin
-        : monitor.y + monitor.height - height - margin;
+        ? monitor.y + margins.menuBar
+        : monitor.y + monitor.height - height - margins.edge;
     x = clamp(
       cursorX - width / 2,
-      monitor.x + margin,
-      monitor.x + monitor.width - width - margin
+      monitor.x + margins.edge,
+      monitor.x + monitor.width - width - margins.edge
     );
   }
 
@@ -133,7 +162,11 @@ export function useMiniMode(scale: number) {
   const snapToNearest = useCallback(async () => {
     const win = getCurrentWindow();
     try {
-      const monitor = screenWorkArea();
+      const monitor = await windowMonitorRect();
+      if (!monitor) {
+        console.warn("[mini-bar] no monitor; leaving bar where it is");
+        return;
+      }
       const sf = await win.scaleFactor();
       const pos = (await win.outerPosition()).toLogical(sf);
       const size = (await win.outerSize()).toLogical(sf);
@@ -144,7 +177,7 @@ export function useMiniMode(scale: number) {
         monitor,
         barLong,
         barShort,
-        WORK_MARGINS
+        DEFAULT_MARGINS
       );
       setOrientation(snap.orientation);
       setEdge(snap.edge);
@@ -157,16 +190,17 @@ export function useMiniMode(scale: number) {
 
   // Edge-constrained drag. Started from the grip's mousedown. While the button
   // is held, the bar tracks the global cursor (event.screenX/Y, delivered to
-  // this window for the whole press) and docks to the nearest edge, sliding
-  // along it. rAF-throttled so we don't flood the window-move IPC.
+  // this window for the whole press) and docks to whichever monitor + edge the
+  // cursor is on, sliding along it. rAF-throttled so we don't flood the IPC.
   const startEdgeDrag = useCallback(
-    (e: React.MouseEvent) => {
+    async (e: React.MouseEvent) => {
       if (e.button !== 0) return;
       e.preventDefault();
       e.stopPropagation();
 
       const win = getCurrentWindow();
-      const monitor = screenWorkArea();
+      const monitors = await allMonitorRects();
+      if (monitors.length === 0) return;
       const barLong = Math.round(barLongLogical * scale);
       const barShort = Math.round(BAR_SHORT * scale);
 
@@ -177,18 +211,29 @@ export function useMiniMode(scale: number) {
       let raf = 0;
       let curW = -1;
       let curH = -1;
+      let logged = false;
 
       const apply = () => {
         raf = 0;
         if (!pending) return;
+        const monitor =
+          monitorContaining(pending.x, pending.y, monitors) ?? monitors[0];
         const dock = dockToCursor(
           pending.x,
           pending.y,
           monitor,
           barLong,
           barShort,
-          WORK_MARGINS.edge
+          DEFAULT_MARGINS
         );
+        if (!logged) {
+          logged = true;
+          console.log("[mini-bar] drag dock", {
+            cursor: pending,
+            monitor,
+            dock,
+          });
+        }
         setOrientation(dock.orientation);
         setEdge(dock.edge);
         if (dock.width !== curW || dock.height !== curH) {

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getCurrentWindow,
-  currentMonitor,
   LogicalPosition,
   LogicalSize,
 } from "@tauri-apps/api/window";
@@ -12,7 +11,7 @@ import {
   computeSnap,
   miniBarLength,
   BAR_SHORT,
-  DEFAULT_MARGINS,
+  type SnapMargins,
   type Orientation,
   type Edge,
   type Rect,
@@ -20,16 +19,23 @@ import {
 
 export type Mode = "pet" | "mini";
 
-/** Read the current monitor as a logical-pixel rect, or null if unavailable. */
-async function monitorLogicalRect(): Promise<Rect | null> {
-  const m = await currentMonitor();
-  if (!m) return null;
-  const sf = m.scaleFactor || 1;
+/** Gap from the work-area edges (uniform — the work area already excludes the
+ *  menu bar and Dock, so no special top margin is needed). */
+const WORK_MARGINS: SnapMargins = { edge: 8, menuBar: 8 };
+
+/**
+ * The current screen's WORK AREA in CSS pixels — the same unit as
+ * `event.screenX/Y` (cursor) and Tauri's `LogicalPosition` (setPosition), so
+ * snapping math is consistent end-to-end. `avail*` excludes the macOS menu bar
+ * and Dock, so the bar docks against the usable area, not under them.
+ */
+function screenWorkArea(): Rect {
+  const s = window.screen as Screen & { availLeft?: number; availTop?: number };
   return {
-    x: m.position.x / sf,
-    y: m.position.y / sf,
-    width: m.size.width / sf,
-    height: m.size.height / sf,
+    x: s.availLeft ?? 0,
+    y: s.availTop ?? 0,
+    width: s.availWidth,
+    height: s.availHeight,
   };
 }
 
@@ -47,7 +53,7 @@ function dockToCursor(
   monitor: Rect,
   barLong: number,
   barShort: number,
-  margins = DEFAULT_MARGINS
+  margin: number
 ): { x: number; y: number; width: number; height: number; edge: Edge; orientation: Orientation } {
   const distLeft = cursorX - monitor.x;
   const distRight = monitor.x + monitor.width - cursorX;
@@ -70,22 +76,22 @@ function dockToCursor(
   if (vertical) {
     x =
       edge === "left"
-        ? monitor.x + margins.edge
-        : monitor.x + monitor.width - width - margins.edge;
+        ? monitor.x + margin
+        : monitor.x + monitor.width - width - margin;
     y = clamp(
       cursorY - height / 2,
-      monitor.y + margins.menuBar,
-      monitor.y + monitor.height - height - margins.edge
+      monitor.y + margin,
+      monitor.y + monitor.height - height - margin
     );
   } else {
     y =
       edge === "top"
-        ? monitor.y + margins.menuBar
-        : monitor.y + monitor.height - height - margins.edge;
+        ? monitor.y + margin
+        : monitor.y + monitor.height - height - margin;
     x = clamp(
       cursorX - width / 2,
-      monitor.x + margins.edge,
-      monitor.x + monitor.width - width - margins.edge
+      monitor.x + margin,
+      monitor.x + monitor.width - width - margin
     );
   }
 
@@ -127,11 +133,7 @@ export function useMiniMode(scale: number) {
   const snapToNearest = useCallback(async () => {
     const win = getCurrentWindow();
     try {
-      const monitor = await monitorLogicalRect();
-      if (!monitor) {
-        console.warn("[mini-bar] no monitor; leaving bar where it is");
-        return;
-      }
+      const monitor = screenWorkArea();
       const sf = await win.scaleFactor();
       const pos = (await win.outerPosition()).toLogical(sf);
       const size = (await win.outerSize()).toLogical(sf);
@@ -142,7 +144,7 @@ export function useMiniMode(scale: number) {
         monitor,
         barLong,
         barShort,
-        DEFAULT_MARGINS
+        WORK_MARGINS
       );
       setOrientation(snap.orientation);
       setEdge(snap.edge);
@@ -158,14 +160,13 @@ export function useMiniMode(scale: number) {
   // this window for the whole press) and docks to the nearest edge, sliding
   // along it. rAF-throttled so we don't flood the window-move IPC.
   const startEdgeDrag = useCallback(
-    async (e: React.MouseEvent) => {
+    (e: React.MouseEvent) => {
       if (e.button !== 0) return;
       e.preventDefault();
       e.stopPropagation();
 
       const win = getCurrentWindow();
-      const monitor = await monitorLogicalRect();
-      if (!monitor) return;
+      const monitor = screenWorkArea();
       const barLong = Math.round(barLongLogical * scale);
       const barShort = Math.round(BAR_SHORT * scale);
 
@@ -185,7 +186,8 @@ export function useMiniMode(scale: number) {
           pending.y,
           monitor,
           barLong,
-          barShort
+          barShort,
+          WORK_MARGINS.edge
         );
         setOrientation(dock.orientation);
         setEdge(dock.edge);

--- a/src/hooks/useMiniMode.ts
+++ b/src/hooks/useMiniMode.ts
@@ -33,91 +33,85 @@ async function monitorLogicalRect(): Promise<Rect | null> {
   };
 }
 
-/** Magnet glide duration when the bar is released near an edge. */
-const MAGNET_DURATION_MS = 220;
-
-/** Ease-out: quick pull, then settle gently onto the edge. */
-function easeOutCubic(t: number): number {
-  return 1 - Math.pow(1 - t, 3);
-}
-
-function prefersReducedMotion(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches
-  );
-}
-
-type TauriWindow = ReturnType<typeof getCurrentWindow>;
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(v, hi));
 
 /**
- * Glide the window from (fromX,fromY) to (toX,toY) over MAGNET_DURATION_MS
- * using an ease-out curve, so releasing the bar feels like it's magnetically
- * inhaled to the nearest edge.
- *
- * Robustness:
- * - `alive()` lets a newer snap cancel this one (rapid re-drags don't fight).
- * - A safety timeout GUARANTEES the bar lands exactly on the edge even if
- *   requestAnimationFrame is throttled/paused for the small transparent
- *   window (which previously left it stranded mid-screen).
- * Falls back to an instant move when there's no distance or reduced motion.
+ * Dock geometry for a given cursor position on a monitor: the bar is glued to
+ * whichever edge the cursor is NEAREST, and slides along that edge centred on
+ * the cursor (clamped on-screen). Pure, so it can be reasoned about easily.
  */
-async function animateWindowTo(
-  win: TauriWindow,
-  fromX: number,
-  fromY: number,
-  toX: number,
-  toY: number,
-  alive: () => boolean
-): Promise<void> {
-  if ((fromX === toX && fromY === toY) || prefersReducedMotion()) {
-    await win.setPosition(new LogicalPosition(toX, toY)).catch(() => {});
-    return;
+function dockToCursor(
+  cursorX: number,
+  cursorY: number,
+  monitor: Rect,
+  barLong: number,
+  barShort: number,
+  margins = DEFAULT_MARGINS
+): { x: number; y: number; width: number; height: number; edge: Edge; orientation: Orientation } {
+  const distLeft = cursorX - monitor.x;
+  const distRight = monitor.x + monitor.width - cursorX;
+  const distTop = cursorY - monitor.y;
+  const distBottom = monitor.y + monitor.height - cursorY;
+  const min = Math.min(distLeft, distRight, distTop, distBottom);
+
+  let edge: Edge;
+  if (min === distLeft) edge = "left";
+  else if (min === distRight) edge = "right";
+  else if (min === distTop) edge = "top";
+  else edge = "bottom";
+
+  const vertical = edge === "left" || edge === "right";
+  const width = vertical ? barShort : barLong;
+  const height = vertical ? barLong : barShort;
+
+  let x: number;
+  let y: number;
+  if (vertical) {
+    x =
+      edge === "left"
+        ? monitor.x + margins.edge
+        : monitor.x + monitor.width - width - margins.edge;
+    y = clamp(
+      cursorY - height / 2,
+      monitor.y + margins.menuBar,
+      monitor.y + monitor.height - height - margins.edge
+    );
+  } else {
+    y =
+      edge === "top"
+        ? monitor.y + margins.menuBar
+        : monitor.y + monitor.height - height - margins.edge;
+    x = clamp(
+      cursorX - width / 2,
+      monitor.x + margins.edge,
+      monitor.x + monitor.width - width - margins.edge
+    );
   }
-  await new Promise<void>((resolve) => {
-    const start = performance.now();
-    let done = false;
-    const finish = (landOnEdge: boolean) => {
-      if (done) return;
-      done = true;
-      if (landOnEdge && alive()) {
-        void win.setPosition(new LogicalPosition(toX, toY)).catch(() => {});
-      }
-      resolve();
-    };
-    const tick = (now: number) => {
-      if (done) return;
-      if (!alive()) {
-        finish(false);
-        return;
-      }
-      const t = Math.min(1, (now - start) / MAGNET_DURATION_MS);
-      const e = easeOutCubic(t);
-      const x = Math.round(fromX + (toX - fromX) * e);
-      const y = Math.round(fromY + (toY - fromY) * e);
-      void win.setPosition(new LogicalPosition(x, y)).catch(() => {});
-      if (t < 1) requestAnimationFrame(tick);
-      else finish(true);
-    };
-    requestAnimationFrame(tick);
-    // Safety net: if rAF stalls, force the final landing so the bar never
-    // gets stuck partway (the core "ends up in the middle" bug).
-    setTimeout(() => finish(true), MAGNET_DURATION_MS + 80);
-  });
+
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width,
+    height,
+    edge,
+    orientation: vertical ? "vertical" : "horizontal",
+  };
 }
 
 /**
- * Owns the pet <-> mini transition and the window resize/snap mechanics.
- * No persistence (the app always launches in pet mode).
+ * Owns the pet <-> mini transition and the window mechanics.
+ *
+ * Mini mode behaves like an edge-docked toolbar: the bar is always glued to a
+ * screen edge. Holding the grip drags it ALONG the nearest edge; pulling the
+ * cursor toward a different edge re-docks the bar to that edge. It never floats
+ * free. No persistence (the app always launches in pet mode).
  */
 export function useMiniMode(scale: number) {
   const [mode, setMode] = useState<Mode>("pet");
   const [orientation, setOrientation] = useState<Orientation>("horizontal");
   const [edge, setEdge] = useState<Edge>("bottom");
   const savedPetPosRef = useRef<LogicalPosition | null>(null);
-  // Bumped on every snap so a newer snap cancels an in-flight magnet glide.
-  const animSeqRef = useRef(0);
 
   // Size the bar to hug its content. miniBarLength already includes the
   // leading dot and trailing grip; here we count only the 20px action
@@ -128,58 +122,98 @@ export function useMiniMode(scale: number) {
     1 /* restore */ + (sessionListEnabled ? 1 : 0) + (lanListEnabled ? 1 : 0);
   const barLongLogical = miniBarLength(actionButtons);
 
-  // Compute the nearest-edge snap and apply it. When `animate` is true the
-  // window glides to the edge (magnet effect); otherwise it moves instantly
-  // (used on enter, panel close, and tool-count re-fit).
-  const applySnap = useCallback(
-    async (animate: boolean) => {
+  // Snap the bar flush to the nearest edge (preserving its along-edge
+  // position). Instant — used on enter, panel close, and tool-count re-fit.
+  const snapToNearest = useCallback(async () => {
+    const win = getCurrentWindow();
+    try {
+      const monitor = await monitorLogicalRect();
+      if (!monitor) {
+        console.warn("[mini-bar] no monitor; leaving bar where it is");
+        return;
+      }
+      const sf = await win.scaleFactor();
+      const pos = (await win.outerPosition()).toLogical(sf);
+      const size = (await win.outerSize()).toLogical(sf);
+      const barLong = Math.round(barLongLogical * scale);
+      const barShort = Math.round(BAR_SHORT * scale);
+      const snap = computeSnap(
+        { x: pos.x, y: pos.y, width: size.width, height: size.height },
+        monitor,
+        barLong,
+        barShort,
+        DEFAULT_MARGINS
+      );
+      setOrientation(snap.orientation);
+      setEdge(snap.edge);
+      await win.setSize(new LogicalSize(snap.width, snap.height));
+      await win.setPosition(new LogicalPosition(snap.x, snap.y));
+    } catch (err) {
+      console.error("[mini-bar] snap failed:", err);
+    }
+  }, [scale, barLongLogical]);
+
+  // Edge-constrained drag. Started from the grip's mousedown. While the button
+  // is held, the bar tracks the global cursor (event.screenX/Y, delivered to
+  // this window for the whole press) and docks to the nearest edge, sliding
+  // along it. rAF-throttled so we don't flood the window-move IPC.
+  const startEdgeDrag = useCallback(
+    async (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+
       const win = getCurrentWindow();
-      try {
-        const monitor = await monitorLogicalRect();
-        if (!monitor) {
-          console.warn("[mini-bar] no monitor; leaving bar where dropped");
-          return;
-        }
-        const sf = await win.scaleFactor();
-        const pos = (await win.outerPosition()).toLogical(sf);
-        const size = (await win.outerSize()).toLogical(sf);
-        const barLong = Math.round(barLongLogical * scale);
-        const barShort = Math.round(BAR_SHORT * scale);
-        const snap = computeSnap(
-          { x: pos.x, y: pos.y, width: size.width, height: size.height },
+      const monitor = await monitorLogicalRect();
+      if (!monitor) return;
+      const barLong = Math.round(barLongLogical * scale);
+      const barShort = Math.round(BAR_SHORT * scale);
+
+      let pending: { x: number; y: number } | null = {
+        x: e.screenX,
+        y: e.screenY,
+      };
+      let raf = 0;
+      let curW = -1;
+      let curH = -1;
+
+      const apply = () => {
+        raf = 0;
+        if (!pending) return;
+        const dock = dockToCursor(
+          pending.x,
+          pending.y,
           monitor,
           barLong,
-          barShort,
-          DEFAULT_MARGINS
+          barShort
         );
-        setOrientation(snap.orientation);
-        setEdge(snap.edge);
-        // Supersede any in-flight glide (rapid re-drags / an instant snap
-        // landing during an animation).
-        const mySeq = ++animSeqRef.current;
-        await win.setSize(new LogicalSize(snap.width, snap.height));
-        if (animate) {
-          await animateWindowTo(
-            win,
-            Math.round(pos.x),
-            Math.round(pos.y),
-            snap.x,
-            snap.y,
-            () => animSeqRef.current === mySeq
-          );
-        } else {
-          await win.setPosition(new LogicalPosition(snap.x, snap.y));
+        setOrientation(dock.orientation);
+        setEdge(dock.edge);
+        if (dock.width !== curW || dock.height !== curH) {
+          curW = dock.width;
+          curH = dock.height;
+          void win.setSize(new LogicalSize(dock.width, dock.height)).catch(() => {});
         }
-      } catch (err) {
-        console.error("[mini-bar] snap failed:", err);
-      }
+        void win.setPosition(new LogicalPosition(dock.x, dock.y)).catch(() => {});
+      };
+
+      const onMove = (ev: MouseEvent) => {
+        pending = { x: ev.screenX, y: ev.screenY };
+        if (!raf) raf = requestAnimationFrame(apply);
+      };
+      const onUp = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+        if (raf) cancelAnimationFrame(raf);
+        apply(); // ensure the final position is committed
+      };
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+      apply(); // dock immediately on grab
     },
     [scale, barLongLogical]
   );
-
-  const snapToNearest = useCallback(() => applySnap(false), [applySnap]);
-  /** Animated snap — used on drag release for the magnet "inhale" feel. */
-  const magnetToNearest = useCallback(() => applySnap(true), [applySnap]);
 
   // Re-fit the bar when the visible-tool count changes (a tool toggled in
   // Settings while minimized) so the bar always hugs its content.
@@ -217,5 +251,13 @@ export function useMiniMode(scale: number) {
     }
   }, [scale]);
 
-  return { mode, orientation, edge, enterMini, exitMini, snapToNearest, magnetToNearest };
+  return {
+    mode,
+    orientation,
+    edge,
+    enterMini,
+    exitMini,
+    snapToNearest,
+    startEdgeDrag,
+  };
 }

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -44,7 +44,8 @@
   width: auto;
   height: 100%;
   color: var(--text-primary);
-  opacity: 0.4;
+  /* Match the action icons (.pill-action-icon): 0.75 at rest, 1 on hover. */
+  opacity: 0.75;
   cursor: grab;
   -webkit-user-select: none;
   user-select: none;
@@ -52,7 +53,7 @@
 }
 
 .mini-bar-grip:hover {
-  opacity: 0.8;
+  opacity: 1;
 }
 
 .mini-bar-grip:active {

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -27,6 +27,17 @@
   padding: 8px 0;
 }
 
+/* Status dot sits in a button-sized slot so the leading element matches
+   the trailing grip — the first and last edge gaps stay equal. */
+.mini-bar-dot-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+}
+
 /* Mini-bar tool buttons reuse the status-pill button styling
    (.pill-action-btn / .pill-action-icon, defined in status-pill.css)
    so hover fill, press animation, icon opacity, and active/has-peers

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -23,7 +23,7 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  padding: 0 4px;
+  padding: 0 8px;
   border-radius: 20px;
   background: var(--bg-pill);
   border: 1px solid var(--border-pill);
@@ -32,7 +32,7 @@
 
 .mini-bar.vertical {
   flex-direction: column;
-  padding: 4px 0;
+  padding: 8px 0;
 }
 
 /* Mini-bar tool buttons reuse the status-pill button styling

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -1,0 +1,54 @@
+/* Collapse the pet container's pet-size minimums while in mini mode. */
+.container.mini-mode {
+  min-width: 0 !important;
+  min-height: 0 !important;
+  padding: 0;
+}
+
+.mini-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 0 10px;
+  border-radius: 20px;
+  background: var(--bg-pill);
+  border: 1px solid var(--border-pill);
+  transition: box-shadow 0.3s, border-color 0.2s;
+}
+
+.mini-bar.vertical {
+  flex-direction: column;
+  padding: 10px 0;
+}
+
+.mini-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 6px;
+  background: var(--bg-pill-hover);
+  border: 1px solid var(--border-pill);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.mini-bar-btn:hover {
+  border-color: var(--border-pill-hover);
+}
+
+/* Status glow — colors mirror the .dot.* values in status-pill.css. */
+.mini-bar.idle         { box-shadow: 0 0 8px rgba(52, 199, 89, 0.5),  0 0 18px rgba(52, 199, 89, 0.3); }
+.mini-bar.busy         { box-shadow: 0 0 8px rgba(255, 59, 48, 0.5),  0 0 18px rgba(255, 59, 48, 0.3); }
+.mini-bar.service      { box-shadow: 0 0 8px rgba(94, 92, 230, 0.5),  0 0 18px rgba(94, 92, 230, 0.3); }
+.mini-bar.searching    { box-shadow: 0 0 8px rgba(255, 204, 0, 0.5),  0 0 18px rgba(255, 204, 0, 0.3); }
+.mini-bar.initializing { box-shadow: 0 0 8px rgba(255, 159, 10, 0.5), 0 0 18px rgba(255, 159, 10, 0.3); }
+.mini-bar.visiting     { box-shadow: 0 0 8px rgba(175, 82, 222, 0.5), 0 0 18px rgba(175, 82, 222, 0.3); }
+.mini-bar.disconnected { box-shadow: 0 0 8px rgba(99, 99, 102, 0.4); }

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -9,11 +9,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  /* gap + padding MUST match MINI_BAR geometry in utils/snap.ts so the
+     window (sized by useMiniMode) hugs the content with no dead space. */
+  gap: 6px;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  padding: 0 10px;
+  padding: 0 8px;
   border-radius: 20px;
   background: var(--bg-pill);
   border: 1px solid var(--border-pill);
@@ -22,7 +24,7 @@
 
 .mini-bar.vertical {
   flex-direction: column;
-  padding: 10px 0;
+  padding: 8px 0;
 }
 
 /* Mini-bar tool buttons reuse the status-pill button styling

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -32,6 +32,30 @@
    so hover fill, press animation, icon opacity, and active/has-peers
    highlights are identical to the pet-mode pill. */
 
+/* Drag handle (6-dot grip). The ONLY element that moves the bar — see
+   useDrag({ requireHandle: true }). Pressing anywhere else does nothing. */
+.mini-bar-grip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--text-primary);
+  opacity: 0.4;
+  cursor: grab;
+  -webkit-user-select: none;
+  user-select: none;
+  transition: opacity 0.12s;
+}
+
+.mini-bar-grip:hover {
+  opacity: 0.8;
+}
+
+.mini-bar-grip:active {
+  cursor: grabbing;
+}
+
 /* Status glow — colors mirror the .dot.* values in status-pill.css. */
 .mini-bar.idle         { box-shadow: 0 0 8px rgba(52, 199, 89, 0.5),  0 0 18px rgba(52, 199, 89, 0.3); }
 .mini-bar.busy         { box-shadow: 0 0 8px rgba(255, 59, 48, 0.5),  0 0 18px rgba(255, 59, 48, 0.3); }

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -38,7 +38,12 @@
 /* Mini-bar tool buttons reuse the status-pill button styling
    (.pill-action-btn / .pill-action-icon, defined in status-pill.css)
    so hover fill, press animation, icon opacity, and active/has-peers
-   highlights are identical to the pet-mode pill. */
+   highlights are identical to the pet-mode pill — but smaller, so the
+   docked bar stays compact (the pet pill keeps its 20px buttons). */
+.mini-bar .pill-action-btn {
+  width: 16px;
+  height: 16px;
+}
 
 /* Drag handle (6-dot grip). The ONLY element that moves the bar — see
    useDrag({ requireHandle: true }). Pressing anywhere else does nothing. */

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -63,11 +63,12 @@
   cursor: grabbing;
 }
 
-/* Status glow — colors mirror the .dot.* values in status-pill.css. */
-.mini-bar.idle         { box-shadow: 0 0 8px rgba(52, 199, 89, 0.5),  0 0 18px rgba(52, 199, 89, 0.3); }
-.mini-bar.busy         { box-shadow: 0 0 8px rgba(255, 59, 48, 0.5),  0 0 18px rgba(255, 59, 48, 0.3); }
-.mini-bar.service      { box-shadow: 0 0 8px rgba(94, 92, 230, 0.5),  0 0 18px rgba(94, 92, 230, 0.3); }
-.mini-bar.searching    { box-shadow: 0 0 8px rgba(255, 204, 0, 0.5),  0 0 18px rgba(255, 204, 0, 0.3); }
-.mini-bar.initializing { box-shadow: 0 0 8px rgba(255, 159, 10, 0.5), 0 0 18px rgba(255, 159, 10, 0.3); }
-.mini-bar.visiting     { box-shadow: 0 0 8px rgba(175, 82, 222, 0.5), 0 0 18px rgba(175, 82, 222, 0.3); }
-.mini-bar.disconnected { box-shadow: 0 0 8px rgba(99, 99, 102, 0.4); }
+/* Status glow — colors mirror the .dot.* values in status-pill.css. Kept
+   tight so the docked bar reads as crisp/solid rather than fuzzy. */
+.mini-bar.idle         { box-shadow: 0 0 5px rgba(52, 199, 89, 0.45); }
+.mini-bar.busy         { box-shadow: 0 0 5px rgba(255, 59, 48, 0.45); }
+.mini-bar.service      { box-shadow: 0 0 5px rgba(94, 92, 230, 0.45); }
+.mini-bar.searching    { box-shadow: 0 0 5px rgba(255, 204, 0, 0.45); }
+.mini-bar.initializing { box-shadow: 0 0 5px rgba(255, 159, 10, 0.45); }
+.mini-bar.visiting     { box-shadow: 0 0 5px rgba(175, 82, 222, 0.45); }
+.mini-bar.disconnected { box-shadow: 0 0 5px rgba(99, 99, 102, 0.35); }

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -27,17 +27,6 @@
   padding: 8px 0;
 }
 
-/* Status dot sits in a button-sized slot so the leading element matches
-   the trailing grip — the first and last edge gaps stay equal. */
-.mini-bar-dot-slot {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  flex: 0 0 auto;
-}
-
 /* Mini-bar tool buttons reuse the status-pill button styling
    (.pill-action-btn / .pill-action-icon, defined in status-pill.css)
    so hover fill, press animation, icon opacity, and active/has-peers
@@ -49,8 +38,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
+  /* Hug the glyph (no extra box width) so the grip's right edge sits the
+     same ~8px from the bar edge as the dot does on the left. Full bar
+     height keeps it grabbable despite the narrow width. */
+  width: auto;
+  height: 100%;
   color: var(--text-primary);
   opacity: 0.4;
   cursor: grab;

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -23,7 +23,7 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  padding: 0 8px;
+  padding: 0 4px;
   border-radius: 20px;
   background: var(--bg-pill);
   border: 1px solid var(--border-pill);
@@ -32,7 +32,7 @@
 
 .mini-bar.vertical {
   flex-direction: column;
-  padding: 8px 0;
+  padding: 4px 0;
 }
 
 /* Mini-bar tool buttons reuse the status-pill button styling

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -3,6 +3,9 @@
   min-width: 0 !important;
   min-height: 0 !important;
   padding: 0;
+  /* The pet container uses cursor:grab (drag anywhere); in mini mode only
+     the grip moves the bar, so the bar/dot use the normal cursor. */
+  cursor: default;
 }
 
 .mini-bar {

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -1,7 +1,12 @@
-/* Collapse the pet container's pet-size minimums while in mini mode. */
+/* Collapse the pet container's pet-size minimums while in mini mode, and make
+   it FILL the window. Without width/height:100% the bar collapses to its
+   content size and #root's centering leaves empty space between the pill and
+   the window edge — which read as the bar "not sticking" to the screen edge. */
 .container.mini-mode {
   min-width: 0 !important;
   min-height: 0 !important;
+  width: 100%;
+  height: 100%;
   padding: 0;
   /* The pet container uses cursor:grab (drag anywhere); in mini mode only
      the grip moves the bar, so the bar/dot use the normal cursor. */

--- a/src/styles/mini-bar.css
+++ b/src/styles/mini-bar.css
@@ -25,24 +25,10 @@
   padding: 10px 0;
 }
 
-.mini-bar-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  border-radius: 6px;
-  background: var(--bg-pill-hover);
-  border: 1px solid var(--border-pill);
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: border-color 0.12s, background 0.12s;
-}
-
-.mini-bar-btn:hover {
-  border-color: var(--border-pill-hover);
-}
+/* Mini-bar tool buttons reuse the status-pill button styling
+   (.pill-action-btn / .pill-action-icon, defined in status-pill.css)
+   so hover fill, press animation, icon opacity, and active/has-peers
+   highlights are identical to the pet-mode pill. */
 
 /* Status glow — colors mirror the .dot.* values in status-pill.css. */
 .mini-bar.idle         { box-shadow: 0 0 8px rgba(52, 199, 89, 0.5),  0 0 18px rgba(52, 199, 89, 0.3); }

--- a/src/styles/session-list-window.css
+++ b/src/styles/session-list-window.css
@@ -1,10 +1,9 @@
-/* Styles for the `session-list` Tauri window — a modal dialog matching the
-   clipboard-manager plugin (opaque solid surface + header), while keeping the
-   original session list item styling below. The window is transparent +
-   decoration-less; .session-list-shell pads 12px so the card's shadow isn't
-   clipped by the window edge. */
+/* Styles for the `session-list` Tauri window — a real window like the plugin
+   dialogs (clipboard/translate): native title bar + opaque surface, with the
+   original session list item styling below. The content fills the window; the
+   list scrolls. The native window provides the move bar, close button + shadow. */
 
-/* Opaque modal surface, mirroring the clipboard plugin palette. */
+/* Opaque surface, mirroring the clipboard plugin palette. */
 :root,
 [data-theme="dark"] {
   --sl-surface: #1e1e22;
@@ -18,54 +17,34 @@
 html,
 body,
 #root {
-  background: transparent;
-}
-
-#root {
-  display: inline-block;
-  width: max-content;
+  height: 100%;
+  margin: 0;
+  background: var(--sl-surface);
 }
 
 .session-list-shell {
-  width: max-content;
-  padding: 12px;
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .session-list-root {
-  min-width: 240px;
-  max-width: 360px;
-  padding: 12px;
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  border-radius: 12px;
+  padding: 12px;
   background: var(--sl-surface);
-  border: 1px solid var(--border-pill);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
   color: var(--text-primary);
-  animation: session-list-fade-in 0.1s ease-out;
 }
 
-@keyframes session-list-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-/* --- Modal header (title + subtitle + close), like the clipboard manager --- */
+/* --- Header (title + subtitle), like the clipboard manager --- */
 .session-list-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.session-list-header-text {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  min-width: 0;
 }
 
 .session-list-header h1 {
@@ -80,33 +59,12 @@ body,
   color: var(--sl-muted);
 }
 
-.session-list-close {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  border-radius: 6px;
-  background: var(--bg-pill-hover);
-  border: 1px solid var(--border-pill);
-  color: var(--text-primary);
-  opacity: 0.7;
-  cursor: pointer;
-  transition: opacity 0.12s, background 0.12s, border-color 0.12s;
-}
-
-.session-list-close:hover {
-  opacity: 1;
-  border-color: var(--border-pill-hover);
-}
-
-/* List body scrolls inside the dialog when there are many sessions. */
+/* List body fills the rest of the window and scrolls when long. */
 .session-list-body {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  max-height: 320px;
   overflow-y: auto;
 }
 

--- a/src/styles/session-list-window.css
+++ b/src/styles/session-list-window.css
@@ -66,6 +66,30 @@ body,
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  /* Thin, subtle overlay scrollbar instead of the chunky default. */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(120, 120, 128, 0.4) transparent;
+}
+
+.session-list-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.session-list-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.session-list-body::-webkit-scrollbar-thumb {
+  background: rgba(120, 120, 128, 0.4);
+  border-radius: 8px;
+  /* Inset the thumb so it reads as a slim pill, not a full-width bar. */
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.session-list-body::-webkit-scrollbar-thumb:hover {
+  background: rgba(120, 120, 128, 0.65);
+  background-clip: padding-box;
 }
 
 .session-empty {

--- a/src/styles/session-list-window.css
+++ b/src/styles/session-list-window.css
@@ -34,7 +34,9 @@ body,
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 12px;
+  /* No right padding: the scroll body reaches the window's right edge so its
+     scrollbar sits flush against it (not floating with a 12px gap). */
+  padding: 0;
   background: var(--sl-surface);
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
   color: var(--text-primary);
@@ -45,6 +47,7 @@ body,
   display: flex;
   flex-direction: column;
   gap: 2px;
+  padding: 12px 12px 0 12px;
 }
 
 .session-list-header h1 {
@@ -59,13 +62,16 @@ body,
   color: var(--sl-muted);
 }
 
-/* List body fills the rest of the window and scrolls when long. */
+/* List body fills the rest of the window and scrolls when long. Reaches the
+   window's right edge (scrollbar flush right); content is padded on the left
+   and bottom, and the list items carry their own right padding. */
 .session-list-body {
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  padding: 0 0 12px 12px;
   /* Thin, subtle overlay scrollbar instead of the chunky default. */
   scrollbar-width: thin;
   scrollbar-color: rgba(120, 120, 128, 0.4) transparent;

--- a/src/styles/session-list-window.css
+++ b/src/styles/session-list-window.css
@@ -1,7 +1,19 @@
-/* Styles for the `session-list` Tauri popover window. The window itself
-   is transparent + decoration-less; the .session-list-shell wrapper adds
-   12px of padding on all sides so the card's box-shadow isn't clipped
-   by the window edge (offsetWidth/Height does NOT include box-shadow). */
+/* Styles for the `session-list` Tauri window — a modal dialog matching the
+   clipboard-manager plugin (opaque solid surface + header), while keeping the
+   original session list item styling below. The window is transparent +
+   decoration-less; .session-list-shell pads 12px so the card's shadow isn't
+   clipped by the window edge. */
+
+/* Opaque modal surface, mirroring the clipboard plugin palette. */
+:root,
+[data-theme="dark"] {
+  --sl-surface: #1e1e22;
+  --sl-muted: rgba(242, 242, 244, 0.55);
+}
+[data-theme="light"] {
+  --sl-surface: #f5f5f7;
+  --sl-muted: rgba(29, 29, 31, 0.55);
+}
 
 html,
 body,
@@ -23,13 +35,14 @@ body,
 .session-list-root {
   min-width: 240px;
   max-width: 360px;
-  padding: 4px;
-  border-radius: 10px;
-  background: var(--bg-pill);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 12px;
+  background: var(--sl-surface);
   border: 1px solid var(--border-pill);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
   color: var(--text-primary);
   animation: session-list-fade-in 0.1s ease-out;
@@ -38,6 +51,33 @@ body,
 @keyframes session-list-fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }
+}
+
+/* --- Modal header (title + subtitle), like the clipboard manager --- */
+.session-list-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.session-list-header h1 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.session-list-header .sub {
+  margin: 0;
+  font-size: 11px;
+  color: var(--sl-muted);
+}
+
+/* List body scrolls inside the dialog when there are many sessions. */
+.session-list-body {
+  display: flex;
+  flex-direction: column;
+  max-height: 320px;
+  overflow-y: auto;
 }
 
 .session-empty {

--- a/src/styles/session-list-window.css
+++ b/src/styles/session-list-window.css
@@ -53,11 +53,19 @@ body,
   to   { opacity: 1; }
 }
 
-/* --- Modal header (title + subtitle), like the clipboard manager --- */
+/* --- Modal header (title + subtitle + close), like the clipboard manager --- */
 .session-list-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.session-list-header-text {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 
 .session-list-header h1 {
@@ -70,6 +78,28 @@ body,
   margin: 0;
   font-size: 11px;
   color: var(--sl-muted);
+}
+
+.session-list-close {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 6px;
+  background: var(--bg-pill-hover);
+  border: 1px solid var(--border-pill);
+  color: var(--text-primary);
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.12s, background 0.12s, border-color 0.12s;
+}
+
+.session-list-close:hover {
+  opacity: 1;
+  border-color: var(--border-pill-hover);
 }
 
 /* List body scrolls inside the dialog when there are many sessions. */

--- a/src/utils/popoverPos.ts
+++ b/src/utils/popoverPos.ts
@@ -1,0 +1,30 @@
+import type { Edge, Rect } from "./snap";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Top-left position (logical screen px) for a popover that opens *inward*
+ * from a snapped mini bar, away from the screen edge it hugs.
+ */
+export function inwardPopoverPos(
+  bar: Rect,
+  edge: Edge,
+  popoverWidth: number,
+  popoverHeight: number,
+  gap: number
+): Point {
+  switch (edge) {
+    case "left":
+      return { x: Math.round(bar.x + bar.width + gap), y: Math.round(bar.y) };
+    case "right":
+      return { x: Math.round(bar.x - popoverWidth - gap), y: Math.round(bar.y) };
+    case "top":
+      return { x: Math.round(bar.x), y: Math.round(bar.y + bar.height + gap) };
+    case "bottom":
+    default:
+      return { x: Math.round(bar.x), y: Math.round(bar.y - popoverHeight - gap) };
+  }
+}

--- a/src/utils/sessionGroups.ts
+++ b/src/utils/sessionGroups.ts
@@ -1,0 +1,145 @@
+import type { SessionInfo } from "../hooks/useSessions";
+
+// Priority for picking a group's summary state: busy > service > idle.
+export const statePriority: Record<string, number> = {
+  busy: 3,
+  service: 2,
+  idle: 1,
+};
+
+export function groupState(sessions: SessionInfo[]): string {
+  let best = "idle";
+  let bestP = 0;
+  for (const s of sessions) {
+    const p = statePriority[s.ui_state] ?? 0;
+    if (p > bestP) {
+      bestP = p;
+      best = s.ui_state;
+    }
+  }
+  return best;
+}
+
+/** Turn /Users/you/dev/foo into ~/dev/foo when home is known. */
+export function prettyPath(pwd: string, home?: string): string {
+  if (!pwd) return "";
+  if (home && pwd.startsWith(home)) return "~" + pwd.slice(home.length);
+  return pwd;
+}
+
+/** Last path segment of a group (the leaf folder name). Falls back to the
+ *  pretty path or a sensible string when pwd is missing. */
+export function groupBasename(g: { pwd: string; pretty: string; sessions: SessionInfo[] }): string {
+  if (g.pwd) {
+    const leaf = g.pwd.split("/").filter(Boolean).pop();
+    if (leaf) return leaf;
+  }
+  return g.pretty || g.sessions[0]?.title || "";
+}
+
+/** Human-readable label for what's happening in a single shell. */
+export function shellLabel(s: SessionInfo): string {
+  if (s.has_claude) return "claude";
+  if (s.fg_cmd) {
+    return s.fg_cmd.replace(/^-/, "");
+  }
+  if (s.ui_state === "busy" && s.busy_type) return s.busy_type;
+  if (s.ui_state === "service") return "service";
+  return "idle";
+}
+
+export interface Group {
+  key: string;
+  pwd: string;
+  pretty: string;
+  sessions: SessionInfo[];
+  state: string;
+  isClaudeFallback: boolean;
+}
+
+export function groupSessions(sessions: SessionInfo[], home?: string): Group[] {
+  const claudeVirtual = sessions.find((s) => s.pid === 0);
+  const anyShellHasClaude = sessions.some((s) => s.pid !== 0 && s.has_claude);
+
+  const byKey = new Map<string, { pwd: string; list: SessionInfo[] }>();
+  for (const s of sessions) {
+    if (s.pid === 0) continue;
+    if (s.is_claude_proc) continue;
+    const key = s.pwd || s.title || String(s.pid);
+    if (!byKey.has(key)) byKey.set(key, { pwd: s.pwd, list: [] });
+    byKey.get(key)!.list.push(s);
+  }
+
+  const groups: Group[] = [];
+  for (const [key, { pwd, list }] of byKey.entries()) {
+    const pretty = pwd
+      ? prettyPath(pwd, home)
+      : list[0].title || `pid ${list[0].pid}`;
+    // Sort children within a group by pid so row order stays stable
+    // across refreshes. The backend returns sessions from a HashMap,
+    // so iteration order can change between invocations — without this
+    // sort, rows can swap under the cursor every 3s refresh and the
+    // CSS :hover highlight flickers off the row you're hovering.
+    list.sort((a, b) => a.pid - b.pid);
+    groups.push({
+      key,
+      pwd,
+      pretty,
+      sessions: list,
+      state: groupState(list),
+      isClaudeFallback: false,
+    });
+  }
+
+  groups.sort((a, b) => {
+    const pa = statePriority[a.state] ?? 0;
+    const pb = statePriority[b.state] ?? 0;
+    if (pa !== pb) return pb - pa;
+    return a.pretty.localeCompare(b.pretty);
+  });
+
+  if (claudeVirtual && !anyShellHasClaude) {
+    groups.push({
+      key: "claude-virtual",
+      pwd: "",
+      pretty: "Claude Code",
+      sessions: [claudeVirtual],
+      state: claudeVirtual.ui_state,
+      isClaudeFallback: true,
+    });
+  }
+
+  return groups;
+}
+
+export function detectHome(sessions: SessionInfo[]): string | undefined {
+  for (const s of sessions) {
+    const m = s.pwd.match(/^(\/Users\/[^/]+|\/home\/[^/]+)/);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+export function reflectActiveServices(sessions: SessionInfo[]): SessionInfo[] {
+  return sessions.map((s) =>
+    s.busy_type === "service" && s.ui_state === "idle"
+      ? { ...s, ui_state: "service" }
+      : s,
+  );
+}
+
+export function overlayClaudeState(sessions: SessionInfo[]): SessionInfo[] {
+  const sessionByPid = new Map<number, SessionInfo>();
+  for (const s of sessions) sessionByPid.set(s.pid, s);
+
+  return sessions.map((s) => {
+    if (!s.has_claude) return s;
+    const claudeSession =
+      (s.claude_pid != null && sessionByPid.get(s.claude_pid)) ||
+      sessionByPid.get(0);
+    if (!claudeSession) return s;
+    const claudeP = statePriority[claudeSession.ui_state] ?? 0;
+    const ownP = statePriority[s.ui_state] ?? 0;
+    return ownP >= claudeP ? s : { ...s, ui_state: claudeSession.ui_state };
+  });
+}

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -28,7 +28,7 @@ export interface SnapResult {
 
 /** Bar dimensions in logical px (before display scale). Long = along the edge. */
 export const BAR_LONG = 168;
-export const BAR_SHORT = 28;
+export const BAR_SHORT = 22;
 
 /**
  * Mini-bar layout geometry (logical px, before display scale).
@@ -41,7 +41,7 @@ export const MINI_BAR = {
   button: 16, // action buttons (session/peer/restore)
   grip: 5, // trailing drag-handle glyph (small, flush, hugs the edge)
   gap: 6,
-  padding: 4, // along the long axis, each side
+  padding: 8, // along the long axis, each side
   border: 1, // each side
 };
 

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -37,7 +37,9 @@ export const BAR_SHORT = 40;
  * window hugs its content exactly.
  */
 export const MINI_BAR = {
-  dot: 7,
+  // The status dot sits in a button-sized slot so the leading element
+  // matches the trailing grip — keeps the first/last edge gaps equal.
+  dot: 20,
   button: 20,
   gap: 6,
   padding: 8, // along the long axis, each side

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -38,6 +38,7 @@ export const DEFAULT_MARGINS: SnapMargins = { edge: 8, menuBar: 30 };
  * and return the snapped top-left position + the bar orientation/size.
  *
  * Pure: no Tauri calls, plain numbers in and out, so it is unit-testable.
+ * Tie-breaking: when two or more distances are equal, edges are chosen in priority order left > right > top > bottom.
  */
 export function computeSnap(
   win: Rect,

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -39,7 +39,7 @@ export const BAR_SHORT = 40;
 export const MINI_BAR = {
   dot: 7, // leading status dot (bare, hugs the edge)
   button: 20, // action buttons (session/peer/restore)
-  grip: 7, // trailing drag-handle glyph (flush, hugs the edge)
+  grip: 5, // trailing drag-handle glyph (small, flush, hugs the edge)
   gap: 6,
   padding: 8, // along the long axis, each side
   border: 1, // each side

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -30,6 +30,30 @@ export interface SnapResult {
 export const BAR_LONG = 168;
 export const BAR_SHORT = 40;
 
+/**
+ * Mini-bar layout geometry (logical px, before display scale).
+ * These MUST stay in sync with the spacing in `mini-bar.css`
+ * (gap, padding) and the `.pill-action-btn` / `.dot` sizes so the
+ * window hugs its content exactly.
+ */
+export const MINI_BAR = {
+  dot: 7,
+  button: 20,
+  gap: 6,
+  padding: 8, // along the long axis, each side
+  border: 1, // each side
+};
+
+/**
+ * Long-axis length (logical px) for a mini bar holding the status dot plus
+ * `buttons` action buttons. Layout: [pad][dot](gap[button])×buttons[pad],
+ * plus borders. Lets the bar hug its content instead of using a fixed width.
+ */
+export function miniBarLength(buttons: number): number {
+  const g = MINI_BAR;
+  return 2 * g.border + 2 * g.padding + g.dot + buttons * (g.gap + g.button);
+}
+
 export const DEFAULT_MARGINS: SnapMargins = { edge: 8, menuBar: 30 };
 
 /**

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -66,8 +66,9 @@ export const DEFAULT_MARGINS: SnapMargins = { edge: 8, menuBar: 30 };
 
 /**
  * Given the current window rect and the monitor rect (both logical px),
- * pick the nearest of the four edges, then the nearest corner on that edge,
- * and return the snapped top-left position + the bar orientation/size.
+ * pick the NEAREST edge and snap the bar flush to it (magnet), KEEPING the
+ * bar's position ALONG that edge (clamped on-screen) rather than jumping to a
+ * corner. Returns the snapped top-left position + the bar orientation/size.
  *
  * Pure: no Tauri calls, plain numbers in and out, so it is unit-testable.
  * Tie-breaking: when two or more distances are equal, edges are chosen in priority order left > right > top > bottom.
@@ -99,27 +100,35 @@ export function computeSnap(
   const width = vertical ? barShort : barLong;
   const height = vertical ? barLong : barShort;
 
+  const clamp = (v: number, lo: number, hi: number) =>
+    Math.max(lo, Math.min(v, hi));
+
   let x: number;
   let y: number;
 
   if (vertical) {
+    // Flush to the left/right edge; keep the dropped Y, clamped on-screen
+    // (top clearance respects the menu bar).
     x =
       edge === "left"
         ? monitor.x + margins.edge
         : monitor.x + monitor.width - width - margins.edge;
-    const topHalf = cy < monitor.y + monitor.height / 2;
-    y = topHalf
-      ? monitor.y + margins.menuBar
-      : monitor.y + monitor.height - height - margins.edge;
+    y = clamp(
+      win.y,
+      monitor.y + margins.menuBar,
+      monitor.y + monitor.height - height - margins.edge
+    );
   } else {
+    // Flush to the top/bottom edge; keep the dropped X, clamped on-screen.
     y =
       edge === "top"
         ? monitor.y + margins.menuBar
         : monitor.y + monitor.height - height - margins.edge;
-    const leftHalf = cx < monitor.x + monitor.width / 2;
-    x = leftHalf
-      ? monitor.x + margins.edge
-      : monitor.x + monitor.width - width - margins.edge;
+    x = clamp(
+      win.x,
+      monitor.x + margins.edge,
+      monitor.x + monitor.width - width - margins.edge
+    );
   }
 
   return {

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -37,23 +37,29 @@ export const BAR_SHORT = 40;
  * window hugs its content exactly.
  */
 export const MINI_BAR = {
-  // The status dot sits in a button-sized slot so the leading element
-  // matches the trailing grip — keeps the first/last edge gaps equal.
-  dot: 20,
-  button: 20,
+  dot: 7, // leading status dot (bare, hugs the edge)
+  button: 20, // action buttons (session/peer/restore)
+  grip: 7, // trailing drag-handle glyph (flush, hugs the edge)
   gap: 6,
   padding: 8, // along the long axis, each side
   border: 1, // each side
 };
 
 /**
- * Long-axis length (logical px) for a mini bar holding the status dot plus
- * `buttons` action buttons. Layout: [pad][dot](gap[button])×buttons[pad],
- * plus borders. Lets the bar hug its content instead of using a fixed width.
+ * Long-axis length (logical px) for a mini bar holding the leading status
+ * dot, `actionButtons` 20px buttons, and the trailing grip handle.
+ * Layout: [pad][dot](gap[button])×actionButtons(gap[grip])[pad] + borders.
+ * Lets the bar hug its content instead of using a fixed width.
  */
-export function miniBarLength(buttons: number): number {
+export function miniBarLength(actionButtons: number): number {
   const g = MINI_BAR;
-  return 2 * g.border + 2 * g.padding + g.dot + buttons * (g.gap + g.button);
+  return (
+    2 * g.border +
+    2 * g.padding +
+    g.dot +
+    actionButtons * (g.gap + g.button) +
+    (g.gap + g.grip)
+  );
 }
 
 export const DEFAULT_MARGINS: SnapMargins = { edge: 8, menuBar: 30 };

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -41,7 +41,7 @@ export const MINI_BAR = {
   button: 16, // action buttons (session/peer/restore)
   grip: 5, // trailing drag-handle glyph (small, flush, hugs the edge)
   gap: 6,
-  padding: 8, // along the long axis, each side
+  padding: 4, // along the long axis, each side
   border: 1, // each side
 };
 

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -1,0 +1,100 @@
+export type Orientation = "horizontal" | "vertical";
+export type Edge = "left" | "right" | "top" | "bottom";
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SnapMargins {
+  /** Gap from screen edges, in logical px. */
+  edge: number;
+  /** Extra gap from the top edge to clear the macOS menu bar, in logical px. */
+  menuBar: number;
+}
+
+export interface SnapResult {
+  x: number;
+  y: number;
+  edge: Edge;
+  orientation: Orientation;
+  /** Bar window width at this orientation (logical px). */
+  width: number;
+  /** Bar window height at this orientation (logical px). */
+  height: number;
+}
+
+/** Bar dimensions in logical px (before display scale). Long = along the edge. */
+export const BAR_LONG = 168;
+export const BAR_SHORT = 40;
+
+export const DEFAULT_MARGINS: SnapMargins = { edge: 8, menuBar: 30 };
+
+/**
+ * Given the current window rect and the monitor rect (both logical px),
+ * pick the nearest of the four edges, then the nearest corner on that edge,
+ * and return the snapped top-left position + the bar orientation/size.
+ *
+ * Pure: no Tauri calls, plain numbers in and out, so it is unit-testable.
+ */
+export function computeSnap(
+  win: Rect,
+  monitor: Rect,
+  barLong: number,
+  barShort: number,
+  margins: SnapMargins = DEFAULT_MARGINS
+): SnapResult {
+  const cx = win.x + win.width / 2;
+  const cy = win.y + win.height / 2;
+
+  const distLeft = cx - monitor.x;
+  const distRight = monitor.x + monitor.width - cx;
+  const distTop = cy - monitor.y;
+  const distBottom = monitor.y + monitor.height - cy;
+
+  const min = Math.min(distLeft, distRight, distTop, distBottom);
+
+  let edge: Edge;
+  if (min === distLeft) edge = "left";
+  else if (min === distRight) edge = "right";
+  else if (min === distTop) edge = "top";
+  else edge = "bottom";
+
+  const vertical = edge === "left" || edge === "right";
+  const width = vertical ? barShort : barLong;
+  const height = vertical ? barLong : barShort;
+
+  let x: number;
+  let y: number;
+
+  if (vertical) {
+    x =
+      edge === "left"
+        ? monitor.x + margins.edge
+        : monitor.x + monitor.width - width - margins.edge;
+    const topHalf = cy < monitor.y + monitor.height / 2;
+    y = topHalf
+      ? monitor.y + margins.menuBar
+      : monitor.y + monitor.height - height - margins.edge;
+  } else {
+    y =
+      edge === "top"
+        ? monitor.y + margins.menuBar
+        : monitor.y + monitor.height - height - margins.edge;
+    const leftHalf = cx < monitor.x + monitor.width / 2;
+    x = leftHalf
+      ? monitor.x + margins.edge
+      : monitor.x + monitor.width - width - margins.edge;
+  }
+
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    edge,
+    orientation: vertical ? "vertical" : "horizontal",
+    width,
+    height,
+  };
+}

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -28,7 +28,7 @@ export interface SnapResult {
 
 /** Bar dimensions in logical px (before display scale). Long = along the edge. */
 export const BAR_LONG = 168;
-export const BAR_SHORT = 40;
+export const BAR_SHORT = 28;
 
 /**
  * Mini-bar layout geometry (logical px, before display scale).
@@ -38,7 +38,7 @@ export const BAR_SHORT = 40;
  */
 export const MINI_BAR = {
   dot: 7, // leading status dot (bare, hugs the edge)
-  button: 20, // action buttons (session/peer/restore)
+  button: 16, // action buttons (session/peer/restore)
   grip: 5, // trailing drag-handle glyph (small, flush, hugs the edge)
   gap: 6,
   padding: 8, // along the long axis, each side

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(async () => ({
         settings: resolve(__dirname, "settings.html"),
         superpower: resolve(__dirname, "superpower.html"),
         "peer-list": resolve(__dirname, "peer-list.html"),
+        "session-list": resolve(__dirname, "session-list.html"),
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds **mini bar mode**: a minimize button on the status pill collapses the floating pet into a thin status bar that docks to any screen edge. Built per the spec/plan in `docs/superpowers/`.

- **Minimize / restore** — a minimize button in the status pill collapses the pet into the bar; a restore button (and the bar's grip) brings the pet back to its previous spot.
- **Edge-docked magnet drag** — hold the 6-dot grip and the bar follows the cursor freely; on release it snaps flush to the nearest screen edge (vertical on left/right, horizontal on top/bottom). Always at rest on an edge, never floating. Multi-monitor aware (docks to the monitor the cursor is on).
- **Status glow + dot** — the bar shows the live status color (no text), reusing `useStatus`.
- **Tools open windows in mini mode** — the session and peer buttons each open their own window docked inward from the bar (never an inline list). Pet mode keeps the inline dropdown.
- **Session dialog** — registers the previously-unwired `session-list` window, styled as a light modal dialog (clipboard-manager look) with a header + close button (✕ / ⌘W). Granted the matching Tauri capability.
- **macOS**: opts the window out of Sequoia drag-to-edge tiling while in mini mode (`set_window_movable`, scoped to mini mode so the native pet drag still works); cfg-gated via the platform facade with a Linux no-op.

## Architecture / conventions

- New: `MiniBar.tsx`, `useMiniMode.ts`, pure `snap.ts` / `popoverPos.ts` (unit-tested), extracted `sessionGroups.ts` + shared `SessionDropdown.tsx`.
- Follows existing rules: `data-testid` on all interactive elements, `app_log!` macros + cfg-gated platform facade for the new Rust command, `#[tauri::command]` registered in the invoke handler.
- No persistence (always launches as the pet), no breaking changes to pet mode.

## Test plan

- [x] Unit (Vitest): `snap`, `popoverPos`, `MiniBar`, `useMiniMode`, `useDrag`, `StatusPill` — all green; pure snap math covers all 4 edges + multi-monitor.
- [x] E2e (Playwright): minimize → bar → restore.
- [x] `tsc --noEmit` clean; `cargo check` clean.
- [ ] Manual on macOS: drag to each edge, open session/peer windows, ✕/⌘W close, verify no tiling overlay (requires `bun run tauri dev` restart for the new window + capability).

> Note: pre-existing unit-suite failures (~10) and C3 doc drift are unrelated to this branch. Follow-ups parked: fully decouple mini/pet sizing logic; give the peer window the same modal-dialog treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)