### PR TITLE
chore: release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.1] - 2026-06-16
+
+### Added
+- **Quick Coffee plugin.** Assign a system-wide hotkey to any website and open it in a chosen browser (macOS lists installed browsers; other platforms use the OS default). Hotkeys fire even with the window closed and after a restart. Manage sites in an app-styled window with a reorderable list, per-item URL + hotkey, and a one-click "Open".
+- **`browser` plugin capability.** Lets a plugin list installed browsers, open an `http`/`https` URL in a chosen one, and register per-item global hotkeys (host-owned and persisted).
+- **Clearable launch hotkeys.** A plugin's launch shortcut can now be left empty / cleared from the Plugin Manager.
+
+### Changed
+- **Plugin data survives reinstall.** Per-plugin storage and hotkey bindings now live in `~/.ani-mime/plugin-data/<id>/`, outside the directory removed on uninstall.
+
 ## [0.18.0] - 2026-06-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ani-mime",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "ani-mime"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "arboard",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ani-mime"
-version = "0.18.0"
+version = "0.18.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ani-mime",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "identifier": "com.vietnguyenwsilentium.ani-mime",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1490,7 +1490,7 @@ export function Settings() {
                   onClick={handleVersionClick}
                   style={{ userSelect: "none" }}
                 >
-                  Version 0.18.0{devMode && " (Dev Mode)"}
+                  Version 0.18.1{devMode && " (Dev Mode)"}
                 </div>
                 <div className="about-desc">A floating macOS desktop mascot that reacts to terminal and Claude Code activity in real-time.</div>
               </div>


### PR DESCRIPTION
Release **v0.18.1**.

Bumps version in all 4 tracked files (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src/components/Settings.tsx`) + `Cargo.lock`, and adds the CHANGELOG entry.

### Highlights (since v0.18.0)
- **Quick Coffee plugin** + host **`browser` capability** — hotkey → open a site in a chosen browser.
- **Clearable launch hotkeys** in the Plugin Manager.
- **Plugin data survives reinstall** (`~/.ani-mime/plugin-data/<id>/`).

After merge: tag `v0.18.1` on main → CI builds DMGs → update the Homebrew cask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)