### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.18.0] - 2026-06-15
+
+### Added
+- **Mini bar mode.** A minimize button on the status pill collapses the floating pet into a thin status bar docked to a screen edge. Hold the grip to drag it; it magnet-snaps to the nearest edge on release (vertical on the sides, horizontal on top/bottom) and is multi-monitor aware. The bar shows the live status color, and its session/peer tools each open their own window (the session list as a clipboard-manager-style dialog). On macOS the window opts out of Sequoia edge-tiling while docked.
+
 ## [0.17.14] - 2026-06-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.17.14",
+  "version": "0.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.17.14"
+version = "0.18.0"
 dependencies = [
  "arboard",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.17.14"
+version = "0.18.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.17.14",
+  "version": "0.18.0",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1490,7 +1490,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.17.14{devMode && " (Dev Mode)"}
+                  Version 0.18.0{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
Release **v0.18.0** — mini bar mode.

Bumps version in all 4 files + `Cargo.lock` and updates `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)